### PR TITLE
Add visual sync tests for frontend and backend

### DIFF
--- a/backend/tests/parse_sync.rs
+++ b/backend/tests/parse_sync.rs
@@ -1,0 +1,10 @@
+use backend::meta::read_all;
+
+#[test]
+fn block_disappears_after_comment_removal() {
+    let with_comment = "// @VISUAL_META {\"id\":\"1\",\"x\":1.0,\"y\":2.0}\nfn main() {}";
+    assert_eq!(read_all(with_comment).len(), 1);
+
+    let without_comment = "fn main() {}";
+    assert!(read_all(without_comment).is_empty());
+}

--- a/frontend/tests/visual_sync.test.ts
+++ b/frontend/tests/visual_sync.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// Mock Codemirror modules used by visual-meta.js
+vi.mock('https://cdn.jsdelivr.net/npm/@codemirror/state@6.4.0/dist/index.js', () => ({
+  StateField: { define: vi.fn() },
+  RangeSetBuilder: class {},
+}));
+
+vi.mock('https://cdn.jsdelivr.net/npm/@codemirror/view@6.21.3/dist/index.js', () => ({
+  Decoration: { mark: () => ({}) },
+  EditorView: { decorations: { from: vi.fn() }, updateListener: { of: vi.fn() } },
+}));
+
+import { updateMetaComment } from '../src/editor/visual-meta.js';
+
+describe('visual-meta synchronization', () => {
+  it('reflects block coordinate changes in comments', () => {
+    const original = '// @VISUAL_META {"id":"1","x":0,"y":0}\nfn main() {}';
+    const view: any = {
+      state: { doc: { toString: () => original } },
+      dispatch: vi.fn(({ changes: { from, to, insert } }) => {
+        const updated = original.slice(0, from) + insert + original.slice(to);
+        view.state.doc.toString = () => updated;
+      }),
+    };
+
+    const updated = updateMetaComment(view, { id: '1', x: 5, y: 7 });
+    expect(updated).toBe(true);
+    const text = view.state.doc.toString();
+    expect(text).toContain('"x":5');
+    expect(text).toContain('"y":7');
+  });
+});


### PR DESCRIPTION
## Summary
- test frontend coordinate updates reflected in comments
- ensure backend drops blocks when comments removed

## Testing
- `cargo test` *(fails: pkg-config could not find `javascriptcoregtk-4.0`)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68989f8edee0832381e72d5952af88c2