### PR TITLE
feat: add debug mode for visual canvas

### DIFF
--- a/frontend/src/visual/canvas.test.js
+++ b/frontend/src/visual/canvas.test.js
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest';
+import { analyzeConnections } from './canvas.js';
+
+describe('analyzeConnections', () => {
+  it('detects missing blocks and cycles', () => {
+    const blocks = ['a', 'b', 'c'];
+    const edges = [['a', 'b'], ['b', 'a']];
+    const { missing, cycles } = analyzeConnections(blocks, edges);
+    expect(Array.from(missing)).toEqual(['c']);
+    expect(cycles.has('a->b')).toBe(true);
+    expect(cycles.has('b->a')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add graph analysis utility and debug mode to VisualCanvas
- highlight missing or cyclic connections with red markers and tooltips
- cover connection analysis with unit test

## Testing
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898a84745f48323b7dfb6a3bbbc8e0b