### PR TITLE
Add tree-sitter parser and visual metadata mapping

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -101,6 +101,12 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tokio",
+ "tree-sitter 0.20.10",
+ "tree-sitter-css",
+ "tree-sitter-html",
+ "tree-sitter-javascript",
+ "tree-sitter-python",
+ "tree-sitter-rust",
 ]
 
 [[package]]
@@ -254,12 +260,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.32"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2352e5597e9c544d5e6d9c95190d5d27738ade584fa8db0a16e130e5c2b5296e"
-dependencies = [
- "shlex",
-]
+checksum = "066fce287b1d4eafef758e89e09d724a24808a9196fe9756b8ca90e86d0719a2"
 
 [[package]]
 name = "cesu8"
@@ -2598,12 +2601,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "shlex"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
-
-[[package]]
 name = "signal-hook-registry"
 version = "1.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3313,6 +3310,76 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
+]
+
+[[package]]
+name = "tree-sitter"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e747b1f9b7b931ed39a548c1fae149101497de3c1fc8d9e18c62c1a66c683d3d"
+dependencies = [
+ "cc",
+ "regex",
+]
+
+[[package]]
+name = "tree-sitter"
+version = "0.22.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df7cc499ceadd4dcdf7ec6d4cbc34ece92c3fa07821e287aedecd4416c516dca"
+dependencies = [
+ "cc",
+ "regex",
+]
+
+[[package]]
+name = "tree-sitter-css"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3306ddefa1d2681adda2613d11974ffabfbeb215e23235da6c862f3493a04fd"
+dependencies = [
+ "cc",
+ "tree-sitter 0.20.10",
+]
+
+[[package]]
+name = "tree-sitter-html"
+version = "0.20.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8766b5ad3721517f8259e6394aefda9c686aebf7a8c74ab8624f2c3b46902fd5"
+dependencies = [
+ "cc",
+ "tree-sitter 0.22.6",
+]
+
+[[package]]
+name = "tree-sitter-javascript"
+version = "0.20.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d015c02ea98b62c806f7329ff71c383286dfc3a7a7da0cc484f6e42922f73c2c"
+dependencies = [
+ "cc",
+ "tree-sitter 0.20.10",
+]
+
+[[package]]
+name = "tree-sitter-python"
+version = "0.20.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c93b1b1fbd0d399db3445f51fd3058e43d0b4dcff62ddbdb46e66550978aa5"
+dependencies = [
+ "cc",
+ "tree-sitter 0.20.10",
+]
+
+[[package]]
+name = "tree-sitter-rust"
+version = "0.20.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0832309b0b2b6d33760ce5c0e818cb47e1d72b468516bfe4134408926fa7594"
+dependencies = [
+ "cc",
+ "tree-sitter 0.20.10",
 ]
 
 [[package]]

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -8,6 +8,12 @@ serde = { version = "1", features = ["derive"] }
 tokio = { version = "1", features = ["full"] }
 tauri = { version = "1" }
 serde_json = "1"
+tree-sitter = "0.20"
+tree-sitter-rust = "0.20"
+tree-sitter-python = "0.20"
+tree-sitter-javascript = "0.20"
+tree-sitter-css = "0.20"
+tree-sitter-html = "0.20"
 
 [build-dependencies]
 tauri-build = { version = "1" }

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1,5 +1,6 @@
 use std::sync::Mutex;
 mod meta;
+mod parser;
 use meta::{insert, read, VisualMeta};
 use tauri::State;
 

--- a/backend/src/meta/mod.rs
+++ b/backend/src/meta/mod.rs
@@ -6,6 +6,8 @@ const MARKER: &str = "@VISUAL_META";
 /// Metadata stored inside `@VISUAL_META` comments.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct VisualMeta {
+    /// Identifier linking this metadata to AST nodes.
+    pub id: String,
     /// Title of the document.
     pub title: String,
     /// List of authors.
@@ -63,6 +65,7 @@ mod tests {
     #[test]
     fn insert_and_read_roundtrip() {
         let meta = VisualMeta {
+            id: "1".into(),
             title: "Example".into(),
             authors: vec!["Alice".into(), "Bob".into()],
             url: Some("https://example.com".into()),


### PR DESCRIPTION
## Summary
- integrate tree-sitter with Rust, Python, JavaScript, CSS and HTML grammars
- convert ASTs into metadata-aware blocks
- record VisualMeta identifiers for AST nodes

## Testing
- `cargo test` *(fails: could not find system library javascriptcoregtk-4.0 required by javascriptcore-rs-sys)*

------
https://chatgpt.com/codex/tasks/task_e_6898564932788323ac634a0e30b94ea8