### PR TITLE
feat: add export functionality

### DIFF
--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 mod meta;
 mod parser;
 mod i18n;
-use meta::{upsert, read_all, VisualMeta, Translations};
+use meta::{upsert, read_all, remove_all, VisualMeta, Translations};
 use parser::{parse, parse_to_blocks, Lang};
 use tauri::State;
 use serde::Serialize;
@@ -95,6 +95,13 @@ fn upsert_meta(content: String, meta: VisualMeta) -> String {
     upsert(&content, &meta)
 }
 
+#[tauri::command]
+fn export_clean(path: String, state: State<EditorState>) -> Result<(), String> {
+    let content = state.0.lock().unwrap().clone();
+    let cleaned = remove_all(&content);
+    std::fs::write(path, cleaned).map_err(|e| e.to_string())
+}
+
 fn main() {
     tauri::Builder::default()
         .manage(EditorState::default())
@@ -102,7 +109,8 @@ fn main() {
             save_state,
             load_state,
             parse_blocks,
-            upsert_meta
+            upsert_meta,
+            export_clean
         ])
         .run(tauri::generate_context!(
             "../frontend/src-tauri/tauri.conf.json"

--- a/backend/src/meta/mod.rs
+++ b/backend/src/meta/mod.rs
@@ -78,6 +78,19 @@ pub fn read_all(content: &str) -> Vec<VisualMeta> {
     metas
 }
 
+/// Remove all visual metadata comments from `content`.
+pub fn remove_all(content: &str) -> String {
+    let marker = format!("<!-- {} ", MARKER);
+    let mut out = String::new();
+    for line in content.lines() {
+        if !line.trim_start().starts_with(&marker) {
+            out.push_str(line);
+            out.push('\n');
+        }
+    }
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -91,5 +104,17 @@ mod tests {
         let metas = read_all(&updated);
         assert_eq!(metas.len(), 1);
         assert_eq!(metas[0].x, 10.0);
+    }
+
+    #[test]
+    fn remove_all_strips_metadata() {
+        let content = format!(
+            "line1\n<!-- {} {{\"id\":\"1\"}} -->\nline2\n",
+            MARKER
+        );
+        let cleaned = remove_all(&content);
+        assert!(!cleaned.contains(MARKER));
+        assert!(cleaned.contains("line1"));
+        assert!(cleaned.contains("line2"));
     }
 }

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -18,6 +18,7 @@
     import { html } from "https://cdn.jsdelivr.net/npm/@codemirror/lang-html@0.19.7/dist/index.js";
     import { css } from "https://cdn.jsdelivr.net/npm/@codemirror/lang-css@0.19.7/dist/index.js";
     import { invoke } from "https://cdn.jsdelivr.net/npm/@tauri-apps/api@1.5.0/tauri.js";
+    import { save as saveDialog } from "https://cdn.jsdelivr.net/npm/@tauri-apps/api@1.5.0/dialog.js";
     import { VisualCanvas } from "./visual/canvas.js";
 
     const canvasEl = document.getElementById('visual-canvas');
@@ -67,8 +68,17 @@
       parseAndRender();
     }
 
+    async function exportFile() {
+      await save();
+      const path = await saveDialog({ defaultPath: 'code.txt' });
+      if (path) {
+        await invoke('export_clean', { path });
+      }
+    }
+
     document.getElementById('save').addEventListener('click', save);
     document.getElementById('load').addEventListener('click', load);
+    document.getElementById('export').addEventListener('click', exportFile);
     document.getElementById('locale').addEventListener('change', e => {
       currentLocale = e.target.value;
       vc.setLocale(currentLocale);
@@ -83,6 +93,7 @@
   <div id="controls">
     <button id="save">Save</button>
     <button id="load">Load</button>
+    <button id="export">Export</button>
     <select id="locale">
       <option value="en">English</option>
       <option value="ru">Русский</option>


### PR DESCRIPTION
## Summary
- add export_clean backend command that strips visual metadata before saving
- add UI export button to invoke backend export API

## Testing
- `cargo test` *(fails: path matching ../backend/target/release/backend-x86_64-unknown-linux-gnu not found)*

------
https://chatgpt.com/codex/tasks/task_e_6898626c3cb88323a6372ab6fc1fc487