### PR TITLE
feat: strip visual metadata on export

### DIFF
--- a/backend/src/export.rs
+++ b/backend/src/export.rs
@@ -1,0 +1,42 @@
+use once_cell::sync::Lazy;
+use regex::Regex;
+
+// Regular expressions matching different comment styles that may contain
+// `@VISUAL_META` markers. Each pattern also consumes the trailing newline so
+// the entire line is removed from the output.
+static PYTHON_SINGLE: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"(?m)^\s*#\s*@VISUAL_META\s*\{.*\}\s*\n?").unwrap());
+
+static SLASH_SINGLE: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"(?m)^\s*//\s*@VISUAL_META\s*\{.*\}\s*\n?").unwrap());
+
+static C_STYLE_MULTI: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"(?ms)^\s*/\*\s*@VISUAL_META\s*\{.*?\}\s*\*/\s*\n?").unwrap());
+
+static HTML_MULTI: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"(?ms)^\s*<!--\s*@VISUAL_META\s*\{.*?\}\s*-->\s*\n?").unwrap());
+
+/// Remove all lines containing `@VISUAL_META` comments from `content`.
+///
+/// Supports single line comments beginning with `#` or `//` and block style
+/// comments like `/* */` and `<!-- -->`.
+pub fn remove_meta_lines(content: &str) -> String {
+    let mut out = content.to_string();
+    for re in [&PYTHON_SINGLE, &SLASH_SINGLE, &C_STYLE_MULTI, &HTML_MULTI] {
+        out = re.replace_all(&out, "").to_string();
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strips_python_comment() {
+        let src = "# @VISUAL_META {\"id\":1}\nprint(\"hi\")\n";
+        let cleaned = remove_meta_lines(src);
+        assert!(!cleaned.contains("@VISUAL_META"));
+        assert!(cleaned.contains("print"));
+    }
+}

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -1,1 +1,2 @@
+pub mod export;
 pub mod meta;

--- a/backend/tests/export.rs
+++ b/backend/tests/export.rs
@@ -1,0 +1,33 @@
+use backend::export::remove_meta_lines;
+
+#[test]
+fn remove_python_meta() {
+    let src = "# @VISUAL_META {\"id\":\"1\",\"x\":1.0,\"y\":2.0}\nprint(\"hi\")";
+    let cleaned = remove_meta_lines(src);
+    assert!(!cleaned.contains("@VISUAL_META"));
+    assert!(cleaned.contains("print"));
+}
+
+#[test]
+fn remove_js_meta() {
+    let src = "// @VISUAL_META {\"id\":\"1\",\"x\":1.0,\"y\":2.0}\nconsole.log(\"hi\");";
+    let cleaned = remove_meta_lines(src);
+    assert!(!cleaned.contains("@VISUAL_META"));
+    assert!(cleaned.contains("console.log"));
+}
+
+#[test]
+fn remove_css_meta() {
+    let src = "/* @VISUAL_META {\"id\":\"1\",\"x\":1.0,\"y\":2.0} */\n.selector { color: red; }";
+    let cleaned = remove_meta_lines(src);
+    assert!(!cleaned.contains("@VISUAL_META"));
+    assert!(cleaned.contains(".selector"));
+}
+
+#[test]
+fn remove_html_meta() {
+    let src = "<!-- @VISUAL_META {\"id\":\"1\",\"x\":1.0,\"y\":2.0} -->\n<div></div>";
+    let cleaned = remove_meta_lines(src);
+    assert!(!cleaned.contains("@VISUAL_META"));
+    assert!(cleaned.contains("<div>"));
+}

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -74,17 +74,24 @@
       parseAndRender();
     }
 
-    async function exportFile() {
-      await save();
-      const path = await saveDialog({ defaultPath: 'code.txt' });
-      if (path) {
-        await invoke('export_clean', { path });
+    async function exportWithoutMeta() {
+      exportProgress.style.display = 'inline';
+      try {
+        await save();
+        const path = await saveDialog({ defaultPath: 'code.txt' });
+        if (path) {
+          await invoke('export_clean', { path });
+        }
+      } finally {
+        exportProgress.style.display = 'none';
       }
     }
 
+    const exportProgress = document.getElementById('export-progress');
+
     document.getElementById('save').addEventListener('click', save);
     document.getElementById('load').addEventListener('click', load);
-    document.getElementById('export').addEventListener('click', exportFile);
+    document.getElementById('export-clean').addEventListener('click', exportWithoutMeta);
     document.getElementById('undo').addEventListener('click', () => vc.undo());
     document.getElementById('redo').addEventListener('click', () => vc.redo());
     document.getElementById('insert-meta').addEventListener('click', () => insertVisualMeta(view, currentLang));
@@ -151,7 +158,8 @@
   <div id="controls">
     <button id="save">Save</button>
     <button id="load">Load</button>
-    <button id="export">Export</button>
+    <button id="export-clean">Экспорт без метаданных</button>
+    <span id="export-progress" style="display:none">Exporting…</span>
     <button id="undo">Undo</button>
     <button id="redo">Redo</button>
     <button id="insert-meta">Insert Meta</button>


### PR DESCRIPTION
## Summary
- remove `@VISUAL_META` comment lines for multiple comment styles
- expose export cleaner in backend and add tests
- add “Экспорт без метаданных” button with progress indicator

## Testing
- `cargo test` *(fails: system library `javascriptcoregtk-4.0` not found)*
- `npm test --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_689899c111d48323a14ddb9b3cd63496