### PR TITLE
Add VisualMeta comment support

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -97,6 +97,7 @@ name = "backend"
 version = "0.1.0"
 dependencies = [
  "serde",
+ "serde_json",
  "tauri",
  "tauri-build",
  "tokio",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 serde = { version = "1", features = ["derive"] }
 tokio = { version = "1", features = ["full"] }
 tauri = { version = "1" }
+serde_json = "1"
 
 [build-dependencies]
 tauri-build = { version = "1" }

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1,5 +1,6 @@
-use serde::Serialize;
 use std::sync::Mutex;
+mod meta;
+use meta::{insert, read, VisualMeta};
 use tauri::State;
 
 #[derive(Default)]
@@ -15,10 +16,27 @@ fn load_state(state: State<EditorState>) -> String {
     state.0.lock().unwrap().clone()
 }
 
+#[tauri::command]
+fn insert_meta(content: String, meta: VisualMeta) -> String {
+    insert(&content, &meta)
+}
+
+#[tauri::command]
+fn read_meta(content: String) -> Option<VisualMeta> {
+    read(&content)
+}
+
 fn main() {
     tauri::Builder::default()
         .manage(EditorState::default())
-        .invoke_handler(tauri::generate_handler![save_state, load_state])
-        .run(tauri::generate_context!("../frontend/src-tauri/tauri.conf.json"))
+        .invoke_handler(tauri::generate_handler![
+            save_state,
+            load_state,
+            insert_meta,
+            read_meta
+        ])
+        .run(tauri::generate_context!(
+            "../frontend/src-tauri/tauri.conf.json"
+        ))
         .expect("error while running tauri application");
 }

--- a/backend/src/meta/mod.rs
+++ b/backend/src/meta/mod.rs
@@ -1,0 +1,81 @@
+use serde::{Deserialize, Serialize};
+
+/// Marker used to identify visual metadata comments in documents.
+const MARKER: &str = "@VISUAL_META";
+
+/// Metadata stored inside `@VISUAL_META` comments.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct VisualMeta {
+    /// Title of the document.
+    pub title: String,
+    /// List of authors.
+    pub authors: Vec<String>,
+    /// Optional URL for the document.
+    pub url: Option<String>,
+    /// Optional DOI of the document.
+    pub doi: Option<String>,
+    /// Optional publication date.
+    pub published: Option<String>,
+}
+
+/// Insert a visual metadata comment into the given `content`.
+///
+/// Any existing visual metadata comment will be replaced.
+pub fn insert(content: &str, meta: &VisualMeta) -> String {
+    let json = match serde_json::to_string(meta) {
+        Ok(j) => j,
+        Err(_) => return content.to_string(),
+    };
+
+    let comment = format!("<!-- {} {} -->\n", MARKER, json);
+    let content_without = remove(content);
+    format!("{}{}", comment, content_without)
+}
+
+/// Read visual metadata comment from `content`.
+pub fn read(content: &str) -> Option<VisualMeta> {
+    let marker = format!("<!-- {}", MARKER);
+    let start = content.find(&marker)?;
+    let rest = &content[start + marker.len()..];
+    let end = rest.find("-->")?;
+    let json_str = rest[..end].trim();
+    serde_json::from_str(json_str).ok()
+}
+
+/// Remove the visual metadata comment from `content` if present.
+fn remove(content: &str) -> String {
+    let marker = format!("<!-- {}", MARKER);
+    if let Some(start) = content.find(&marker) {
+        if let Some(end_rel) = content[start..].find("-->") {
+            let end = start + end_rel + 3;
+            let mut result = content.to_string();
+            result.replace_range(start..end, "");
+            return result.trim_start_matches('\n').to_string();
+        }
+    }
+    content.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn insert_and_read_roundtrip() {
+        let meta = VisualMeta {
+            title: "Example".into(),
+            authors: vec!["Alice".into(), "Bob".into()],
+            url: Some("https://example.com".into()),
+            doi: None,
+            published: Some("2024-01-01".into()),
+        };
+
+        let content = "Hello world";
+        let with_meta = insert(content, &meta);
+        assert!(with_meta.contains(MARKER));
+
+        let parsed = read(&with_meta).expect("meta should be read");
+        assert_eq!(parsed.title, meta.title);
+        assert_eq!(parsed.authors, meta.authors);
+    }
+}


### PR DESCRIPTION
## Summary
- add VisualMeta struct and helper functions to insert/read `@VISUAL_META` comments
- expose `insert_meta` and `read_meta` Tauri commands
- include serde_json dependency for metadata serialization

## Testing
- `cargo test` *(fails: path matching ../backend/target/release/backend-x86_64-unknown-linux-gnu not found)*

------
https://chatgpt.com/codex/tasks/task_e_6898513dc2d88323af2fd4f4d053e410