### PR TITLE
feat: reorder blocks and support undo

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -96,8 +96,11 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 name = "backend"
 version = "0.1.0"
 dependencies = [
+ "prettyplease",
+ "quote",
  "serde",
  "serde_json",
+ "syn 2.0.104",
  "tauri",
  "tauri-build",
  "tokio",
@@ -2104,6 +2107,16 @@ name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
+
+[[package]]
+name = "prettyplease"
+version = "0.2.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff24dfcda44452b9816fff4cd4227e1bb73ff5a2f1bc1105aa92fb8565ce44d2"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.104",
+]
 
 [[package]]
 name = "proc-macro-crate"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -14,6 +14,9 @@ tree-sitter-python = "0.20"
 tree-sitter-javascript = "0.20"
 tree-sitter-css = "0.20"
 tree-sitter-html = "0.20"
+syn = { version = "2", features = ["full"] }
+quote = "1"
+prettyplease = "0.2"
 
 [build-dependencies]
 tauri-build = { version = "1" }

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -26,7 +26,7 @@
 
     vc.onBlockMove(async block => {
       const content = view.state.doc.toString();
-      const updated = await invoke('upsert_meta', { content, meta: { id: block.id, x: block.x, y: block.y } });
+      const updated = await invoke('upsert_meta', { content, meta: { id: block.id, x: block.x, y: block.y }, lang: currentLang });
       view.dispatch({ changes: { from: 0, to: view.state.doc.length, insert: updated } });
       await invoke('save_state', { content: updated });
     });
@@ -79,6 +79,8 @@
     document.getElementById('save').addEventListener('click', save);
     document.getElementById('load').addEventListener('click', load);
     document.getElementById('export').addEventListener('click', exportFile);
+    document.getElementById('undo').addEventListener('click', () => vc.undo());
+    document.getElementById('redo').addEventListener('click', () => vc.redo());
     document.getElementById('locale').addEventListener('change', e => {
       currentLocale = e.target.value;
       vc.setLocale(currentLocale);
@@ -94,6 +96,8 @@
     <button id="save">Save</button>
     <button id="load">Load</button>
     <button id="export">Export</button>
+    <button id="undo">Undo</button>
+    <button id="redo">Redo</button>
     <select id="locale">
       <option value="en">English</option>
       <option value="ru">Русский</option>


### PR DESCRIPTION
## Summary
- regenerate Rust source using `syn` and `prettyplease` when blocks move
- add undo/redo for visual block movements and update code via backend
- expose undo/redo controls on the frontend

## Testing
- `cargo test` *(fails: The system library `javascriptcoregtk-4.0` required by crate `javascriptcore-rs-sys` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_6898684446f88323b5dad9f48c6a2771