### PR TITLE
feat: validate visual meta schema

### DIFF
--- a/frontend/src/editor/visual-meta-schema.json
+++ b/frontend/src/editor/visual-meta-schema.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": ["id", "x", "y"],
+  "additionalProperties": false,
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "Identifier linking this metadata to blocks."
+    },
+    "x": {
+      "type": "number",
+      "description": "X coordinate on the canvas."
+    },
+    "y": {
+      "type": "number",
+      "description": "Y coordinate on the canvas."
+    },
+    "translations": {
+      "type": "object",
+      "description": "Optional translations for block labels.",
+      "additionalProperties": false,
+      "properties": {
+        "ru": { "type": "string", "description": "Russian translation." },
+        "en": { "type": "string", "description": "English translation." },
+        "es": { "type": "string", "description": "Spanish translation." }
+      }
+    },
+    "ai": {
+      "type": "object",
+      "description": "Optional AI-generated note.",
+      "additionalProperties": false,
+      "properties": {
+        "description": { "type": "string", "description": "AI provided description." },
+        "hints": {
+          "type": "array",
+          "description": "Helpful hints for the user.",
+          "items": { "type": "string" }
+        }
+      }
+    }
+  }
+}

--- a/frontend/src/editor/visual-meta.js
+++ b/frontend/src/editor/visual-meta.js
@@ -1,5 +1,7 @@
 import { StateField, RangeSetBuilder } from "https://cdn.jsdelivr.net/npm/@codemirror/state@6.4.0/dist/index.js";
 import { Decoration, EditorView } from "https://cdn.jsdelivr.net/npm/@codemirror/view@6.21.3/dist/index.js";
+import { hoverTooltip } from "https://cdn.jsdelivr.net/npm/@codemirror/language@6.10.1/dist/index.js";
+import schema from "./visual-meta-schema.json" with { type: "json" };
 
 const templates = {
   rust: () => `// @VISUAL_META ${JSON.stringify({id: crypto.randomUUID(), x:0, y:0})}`,
@@ -46,6 +48,44 @@ const regexes = [
   /<!--\s*@VISUAL_META\s*(\{.*?\})\s*-->/gs,
 ];
 
+function validateAgainstSchema(obj, sch, path = "") {
+  const errors = [];
+  if (sch.type === "object") {
+    if (typeof obj !== "object" || obj === null || Array.isArray(obj)) {
+      errors.push(`${path || 'value'} should be object`);
+      return errors;
+    }
+    if (sch.required) {
+      for (const key of sch.required) {
+        if (!(key in obj)) errors.push(`${path}${key} is required`);
+      }
+    }
+    if (sch.additionalProperties === false && sch.properties) {
+      for (const key of Object.keys(obj)) {
+        if (!(key in sch.properties)) errors.push(`${path}${key} is not allowed`);
+      }
+    }
+    for (const [key, val] of Object.entries(sch.properties || {})) {
+      if (key in obj) {
+        errors.push(...validateAgainstSchema(obj[key], val, `${path}${key}.`));
+      }
+    }
+  } else if (sch.type === "number") {
+    if (typeof obj !== "number") errors.push(`${path.slice(0, -1)} should be number`);
+  } else if (sch.type === "string") {
+    if (typeof obj !== "string") errors.push(`${path.slice(0, -1)} should be string`);
+  } else if (sch.type === "array") {
+    if (!Array.isArray(obj)) {
+      errors.push(`${path.slice(0, -1)} should be array`);
+    } else if (sch.items) {
+      obj.forEach((item, i) => {
+        errors.push(...validateAgainstSchema(item, sch.items, `${path}${i}.`));
+      });
+    }
+  }
+  return errors;
+}
+
 export const visualMetaHighlighter = StateField.define({
   create() {
     return Decoration.none;
@@ -59,17 +99,46 @@ export const visualMetaHighlighter = StateField.define({
       let m;
       while ((m = re.exec(text)) !== null) {
         const json = m[1];
+        let start = m.index + m[0].indexOf(json);
+        let end = start + json.length;
+        let obj;
         try {
-          JSON.parse(json);
+          obj = JSON.parse(json);
         } catch (_) {
-          const start = m.index + m[0].indexOf(json);
-          const end = start + json.length;
-          builder.add(start, end, Decoration.mark({ class: "cm-invalid-meta" }));
+          builder.add(start, end, Decoration.mark({ class: "cm-invalid-meta", attributes: { title: "Invalid JSON" } }));
+          continue;
+        }
+        const errors = validateAgainstSchema(obj, schema);
+        if (errors.length) {
+          builder.add(start, end, Decoration.mark({ class: "cm-invalid-meta", attributes: { title: errors.join("; ") } }));
         }
       }
     });
     return builder.finish();
   },
   provide: f => EditorView.decorations.from(f)
+});
+
+export const visualMetaTooltip = hoverTooltip((view, pos) => {
+  const text = view.state.doc.toString();
+  for (const re of regexes) {
+    re.lastIndex = 0;
+    let m;
+    while ((m = re.exec(text)) !== null) {
+      const json = m[1];
+      const start = m.index + m[0].indexOf(json);
+      const end = start + json.length;
+      if (pos >= start && pos <= end) {
+        const dom = document.createElement("div");
+        for (const [key, prop] of Object.entries(schema.properties)) {
+          const line = document.createElement("div");
+          line.textContent = `${key}: ${prop.description || ""}`;
+          dom.appendChild(line);
+        }
+        return { pos: start, end, above: true, create: () => ({ dom }) };
+      }
+    }
+  }
+  return null;
 });
 

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -24,7 +24,7 @@
     import { save as saveDialog } from "https://cdn.jsdelivr.net/npm/@tauri-apps/api@1.5.0/dialog.js";
     import { VisualCanvas } from "./visual/canvas.js";
     import { loadBlockPlugins } from "./visual/blocks.js";
-    import { insertVisualMeta, updateMetaComment, visualMetaHighlighter } from "./editor/visual-meta.js";
+    import { insertVisualMeta, updateMetaComment, visualMetaHighlighter, visualMetaTooltip } from "./editor/visual-meta.js";
 
     await loadBlockPlugins(window.blockPlugins || []);
 
@@ -55,7 +55,7 @@
       state: EditorState.create({
         doc: '',
         extensions: [
-          basicSetup, javascript(), python(), rust(), html(), css(), visualMetaHighlighter,
+          basicSetup, javascript(), python(), rust(), html(), css(), visualMetaHighlighter, visualMetaTooltip,
           EditorView.updateListener.of(update => {
             if (update.docChanged) parseAndRender();
           })

--- a/frontend/tests/visual_sync.test.ts
+++ b/frontend/tests/visual_sync.test.ts
@@ -11,6 +11,10 @@ vi.mock('https://cdn.jsdelivr.net/npm/@codemirror/view@6.21.3/dist/index.js', ()
   EditorView: { decorations: { from: vi.fn() }, updateListener: { of: vi.fn() } },
 }));
 
+vi.mock('https://cdn.jsdelivr.net/npm/@codemirror/language@6.10.1/dist/index.js', () => ({
+  hoverTooltip: () => ({})
+}));
+
 import { updateMetaComment } from '../src/editor/visual-meta.js';
 
 describe('visual-meta synchronization', () => {


### PR DESCRIPTION
## Summary
- validate @VISUAL_META comments against JSON schema and show errors
- add tooltip describing metadata fields in editor

## Testing
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898a30cf15483238d08cce0c3a5f2db