### PR TITLE
Add VisualMeta id registry with duplicate tracking

### DIFF
--- a/backend/src/meta/id_registry.rs
+++ b/backend/src/meta/id_registry.rs
@@ -1,0 +1,45 @@
+use std::collections::{HashMap, HashSet};
+use std::sync::Mutex;
+use once_cell::sync::Lazy;
+
+use super::VisualMeta;
+
+#[derive(Default)]
+struct Registry {
+    metas: HashMap<String, VisualMeta>,
+    dups: HashSet<String>,
+}
+
+static REGISTRY: Lazy<Mutex<Registry>> = Lazy::new(|| Mutex::new(Registry::default()));
+
+/// Register a [`VisualMeta`] entry, tracking duplicates.
+pub fn register(meta: VisualMeta) {
+    let mut reg = REGISTRY.lock().unwrap();
+    if reg.metas.contains_key(&meta.id) {
+        reg.dups.insert(meta.id.clone());
+    }
+    reg.metas.insert(meta.id.clone(), meta);
+}
+
+/// Retrieve a [`VisualMeta`] by id.
+pub fn get(id: &str) -> Option<VisualMeta> {
+    REGISTRY.lock().unwrap().metas.get(id).cloned()
+}
+
+/// Return a list of duplicate ids encountered so far.
+pub fn duplicates() -> Vec<String> {
+    REGISTRY
+        .lock()
+        .unwrap()
+        .dups
+        .iter()
+        .cloned()
+        .collect()
+}
+
+/// Clear the registry. Useful for tests.
+pub fn clear() {
+    let mut reg = REGISTRY.lock().unwrap();
+    reg.metas.clear();
+    reg.dups.clear();
+}

--- a/backend/src/meta/mod.rs
+++ b/backend/src/meta/mod.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 mod comment_detector;
+pub mod id_registry;
 
 /// Marker used to identify visual metadata comments in documents.
 const MARKER: &str = "@VISUAL_META";
@@ -77,9 +78,11 @@ pub fn upsert(content: &str, meta: &VisualMeta) -> String {
 
 /// Read all visual metadata comments from `content`.
 pub fn read_all(content: &str) -> Vec<VisualMeta> {
+    id_registry::clear();
     let mut metas = Vec::new();
     for json in comment_detector::extract_json(content) {
         if let Ok(meta) = serde_json::from_str::<VisualMeta>(&json) {
+            id_registry::register(meta.clone());
             metas.push(meta);
         }
     }

--- a/backend/tests/id_registry.rs
+++ b/backend/tests/id_registry.rs
@@ -1,0 +1,21 @@
+use backend::meta::{self, id_registry};
+
+#[test]
+fn detects_duplicate_ids() {
+    id_registry::clear();
+    let content = "# @VISUAL_META {\"id\":\"dup\",\"x\":0.0,\"y\":0.0}\n# @VISUAL_META {\"id\":\"dup\",\"x\":1.0,\"y\":1.0}";
+    // reading registers IDs
+    meta::read_all(content);
+    let dups = id_registry::duplicates();
+    assert_eq!(dups, vec!["dup".to_string()]);
+}
+
+#[test]
+fn finds_registered_meta() {
+    id_registry::clear();
+    let content = "# @VISUAL_META {\"id\":\"main\",\"x\":1.0,\"y\":2.0}";
+    meta::read_all(content);
+    let found = id_registry::get("main").expect("meta not found");
+    assert_eq!(found.x, 1.0);
+    assert_eq!(found.y, 2.0);
+}


### PR DESCRIPTION
## Summary
- implement global VisualMeta ID registry with duplicate detection
- hook registry into metadata reader
- add tests for duplicate IDs and lookup

## Testing
- `SKIP_TAURI_BUILD=1 cargo test --lib`
- Attempted `SKIP_TAURI_BUILD=1 cargo test --tests` *(fails: failed to read icon ...)*

------
https://chatgpt.com/codex/tasks/task_e_6898aeac87b0832399adb620f3864171