### PR TITLE
Add parser modules and examples for multiple languages

### DIFF
--- a/backend/src/parser/css.rs
+++ b/backend/src/parser/css.rs
@@ -1,0 +1,11 @@
+use tree_sitter::{Language, Parser, Tree};
+
+pub fn language() -> Language {
+    tree_sitter_css::language()
+}
+
+pub fn parse(source: &str) -> Option<Tree> {
+    let mut parser = Parser::new();
+    parser.set_language(language()).ok()?;
+    parser.parse(source, None)
+}

--- a/backend/src/parser/html.rs
+++ b/backend/src/parser/html.rs
@@ -1,0 +1,11 @@
+use tree_sitter::{Language, Parser, Tree};
+
+pub fn language() -> Language {
+    tree_sitter_html::language()
+}
+
+pub fn parse(source: &str) -> Option<Tree> {
+    let mut parser = Parser::new();
+    parser.set_language(language()).ok()?;
+    parser.parse(source, None)
+}

--- a/backend/src/parser/javascript.rs
+++ b/backend/src/parser/javascript.rs
@@ -1,0 +1,11 @@
+use tree_sitter::{Language, Parser, Tree};
+
+pub fn language() -> Language {
+    tree_sitter_javascript::language()
+}
+
+pub fn parse(source: &str) -> Option<Tree> {
+    let mut parser = Parser::new();
+    parser.set_language(language()).ok()?;
+    parser.parse(source, None)
+}

--- a/backend/src/parser/python.rs
+++ b/backend/src/parser/python.rs
@@ -1,0 +1,11 @@
+use tree_sitter::{Language, Parser, Tree};
+
+pub fn language() -> Language {
+    tree_sitter_python::language()
+}
+
+pub fn parse(source: &str) -> Option<Tree> {
+    let mut parser = Parser::new();
+    parser.set_language(language()).ok()?;
+    parser.parse(source, None)
+}

--- a/backend/src/parser/rust.rs
+++ b/backend/src/parser/rust.rs
@@ -1,0 +1,11 @@
+use tree_sitter::{Language, Parser, Tree};
+
+pub fn language() -> Language {
+    tree_sitter_rust::language()
+}
+
+pub fn parse(source: &str) -> Option<Tree> {
+    let mut parser = Parser::new();
+    parser.set_language(language()).ok()?;
+    parser.parse(source, None)
+}

--- a/examples/test.css
+++ b/examples/test.css
@@ -1,0 +1,3 @@
+body {
+  color: red;
+}

--- a/examples/test.html
+++ b/examples/test.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <p>Hello</p>
+  </body>
+</html>

--- a/examples/test.js
+++ b/examples/test.js
@@ -1,0 +1,5 @@
+function main() {
+    console.log("hello");
+}
+
+main();

--- a/examples/test.py
+++ b/examples/test.py
@@ -1,0 +1,5 @@
+def main():
+    print("hello")
+
+if __name__ == "__main__":
+    main()

--- a/examples/test.rs
+++ b/examples/test.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("hello");
+}

--- a/frontend/src/monaco-languages.ts
+++ b/frontend/src/monaco-languages.ts
@@ -1,0 +1,7 @@
+export const MONACO_LANGUAGES = [
+  'rust',
+  'python',
+  'javascript',
+  'css',
+  'html',
+];


### PR DESCRIPTION
## Summary
- add tree-sitter parser modules for Rust, Python, JavaScript, CSS, and HTML
- list supported languages for Monaco editor highlighting
- provide example source files for synchronization tests

## Testing
- `cargo test` *(fails: The system library `javascriptcoregtk-4.0` required by crate `javascriptcore-rs-sys` was not found)*
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898603a65f083239421c2c92648c0b1