### PR TITLE
feat: add visual canvas with basic blocks

### DIFF
--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -5,7 +5,8 @@
   <title>Multicode Editor</title>
   <style>
     body { margin: 0; font-family: sans-serif; }
-    #editor { height: 90vh; border: 1px solid #ccc; }
+    #visual-canvas { width: 100%; height: 50vh; border: 1px solid #ccc; display: block; }
+    #editor { height: 40vh; border: 1px solid #ccc; }
     #controls { padding: 0.5rem; }
   </style>
   <script type="module">
@@ -40,10 +41,12 @@
   </script>
 </head>
 <body>
+  <canvas id="visual-canvas"></canvas>
   <div id="editor"></div>
   <div id="controls">
     <button id="save">Save</button>
     <button id="load">Load</button>
   </div>
+  <script type="module" src="./visual/index.js"></script>
 </body>
 </html>

--- a/frontend/src/visual/blocks.js
+++ b/frontend/src/visual/blocks.js
@@ -1,0 +1,56 @@
+export class Block {
+  constructor(x, y, w, h, label, color = '#fff') {
+    this.x = x;
+    this.y = y;
+    this.w = w;
+    this.h = h;
+    this.label = label;
+    this.color = color;
+  }
+
+  draw(ctx) {
+    ctx.fillStyle = this.color;
+    ctx.strokeStyle = '#333';
+    ctx.lineWidth = 2;
+    ctx.fillRect(this.x, this.y, this.w, this.h);
+    ctx.strokeRect(this.x, this.y, this.w, this.h);
+    ctx.fillStyle = '#000';
+    ctx.font = '16px sans-serif';
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.fillText(this.label, this.x + this.w / 2, this.y + this.h / 2);
+  }
+
+  contains(px, py) {
+    return px >= this.x && px <= this.x + this.w &&
+           py >= this.y && py <= this.y + this.h;
+  }
+
+  center() {
+    return { x: this.x + this.w / 2, y: this.y + this.h / 2 };
+  }
+}
+
+export class FunctionBlock extends Block {
+  constructor(x, y) {
+    super(x, y, 120, 50, 'Function', '#e0f7fa');
+  }
+}
+
+export class VariableBlock extends Block {
+  constructor(x, y) {
+    super(x, y, 120, 50, 'Variable', '#f1f8e9');
+  }
+}
+
+export class ConditionBlock extends Block {
+  constructor(x, y) {
+    super(x, y, 120, 50, 'Condition', '#fff9c4');
+  }
+}
+
+export class LoopBlock extends Block {
+  constructor(x, y) {
+    super(x, y, 120, 50, 'Loop', '#fce4ec');
+  }
+}

--- a/frontend/src/visual/canvas.js
+++ b/frontend/src/visual/canvas.js
@@ -1,0 +1,109 @@
+import { FunctionBlock, VariableBlock, ConditionBlock, LoopBlock } from './blocks.js';
+
+export class VisualCanvas {
+  constructor(canvas) {
+    this.canvas = canvas;
+    this.ctx = canvas.getContext('2d');
+    this.scale = 1;
+    this.offset = { x: 0, y: 0 };
+    this.blocks = [];
+    this.connections = [];
+    this.dragged = null;
+    this.dragOffset = { x: 0, y: 0 };
+    this.panning = false;
+    this.panStart = { x: 0, y: 0 };
+
+    this.resize();
+    window.addEventListener('resize', () => this.resize());
+    this.registerEvents();
+    requestAnimationFrame(() => this.draw());
+  }
+
+  addBlock(block) {
+    this.blocks.push(block);
+  }
+
+  connect(a, b) {
+    this.connections.push([a, b]);
+  }
+
+  registerEvents() {
+    this.canvas.addEventListener('mousedown', e => {
+      const pos = this.toWorld(e.offsetX, e.offsetY);
+      this.dragged = this.blocks.find(b => b.contains(pos.x, pos.y));
+      if (this.dragged) {
+        this.dragOffset.x = pos.x - this.dragged.x;
+        this.dragOffset.y = pos.y - this.dragged.y;
+      } else {
+        this.panning = true;
+        this.panStart.x = e.offsetX - this.offset.x;
+        this.panStart.y = e.offsetY - this.offset.y;
+      }
+    });
+
+    this.canvas.addEventListener('mousemove', e => {
+      const pos = this.toWorld(e.offsetX, e.offsetY);
+      if (this.dragged) {
+        this.dragged.x = pos.x - this.dragOffset.x;
+        this.dragged.y = pos.y - this.dragOffset.y;
+      } else if (this.panning) {
+        this.offset.x = e.offsetX - this.panStart.x;
+        this.offset.y = e.offsetY - this.panStart.y;
+      }
+    });
+
+    window.addEventListener('mouseup', () => {
+      this.dragged = null;
+      this.panning = false;
+    });
+
+    this.canvas.addEventListener('wheel', e => {
+      e.preventDefault();
+      const mouseX = e.offsetX;
+      const mouseY = e.offsetY;
+      const worldPos = this.toWorld(mouseX, mouseY);
+      const scaleFactor = e.deltaY < 0 ? 1.1 : 0.9;
+      this.scale *= scaleFactor;
+      const newScreenX = worldPos.x * this.scale + this.offset.x;
+      const newScreenY = worldPos.y * this.scale + this.offset.y;
+      this.offset.x += mouseX - newScreenX;
+      this.offset.y += mouseY - newScreenY;
+    });
+  }
+
+  resize() {
+    this.canvas.width = this.canvas.clientWidth;
+    this.canvas.height = this.canvas.clientHeight;
+  }
+
+  toWorld(x, y) {
+    return {
+      x: (x - this.offset.x) / this.scale,
+      y: (y - this.offset.y) / this.scale
+    };
+  }
+
+  draw() {
+    this.ctx.save();
+    this.ctx.setTransform(this.scale, 0, 0, this.scale, this.offset.x, this.offset.y);
+    this.ctx.clearRect(-this.offset.x / this.scale, -this.offset.y / this.scale,
+      this.canvas.width / this.scale, this.canvas.height / this.scale);
+
+    // Draw connections
+    this.ctx.strokeStyle = '#000';
+    this.connections.forEach(([a, b]) => {
+      const ac = a.center();
+      const bc = b.center();
+      this.ctx.beginPath();
+      this.ctx.moveTo(ac.x, ac.y);
+      this.ctx.lineTo(bc.x, bc.y);
+      this.ctx.stroke();
+    });
+
+    // Draw blocks
+    this.blocks.forEach(b => b.draw(this.ctx));
+
+    this.ctx.restore();
+    requestAnimationFrame(() => this.draw());
+  }
+}

--- a/frontend/src/visual/index.js
+++ b/frontend/src/visual/index.js
@@ -1,0 +1,24 @@
+import { VisualCanvas } from './canvas.js';
+import { FunctionBlock, VariableBlock, ConditionBlock, LoopBlock } from './blocks.js';
+
+document.addEventListener('DOMContentLoaded', () => {
+  const canvas = document.getElementById('visual-canvas');
+  if (!canvas) return;
+  const vc = new VisualCanvas(canvas);
+
+  const func = new FunctionBlock(50, 50);
+  const variable = new VariableBlock(250, 50);
+  const cond = new ConditionBlock(50, 200);
+  const loop = new LoopBlock(250, 200);
+
+  vc.addBlock(func);
+  vc.addBlock(variable);
+  vc.addBlock(cond);
+  vc.addBlock(loop);
+
+  vc.connect(func, variable);
+  vc.connect(cond, loop);
+
+  // expose for debugging
+  window.visualCanvas = vc;
+});


### PR DESCRIPTION
## Summary
- add HTML canvas layer with zoom/pan handling and interactive block dragging
- define function, variable, condition, and loop block types and render connections
- integrate visual canvas initialization into main frontend page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898596c404c8323a60dda5aef1c11eb