### PR TITLE
Add metadata LSP prototype

### DIFF
--- a/plugins/lsp/README.md
+++ b/plugins/lsp/README.md
@@ -1,0 +1,28 @@
+# Metadata LSP Prototype
+
+This directory contains a prototype [Language Server Protocol](https://microsoft.github.io/language-server-protocol/) implementation. The server scans documents for metadata markers and exposes them to editors so they can be highlighted in other IDEs.
+
+## Running the server
+
+```bash
+npm install
+npm start
+```
+
+The server communicates over standard input/output and therefore can be embedded in any LSP‑aware editor.
+
+## Protocol
+
+The server uses the standard LSP messages:
+
+* `initialize` – the client initializes the connection. The server replies with support for basic text document synchronization.
+* `textDocument/didOpen` and `textDocument/didChange` – whenever a document is opened or changed the server scans its contents for `meta:` markers.
+* `textDocument/publishDiagnostics` – for every occurrence of `meta:` the server publishes a diagnostic with severity `Hint`. Editors can use these diagnostics to highlight metadata ranges.
+
+A metadata marker has the form:
+
+```
+meta: description of the data
+```
+
+The text after `meta:` is included in the diagnostic message so an IDE can render it to the user.

--- a/plugins/lsp/package.json
+++ b/plugins/lsp/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@multicode/lsp",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Prototype language server highlighting metadata",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "vscode-languageserver": "^9.0.1"
+  }
+}

--- a/plugins/lsp/server.js
+++ b/plugins/lsp/server.js
@@ -1,0 +1,46 @@
+const {
+  createConnection,
+  TextDocuments,
+  ProposedFeatures,
+  DiagnosticSeverity
+} = require('vscode-languageserver/node');
+
+// Create a connection for the server using Node's IPC as a transport.
+const connection = createConnection(ProposedFeatures.all);
+const documents = new TextDocuments();
+
+// The server's capabilities on initialization.
+connection.onInitialize(() => ({
+  capabilities: {
+    textDocumentSync: documents.syncKind,
+  }
+}));
+
+// Scan the document for `meta:` markers and publish them as diagnostics.
+function validateTextDocument(textDocument) {
+  const text = textDocument.getText();
+  const pattern = /meta:\s*(.*)/g;
+  let diagnostics = [];
+  let match;
+  while ((match = pattern.exec(text))) {
+    const start = textDocument.positionAt(match.index);
+    const end = textDocument.positionAt(match.index + match[0].length);
+    diagnostics.push({
+      severity: DiagnosticSeverity.Hint,
+      range: { start, end },
+      message: `Metadata: ${match[1].trim()}`,
+      source: 'metadata-lsp'
+    });
+  }
+  connection.sendDiagnostics({ uri: textDocument.uri, diagnostics });
+}
+
+documents.onDidOpen(event => validateTextDocument(event.document));
+documents.onDidChangeContent(change => validateTextDocument(change.document));
+
+// Make the text document manager listen on the connection
+// for open, change and close text document events
+// and the connection listen on the input for 
+// `initialize` requests.
+documents.listen(connection);
+connection.listen();


### PR DESCRIPTION
## Summary
- add Node.js LSP server prototype to highlight `meta:` markers
- document protocol and usage for the metadata LSP

## Testing
- `npm test`
- `cargo test` *(fails: `javascriptcoregtk-4.0` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6898a61608688323a1d2a6a3e4be8e6d