### PR TITLE
feat: add plugin system

### DIFF
--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -5,6 +5,7 @@ mod meta;
 mod parser;
 mod i18n;
 mod git;
+mod plugins;
 use meta::{upsert, read_all, remove_all, VisualMeta, Translations};
 use parser::{parse, parse_to_blocks, Lang};
 use tauri::State;

--- a/backend/src/plugins/mod.rs
+++ b/backend/src/plugins/mod.rs
@@ -1,0 +1,27 @@
+use serde::{Serialize, Deserialize};
+
+/// Description of a block type provided by a plugin.
+///
+/// Backend uses this information to tell the frontend which visual
+/// components should be loaded.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BlockDescriptor {
+    /// Identifier of the block kind.
+    pub kind: String,
+    /// Optional human‑readable label for the block.
+    pub label: Option<String>,
+}
+
+/// Interface implemented by backend plugins.
+///
+/// Plugins can extend the system with new block kinds or other
+/// functionality.  Each plugin must provide a unique name and may return
+/// descriptors of additional blocks that should be available on the
+/// frontend.
+pub trait Plugin: Send + Sync {
+    /// Unique plugin name.
+    fn name(&self) -> &'static str;
+
+    /// Return block descriptors contributed by this plugin.
+    fn blocks(&self) -> Vec<BlockDescriptor>;
+}

--- a/examples/plugins/README.md
+++ b/examples/plugins/README.md
@@ -1,0 +1,51 @@
+# Плагины
+
+В проекте поддерживается расширение функциональности через плагины.
+Плагин состоит из двух частей:
+
+* **Backend** – реализует трейт [`Plugin`](../../backend/src/plugins/mod.rs) и
+  сообщает о дополнительных типах блоков.
+* **Frontend** – предоставляет визуальный компонент для нового блока и
+  регистрирует его через функцию `registerBlock`.
+
+## Backend API
+
+```rust
+use backend::plugins::{Plugin, BlockDescriptor};
+
+pub struct MyPlugin;
+
+impl Plugin for MyPlugin {
+    fn name(&self) -> &'static str { "my-plugin" }
+
+    fn blocks(&self) -> Vec<BlockDescriptor> {
+        vec![BlockDescriptor {
+            kind: "MyBlock".into(),
+            label: Some("Мой блок".into()),
+        }]
+    }
+}
+```
+
+## Frontend пример
+
+```javascript
+// my-block.js
+export function register({ Block, registerBlock }) {
+  class MyBlock extends Block {
+    draw(ctx) {
+      super.draw(ctx);
+      ctx.strokeStyle = 'red';
+      ctx.strokeRect(this.x, this.y, this.w, this.h);
+    }
+  }
+
+  registerBlock('MyBlock', MyBlock);
+}
+```
+
+Загрузить модуль можно, передав путь в `loadBlockPlugins`:
+
+```javascript
+await loadBlockPlugins(['./my-block.js']);
+```

--- a/examples/plugins/my-block.js
+++ b/examples/plugins/my-block.js
@@ -1,0 +1,14 @@
+// Example block plugin used in documentation.
+// The module exposes a `register` function which receives the base Block
+// class and a helper for registration.
+export function register({ Block, registerBlock }) {
+  class MyBlock extends Block {
+    draw(ctx) {
+      super.draw(ctx);
+      ctx.strokeStyle = 'red';
+      ctx.strokeRect(this.x, this.y, this.w, this.h);
+    }
+  }
+
+  registerBlock('MyBlock', MyBlock);
+}

--- a/examples/plugins/my_plugin.rs
+++ b/examples/plugins/my_plugin.rs
@@ -1,0 +1,16 @@
+use backend::plugins::{Plugin, BlockDescriptor};
+
+pub struct MyPlugin;
+
+impl Plugin for MyPlugin {
+    fn name(&self) -> &'static str {
+        "my-plugin"
+    }
+
+    fn blocks(&self) -> Vec<BlockDescriptor> {
+        vec![BlockDescriptor {
+            kind: "MyBlock".to_string(),
+            label: Some("Мой блок".to_string()),
+        }]
+    }
+}

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -22,6 +22,9 @@
     import { invoke } from "https://cdn.jsdelivr.net/npm/@tauri-apps/api@1.5.0/tauri.js";
     import { save as saveDialog } from "https://cdn.jsdelivr.net/npm/@tauri-apps/api@1.5.0/dialog.js";
     import { VisualCanvas } from "./visual/canvas.js";
+    import { loadBlockPlugins } from "./visual/blocks.js";
+
+    await loadBlockPlugins(window.blockPlugins || []);
 
     const canvasEl = document.getElementById('visual-canvas');
     const vc = new VisualCanvas(canvasEl);

--- a/frontend/src/visual/blocks.js
+++ b/frontend/src/visual/blocks.js
@@ -32,6 +32,34 @@ export class Block {
   }
 }
 
+// ---- Plugin infrastructure -------------------------------------------------
+
+const registry = {};
+
+export function registerBlock(kind, ctor) {
+  registry[kind] = ctor;
+}
+
+export function createBlock(kind, id, x, y, label, color) {
+  const Ctor = registry[kind] || Block;
+  return new Ctor(id, x, y, 120, 50, label, color);
+}
+
+export async function loadBlockPlugins(urls) {
+  for (const url of urls) {
+    try {
+      const mod = await import(/* @vite-ignore */ url);
+      if (mod && typeof mod.register === 'function') {
+        mod.register({ Block, registerBlock });
+      }
+    } catch (e) {
+      console.error('Failed to load block plugin', url, e);
+    }
+  }
+}
+
+// ---- Built-in blocks -------------------------------------------------------
+
 export class FunctionBlock extends Block {
   constructor(id, x, y) {
     super(id, x, y, 120, 50, 'Function', '#e0f7fa');
@@ -55,3 +83,8 @@ export class LoopBlock extends Block {
     super(id, x, y, 120, 50, 'Loop', '#fce4ec');
   }
 }
+
+registerBlock('Function', FunctionBlock);
+registerBlock('Variable', VariableBlock);
+registerBlock('Condition', ConditionBlock);
+registerBlock('Loop', LoopBlock);

--- a/frontend/src/visual/canvas.js
+++ b/frontend/src/visual/canvas.js
@@ -1,4 +1,4 @@
-import { Block } from './blocks.js';
+import { createBlock } from './blocks.js';
 
 export class VisualCanvas {
   constructor(canvas) {
@@ -42,7 +42,7 @@ export class VisualCanvas {
     this.blocks = this.blocksData.map(b => {
       const label = (b.translations && b.translations[this.locale]) || b.kind;
       const color = this.highlighted.has(b.visual_id) ? '#ffcccc' : '#fff';
-      return new Block(b.visual_id, b.x, b.y, 120, 50, label, color);
+      return createBlock(b.kind, b.visual_id, b.x, b.y, label, color);
     });
   }
 


### PR DESCRIPTION
## Summary
- define backend plugin interface and block descriptors
- allow frontend to load block components from plugins
- document plugin API with examples

## Testing
- `cargo test` *(fails: path matching ../backend/target/release/backend-x86_64-unknown-linux-gnu not found)*

------
https://chatgpt.com/codex/tasks/task_e_68986e2de6888323a44cc2e4fcad9671