### PR TITLE
Add localization support for visual blocks

### DIFF
--- a/backend/src/i18n/mod.rs
+++ b/backend/src/i18n/mod.rs
@@ -1,0 +1,28 @@
+use crate::meta::Translations;
+
+/// Return default translations for known block kinds.
+pub fn lookup(kind: &str) -> Option<Translations> {
+    match kind {
+        "Function" => Some(Translations {
+            ru: Some("Функция".into()),
+            en: Some("Function".into()),
+            es: Some("Función".into()),
+        }),
+        "Variable" => Some(Translations {
+            ru: Some("Переменная".into()),
+            en: Some("Variable".into()),
+            es: Some("Variable".into()),
+        }),
+        "Condition" => Some(Translations {
+            ru: Some("Условие".into()),
+            en: Some("Condition".into()),
+            es: Some("Condición".into()),
+        }),
+        "Loop" => Some(Translations {
+            ru: Some("Цикл".into()),
+            en: Some("Loop".into()),
+            es: Some("Bucle".into()),
+        }),
+        _ => None,
+    }
+}

--- a/backend/src/meta/mod.rs
+++ b/backend/src/meta/mod.rs
@@ -4,6 +4,14 @@ use serde::{Deserialize, Serialize};
 const MARKER: &str = "@VISUAL_META";
 
 /// Metadata stored inside `@VISUAL_META` comments.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct Translations {
+    pub ru: Option<String>,
+    pub en: Option<String>,
+    pub es: Option<String>,
+}
+
+/// Metadata stored inside `@VISUAL_META` comments.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct VisualMeta {
     /// Identifier linking this metadata to AST nodes.
@@ -12,6 +20,9 @@ pub struct VisualMeta {
     pub x: f64,
     /// Y coordinate on the canvas.
     pub y: f64,
+    /// Optional translations for block labels.
+    #[serde(default)]
+    pub translations: Translations,
 }
 
 /// Insert or update a visual metadata comment in `content`.
@@ -73,7 +84,7 @@ mod tests {
 
     #[test]
     fn upsert_and_read_roundtrip() {
-        let meta = VisualMeta { id: "1".into(), x: 10.0, y: 20.0 };
+        let meta = VisualMeta { id: "1".into(), x: 10.0, y: 20.0, translations: Translations::default() };
         let content = "fn main() {}";
         let updated = upsert(content, &meta);
         assert!(updated.contains(MARKER));

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -31,6 +31,8 @@
     });
 
     const currentLang = 'rust';
+    let currentLocale = 'en';
+    vc.setLocale(currentLocale);
 
     async function parseAndRender() {
       const content = view.state.doc.toString();
@@ -67,6 +69,10 @@
 
     document.getElementById('save').addEventListener('click', save);
     document.getElementById('load').addEventListener('click', load);
+    document.getElementById('locale').addEventListener('change', e => {
+      currentLocale = e.target.value;
+      vc.setLocale(currentLocale);
+    });
 
     parseAndRender();
   </script>
@@ -77,6 +83,11 @@
   <div id="controls">
     <button id="save">Save</button>
     <button id="load">Load</button>
+    <select id="locale">
+      <option value="en">English</option>
+      <option value="ru">Русский</option>
+      <option value="es">Español</option>
+    </select>
   </div>
 </body>
 </html>

--- a/frontend/src/visual/canvas.js
+++ b/frontend/src/visual/canvas.js
@@ -7,6 +7,8 @@ export class VisualCanvas {
     this.scale = 1;
     this.offset = { x: 0, y: 0 };
     this.blocks = [];
+    this.blocksData = [];
+    this.locale = 'en';
     this.connections = [];
     this.dragged = null;
     this.dragOffset = { x: 0, y: 0 };
@@ -21,8 +23,21 @@ export class VisualCanvas {
   }
 
   setBlocks(blocks) {
-    this.blocks = blocks.map(b => new Block(b.visual_id, b.x, b.y, 120, 50, b.kind));
+    this.blocksData = blocks;
+    this.updateLabels();
     this.connections = [];
+  }
+
+  setLocale(locale) {
+    this.locale = locale;
+    this.updateLabels();
+  }
+
+  updateLabels() {
+    this.blocks = this.blocksData.map(b => {
+      const label = (b.translations && b.translations[this.locale]) || b.kind;
+      return new Block(b.visual_id, b.x, b.y, 120, 50, label);
+    });
   }
 
   onBlockMove(cb) {


### PR DESCRIPTION
## Summary
- add default translations for common block types
- extend visual metadata with `ru`, `en`, and `es` labels
- allow UI to switch locale and render blocks in the selected language

## Testing
- `cargo test` *(fails: system library `javascriptcoregtk-4.0` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68985d9310d88323b86c355b46d243f5