### PR TITLE
feat: add visual meta editor features

### DIFF
--- a/frontend/src/editor/visual-meta.js
+++ b/frontend/src/editor/visual-meta.js
@@ -1,0 +1,75 @@
+import { StateField, RangeSetBuilder } from "https://cdn.jsdelivr.net/npm/@codemirror/state@6.4.0/dist/index.js";
+import { Decoration, EditorView } from "https://cdn.jsdelivr.net/npm/@codemirror/view@6.21.3/dist/index.js";
+
+const templates = {
+  rust: () => `// @VISUAL_META ${JSON.stringify({id: crypto.randomUUID(), x:0, y:0})}`,
+  javascript: () => `// @VISUAL_META ${JSON.stringify({id: crypto.randomUUID(), x:0, y:0})}`,
+  python: () => `# @VISUAL_META ${JSON.stringify({id: crypto.randomUUID(), x:0, y:0})}`,
+  html: () => `<!-- @VISUAL_META ${JSON.stringify({id: crypto.randomUUID(), x:0, y:0})} -->`,
+  css: () => `/* @VISUAL_META ${JSON.stringify({id: crypto.randomUUID(), x:0, y:0})} */`,
+};
+
+export function insertVisualMeta(view, lang) {
+  const tmpl = (templates[lang] || templates.javascript)() + "\n";
+  const { from } = view.state.selection.main;
+  view.dispatch({ changes: { from, to: from, insert: tmpl } });
+}
+
+export function updateMetaComment(view, meta) {
+  const text = view.state.doc.toString();
+  const re = /@VISUAL_META\s*(\{[^\}]*\})/g;
+  let m;
+  while ((m = re.exec(text)) !== null) {
+    const json = m[1];
+    try {
+      const obj = JSON.parse(json);
+      if (obj.id === meta.id) {
+        obj.x = meta.x;
+        obj.y = meta.y;
+        const newJson = JSON.stringify(obj);
+        const start = m.index + m[0].indexOf(json);
+        const end = start + json.length;
+        view.dispatch({ changes: { from: start, to: end, insert: newJson } });
+        return true;
+      }
+    } catch(_) {
+      // ignore
+    }
+  }
+  return false;
+}
+
+const regexes = [
+  /#\s*@VISUAL_META\s*(\{.*\})/g,
+  /\/\/\s*@VISUAL_META\s*(\{.*\})/g,
+  /\/\*\s*@VISUAL_META\s*(\{.*?\})\s*\*\//gs,
+  /<!--\s*@VISUAL_META\s*(\{.*?\})\s*-->/gs,
+];
+
+export const visualMetaHighlighter = StateField.define({
+  create() {
+    return Decoration.none;
+  },
+  update(deco, tr) {
+    if (!tr.docChanged) return deco;
+    const builder = new RangeSetBuilder();
+    const text = tr.newDoc.toString();
+    regexes.forEach(re => {
+      re.lastIndex = 0;
+      let m;
+      while ((m = re.exec(text)) !== null) {
+        const json = m[1];
+        try {
+          JSON.parse(json);
+        } catch (_) {
+          const start = m.index + m[0].indexOf(json);
+          const end = start + json.length;
+          builder.add(start, end, Decoration.mark({ class: "cm-invalid-meta" }));
+        }
+      }
+    });
+    return builder.finish();
+  },
+  provide: f => EditorView.decorations.from(f)
+});
+

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -10,6 +10,7 @@
     #controls { padding: 0.5rem; }
     #git-panel { padding: 0.5rem; border-top: 1px solid #ccc; }
     #git-log { white-space: pre-wrap; background: #f5f5f5; max-height: 20vh; overflow: auto; padding: 0.5rem; }
+    .cm-invalid-meta { text-decoration: wavy underline red; }
   </style>
   <script type="module">
     import { EditorState } from "https://cdn.jsdelivr.net/npm/@codemirror/state@6.4.0/dist/index.js";
@@ -23,6 +24,7 @@
     import { save as saveDialog } from "https://cdn.jsdelivr.net/npm/@tauri-apps/api@1.5.0/dialog.js";
     import { VisualCanvas } from "./visual/canvas.js";
     import { loadBlockPlugins } from "./visual/blocks.js";
+    import { insertVisualMeta, updateMetaComment, visualMetaHighlighter } from "./editor/visual-meta.js";
 
     await loadBlockPlugins(window.blockPlugins || []);
 
@@ -30,10 +32,9 @@
     const vc = new VisualCanvas(canvasEl);
 
     vc.onBlockMove(async block => {
-      const content = view.state.doc.toString();
-      const updated = await invoke('upsert_meta', { content, meta: { id: block.id, x: block.x, y: block.y }, lang: currentLang });
-      view.dispatch({ changes: { from: 0, to: view.state.doc.length, insert: updated } });
-      await invoke('save_state', { content: updated });
+      if (updateMetaComment(view, { id: block.id, x: block.x, y: block.y })) {
+        await invoke('save_state', { content: view.state.doc.toString() });
+      }
     });
 
     const currentLang = 'rust';
@@ -54,7 +55,7 @@
       state: EditorState.create({
         doc: '',
         extensions: [
-          basicSetup, javascript(), python(), rust(), html(), css(),
+          basicSetup, javascript(), python(), rust(), html(), css(), visualMetaHighlighter,
           EditorView.updateListener.of(update => {
             if (update.docChanged) parseAndRender();
           })
@@ -86,6 +87,7 @@
     document.getElementById('export').addEventListener('click', exportFile);
     document.getElementById('undo').addEventListener('click', () => vc.undo());
     document.getElementById('redo').addEventListener('click', () => vc.redo());
+    document.getElementById('insert-meta').addEventListener('click', () => insertVisualMeta(view, currentLang));
     document.getElementById('locale').addEventListener('change', e => {
       currentLocale = e.target.value;
       vc.setLocale(currentLocale);
@@ -152,6 +154,7 @@
     <button id="export">Export</button>
     <button id="undo">Undo</button>
     <button id="redo">Redo</button>
+    <button id="insert-meta">Insert Meta</button>
     <select id="locale">
       <option value="en">English</option>
       <option value="ru">Русский</option>


### PR DESCRIPTION
## Summary
- add Visual Meta helper with insert command and JSON validation
- wire Visual Meta commands into editor and add toolbar control

## Testing
- `npm test`
- `cargo test` *(fails: unable to read Tauri config file)*


------
https://chatgpt.com/codex/tasks/task_e_689895b637988323a05b54fd610912b2