### PR TITLE
feat: add configurable menu and hotkeys

### DIFF
--- a/frontend/settings.json
+++ b/frontend/settings.json
@@ -1,0 +1,9 @@
+{
+  "hotkeys": {
+    "copyBlock": "Ctrl+C",
+    "pasteBlock": "Ctrl+V",
+    "selectConnections": "Ctrl+Shift+A",
+    "focusSearch": "Ctrl+F",
+    "showHelp": "Ctrl+?"
+  }
+}

--- a/frontend/src/visual/hotkeys.ts
+++ b/frontend/src/visual/hotkeys.ts
@@ -1,0 +1,88 @@
+import settings from '../../settings.json' assert { type: 'json' };
+
+interface HotkeyMap {
+  copyBlock: string;
+  pasteBlock: string;
+  selectConnections: string;
+  focusSearch: string;
+  showHelp: string;
+}
+
+const cfg: { hotkeys?: Partial<HotkeyMap> } = settings as any;
+
+export const hotkeys: HotkeyMap = {
+  copyBlock: cfg.hotkeys?.copyBlock || 'Ctrl+C',
+  pasteBlock: cfg.hotkeys?.pasteBlock || 'Ctrl+V',
+  selectConnections: cfg.hotkeys?.selectConnections || 'Ctrl+Shift+A',
+  focusSearch: cfg.hotkeys?.focusSearch || 'Ctrl+F',
+  showHelp: cfg.hotkeys?.showHelp || 'Ctrl+?'
+};
+
+function buildCombo(e: KeyboardEvent) {
+  const parts: string[] = [];
+  if (e.ctrlKey) parts.push('Ctrl');
+  if (e.altKey) parts.push('Alt');
+  if (e.shiftKey) parts.push('Shift');
+  const key = e.key.length === 1 ? e.key.toUpperCase() : e.key;
+  parts.push(key);
+  return parts.join('+');
+}
+
+export function registerHotkeys(target: Document = document) {
+  target.addEventListener('keydown', handleKey);
+}
+
+export function unregisterHotkeys(target: Document = document) {
+  target.removeEventListener('keydown', handleKey);
+}
+
+function handleKey(e: KeyboardEvent) {
+  const combo = buildCombo(e);
+  switch (combo) {
+    case hotkeys.copyBlock:
+      e.preventDefault();
+      copyBlock();
+      break;
+    case hotkeys.pasteBlock:
+      e.preventDefault();
+      pasteBlock();
+      break;
+    case hotkeys.selectConnections:
+      e.preventDefault();
+      selectConnections();
+      break;
+    case hotkeys.focusSearch:
+      e.preventDefault();
+      focusSearch();
+      break;
+    case hotkeys.showHelp:
+      e.preventDefault();
+      showHotkeyHelp();
+      break;
+  }
+}
+
+export function copyBlock() {
+  console.log('copy block');
+}
+
+export function pasteBlock() {
+  console.log('paste block');
+}
+
+export function selectConnections() {
+  console.log('select connections');
+}
+
+export function focusSearch() {
+  const el = document.querySelector('input[type="search"]') as HTMLElement | null;
+  el?.focus();
+}
+
+export function showHotkeyHelp() {
+  const list = Object.entries(hotkeys)
+    .map(([name, combo]) => `${combo} - ${name}`)
+    .join('\n');
+  alert(list);
+}
+

--- a/frontend/src/visual/menu.ts
+++ b/frontend/src/visual/menu.ts
@@ -1,0 +1,45 @@
+import { hotkeys, showHotkeyHelp } from './hotkeys';
+
+export interface MenuItem {
+  label: string;
+  action?: () => void;
+  shortcut?: string;
+  submenu?: MenuItem[];
+}
+
+export const mainMenu: MenuItem[] = [
+  {
+    label: 'File',
+    submenu: [
+      { label: 'New', action: () => console.log('new file') },
+      { label: 'Open', action: () => console.log('open file') }
+    ]
+  },
+  {
+    label: 'Edit',
+    submenu: [
+      { label: 'Copy Block', action: () => console.log('copy'), shortcut: hotkeys.copyBlock },
+      { label: 'Paste Block', action: () => console.log('paste'), shortcut: hotkeys.pasteBlock },
+      { label: 'Select Connections', action: () => console.log('select'), shortcut: hotkeys.selectConnections },
+      { label: 'Focus Search', action: () => console.log('focus search'), shortcut: hotkeys.focusSearch }
+    ]
+  },
+  {
+    label: 'Help',
+    submenu: [
+      { label: 'Hotkeys', action: showHotkeyHelp, shortcut: hotkeys.showHelp }
+    ]
+  }
+];
+
+export const contextMenus = {
+  block: [
+    { label: 'Copy Block', action: () => console.log('copy'), shortcut: hotkeys.copyBlock },
+    { label: 'Paste Block', action: () => console.log('paste'), shortcut: hotkeys.pasteBlock }
+  ],
+  canvas: [
+    { label: 'Paste Block', action: () => console.log('paste'), shortcut: hotkeys.pasteBlock },
+    { label: 'Select Connections', action: () => console.log('select'), shortcut: hotkeys.selectConnections }
+  ]
+};
+


### PR DESCRIPTION
## Summary
- describe main and context menus along with actions
- add hotkey manager with configurable combos and help overlay
- read hotkey bindings from `settings.json`

## Testing
- `cd frontend && npm test >/tmp/unit.log && tail -n 20 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_6898b60724308323beeb45ba22b7e6f0