### PR TITLE
feat: add widget drag-drop library

### DIFF
--- a/examples/widget_app/index.html
+++ b/examples/widget_app/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Widget App</title>
+  <style>
+    #canvas { position: relative; width: 400px; height: 300px; border: 1px solid #ccc; }
+  </style>
+</head>
+<body>
+  <div id="canvas"></div>
+  <script type="module" src="./main.js"></script>
+</body>
+</html>

--- a/examples/widget_app/main.js
+++ b/examples/widget_app/main.js
@@ -1,0 +1,16 @@
+import { ButtonWidget, PanelWidget, TextWidget, syncWidgetsToCode } from '../../frontend/src/widget/index.js';
+
+const canvas = document.getElementById('canvas');
+
+const btn = new ButtonWidget('btn1', 20, 20, 'Click');
+const panel = new PanelWidget('panel1', 100, 80, 120, 80);
+const text = new TextWidget('text1', 40, 180, 'Hello');
+
+const widgets = [btn, panel, text];
+widgets.forEach(w => {
+  w.onMove = () => {
+    const code = syncWidgetsToCode(widgets, '');
+    console.log(code);
+  };
+  w.render(canvas);
+});

--- a/frontend/src/widget/codegen.js
+++ b/frontend/src/widget/codegen.js
@@ -1,0 +1,71 @@
+import { ButtonWidget, PanelWidget, TextWidget } from './widgets.js';
+
+export function widgetToCode(widget) {
+  const meta = {
+    id: widget.id,
+    type: 'widget',
+    kind: widget.kind,
+    x: widget.x,
+    y: widget.y,
+  };
+  if (widget.kind === 'button') meta.label = widget.label;
+  if (widget.kind === 'text') meta.text = widget.text;
+  if (widget.kind === 'panel') { meta.w = widget.w; meta.h = widget.h; }
+  const metaComment = `// @VISUAL_META ${JSON.stringify(meta)}`;
+  switch (widget.kind) {
+    case 'button':
+      return `${metaComment}\n<button id="${widget.id}" style="position:absolute;left:${widget.x}px;top:${widget.y}px;">${widget.label}</button>`;
+    case 'panel':
+      return `${metaComment}\n<div id="${widget.id}" style="position:absolute;left:${widget.x}px;top:${widget.y}px;width:${widget.w}px;height:${widget.h}px;border:1px solid #333;"></div>`;
+    case 'text':
+      return `${metaComment}\n<span id="${widget.id}" style="position:absolute;left:${widget.x}px;top:${widget.y}px;">${widget.text}</span>`;
+    default:
+      return metaComment;
+  }
+}
+
+export function syncWidgetsToCode(widgets, source) {
+  const lines = source.split(/\r?\n/);
+  widgets.forEach(w => {
+    const snippetLines = widgetToCode(w).split(/\r?\n/);
+    const regex = new RegExp(`@VISUAL_META\\s+\\{\\"id\\":\\"${w.id}\\"`);
+    const idx = lines.findIndex(line => regex.test(line));
+    if (idx !== -1) {
+      lines.splice(idx, snippetLines.length, ...snippetLines);
+    } else {
+      if (lines.length && lines[lines.length - 1] !== '') lines.push('');
+      lines.push(...snippetLines);
+    }
+  });
+  return lines.join('\n');
+}
+
+export function widgetsFromCode(source) {
+  const widgets = [];
+  const regex = /@VISUAL_META\s+(\{[^}]+\})/g;
+  let match;
+  while ((match = regex.exec(source))) {
+    try {
+      const meta = JSON.parse(match[1]);
+      if (meta.type !== 'widget') continue;
+      let w;
+      switch (meta.kind) {
+        case 'button':
+          w = new ButtonWidget(meta.id, meta.x, meta.y, meta.label);
+          break;
+        case 'panel':
+          w = new PanelWidget(meta.id, meta.x, meta.y, meta.w, meta.h);
+          break;
+        case 'text':
+          w = new TextWidget(meta.id, meta.x, meta.y, meta.text);
+          break;
+        default:
+          continue;
+      }
+      widgets.push(w);
+    } catch (e) {
+      // ignore malformed meta
+    }
+  }
+  return widgets;
+}

--- a/frontend/src/widget/codegen.test.js
+++ b/frontend/src/widget/codegen.test.js
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { ButtonWidget } from './widgets.js';
+import { widgetToCode, syncWidgetsToCode, widgetsFromCode } from './codegen.js';
+
+describe('widget code generation', () => {
+  it('generates code with meta comment', () => {
+    const w = new ButtonWidget('b1', 10, 20, 'OK');
+    const code = widgetToCode(w);
+    expect(code).toContain('@VISUAL_META');
+    expect(code).toContain('"type":"widget"');
+  });
+
+  it('syncs widgets into source and updates position', () => {
+    const w = new ButtonWidget('b1', 10, 20, 'OK');
+    let source = '';
+    source = syncWidgetsToCode([w], source);
+    expect(source).toMatch(/left:10px/);
+    w.x = 30; w.y = 40;
+    source = syncWidgetsToCode([w], source);
+    expect(source).toMatch(/left:30px/);
+  });
+
+  it('parses widgets from code', () => {
+    const w = new ButtonWidget('b2', 5, 5, 'Hi');
+    const source = syncWidgetsToCode([w], '');
+    const widgets = widgetsFromCode(source);
+    expect(widgets.length).toBe(1);
+    expect(widgets[0].id).toBe('b2');
+    expect(widgets[0].x).toBe(5);
+  });
+});

--- a/frontend/src/widget/index.js
+++ b/frontend/src/widget/index.js
@@ -1,0 +1,2 @@
+export { Widget, ButtonWidget, PanelWidget, TextWidget } from './widgets.js';
+export { widgetToCode, syncWidgetsToCode, widgetsFromCode } from './codegen.js';

--- a/frontend/src/widget/widgets.js
+++ b/frontend/src/widget/widgets.js
@@ -1,0 +1,112 @@
+export class Widget {
+  constructor(id, x, y) {
+    this.id = id;
+    this.x = x;
+    this.y = y;
+    this.el = null;
+    this.kind = 'widget';
+    this.onMove = null;
+  }
+
+  createElement() {
+    const el = document.createElement('div');
+    el.style.position = 'absolute';
+    el.style.left = this.x + 'px';
+    el.style.top = this.y + 'px';
+    el.dataset.widgetId = this.id;
+    this.el = el;
+    this.makeDraggable(el);
+    return el;
+  }
+
+  makeDraggable(el) {
+    let startX, startY;
+    const move = e => {
+      const dx = e.clientX - startX;
+      const dy = e.clientY - startY;
+      this.x += dx;
+      this.y += dy;
+      startX = e.clientX;
+      startY = e.clientY;
+      el.style.left = this.x + 'px';
+      el.style.top = this.y + 'px';
+      if (this.onMove) this.onMove(this);
+    };
+    el.addEventListener('mousedown', e => {
+      e.preventDefault();
+      startX = e.clientX;
+      startY = e.clientY;
+      document.addEventListener('mousemove', move);
+      document.addEventListener('mouseup', () => {
+        document.removeEventListener('mousemove', move);
+      }, { once: true });
+    });
+  }
+
+  render(parent) {
+    parent.appendChild(this.createElement());
+  }
+}
+
+export class ButtonWidget extends Widget {
+  constructor(id, x, y, label = 'Button') {
+    super(id, x, y);
+    this.label = label;
+    this.kind = 'button';
+  }
+
+  createElement() {
+    const btn = document.createElement('button');
+    btn.textContent = this.label;
+    btn.style.position = 'absolute';
+    btn.style.left = this.x + 'px';
+    btn.style.top = this.y + 'px';
+    btn.dataset.widgetId = this.id;
+    this.el = btn;
+    this.makeDraggable(btn);
+    return btn;
+  }
+}
+
+export class PanelWidget extends Widget {
+  constructor(id, x, y, w = 120, h = 80) {
+    super(id, x, y);
+    this.w = w;
+    this.h = h;
+    this.kind = 'panel';
+  }
+
+  createElement() {
+    const div = document.createElement('div');
+    div.style.position = 'absolute';
+    div.style.left = this.x + 'px';
+    div.style.top = this.y + 'px';
+    div.style.width = this.w + 'px';
+    div.style.height = this.h + 'px';
+    div.style.border = '1px solid #333';
+    div.dataset.widgetId = this.id;
+    this.el = div;
+    this.makeDraggable(div);
+    return div;
+  }
+}
+
+export class TextWidget extends Widget {
+  constructor(id, x, y, text = 'Text') {
+    super(id, x, y);
+    this.text = text;
+    this.kind = 'text';
+  }
+
+  createElement() {
+    const span = document.createElement('span');
+    span.textContent = this.text;
+    span.style.position = 'absolute';
+    span.style.left = this.x + 'px';
+    span.style.top = this.y + 'px';
+    span.dataset.widgetId = this.id;
+    this.el = span;
+    this.makeDraggable(span);
+    return span;
+  }
+}


### PR DESCRIPTION
## Summary
- implement draggable Button, Panel and Text widgets
- generate widget code with @VISUAL_META markers and sync functions
- add example widget_app demonstrating library

## Testing
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898b40f42d883239144dee531eeb0c6