### PR TITLE
Add basic debugger and terminal integration

### DIFF
--- a/backend/src/debugger.rs
+++ b/backend/src/debugger.rs
@@ -1,0 +1,32 @@
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn log_action(action: &str) {
+    if let Ok(mut file) = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open("logs/debug.log")
+    {
+        let ts = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        let _ = writeln!(file, "[{}] {}", ts, action);
+    }
+}
+
+#[cfg_attr(not(test), tauri::command)]
+pub fn debug_run() {
+    log_action("run");
+}
+
+#[cfg_attr(not(test), tauri::command)]
+pub fn debug_step() {
+    log_action("step");
+}
+
+#[cfg_attr(not(test), tauri::command)]
+pub fn debug_break() {
+    log_action("break");
+}

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod export;
 pub mod meta;
+pub mod debugger;

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -8,12 +8,14 @@ mod meta;
 mod parser;
 mod plugins;
 mod server;
+mod debugger;
 use export::remove_meta_lines;
 use meta::{read_all, remove_all, upsert, AiNote, Translations, VisualMeta};
 use parser::{parse, parse_to_blocks, Lang};
 use serde::Serialize;
 use syn::{File, Item};
 use tauri::State;
+use debugger::{debug_run, debug_step, debug_break};
 
 #[derive(Default)]
 struct EditorState(Mutex<String>);
@@ -241,7 +243,10 @@ fn main() {
             git_commit_cmd,
             git_diff_cmd,
             git_branches_cmd,
-            git_log_cmd
+            git_log_cmd,
+            debug_run,
+            debug_step,
+            debug_break
         ])
         .run(tauri::generate_context!(
             "../frontend/src-tauri/tauri.conf.json"

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -7,6 +7,10 @@
     "": {
       "name": "frontend",
       "version": "0.1.0",
+      "dependencies": {
+        "@tauri-apps/api": "^1.0.0",
+        "xterm": "^5.3.0"
+      },
       "devDependencies": {
         "vitest": "^1.0.0"
       }
@@ -708,6 +712,21 @@
       "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@tauri-apps/api": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-1.6.0.tgz",
+      "integrity": "sha512-rqI++FWClU5I2UBp4HXFvl+sBWkdigBkxnpJDQUWttNyG7IZP4FwQGhTNL5EOw0vI8i6eSAJ5frLqO7n7jbJdg==",
+      "license": "Apache-2.0 OR MIT",
+      "engines": {
+        "node": ">= 14.6.0",
+        "npm": ">= 6.6.0",
+        "yarn": ">= 1.19.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/tauri"
+      }
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -1718,6 +1737,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/xterm": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/xterm/-/xterm-5.3.0.tgz",
+      "integrity": "sha512-8QqjlekLUFTrU6x7xck1MsPzPA571K5zNqWm0M0oroYEWVOptZ0+ubQSkQ3uxIEhcIHRujJy6emDWX4A7qyFzg==",
+      "deprecated": "This package is now deprecated. Move to @xterm/xterm instead.",
+      "license": "MIT"
     },
     "node_modules/yocto-queue": {
       "version": "1.2.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,6 +5,10 @@
   "scripts": {
     "test": "vitest"
   },
+  "dependencies": {
+    "@tauri-apps/api": "^1.0.0",
+    "xterm": "^5.3.0"
+  },
   "devDependencies": {
     "vitest": "^1.0.0"
   }

--- a/frontend/src/debug/index.js
+++ b/frontend/src/debug/index.js
@@ -1,0 +1,41 @@
+import { invoke } from "@tauri-apps/api/tauri";
+
+const breakpoints = new Set();
+
+export function toggleBreakpoint(line) {
+  if (breakpoints.has(line)) {
+    breakpoints.delete(line);
+  } else {
+    breakpoints.add(line);
+  }
+  renderBreakpoints();
+}
+
+function renderBreakpoints() {
+  const list = document.getElementById("debug-breakpoints");
+  if (!list) return;
+  list.innerHTML = "";
+  breakpoints.forEach((ln) => {
+    const li = document.createElement("li");
+    li.textContent = `Line ${ln}`;
+    list.appendChild(li);
+  });
+}
+
+export async function run() {
+  await invoke("debug_run");
+}
+
+export async function step() {
+  await invoke("debug_step");
+}
+
+export async function breakExecution() {
+  await invoke("debug_break");
+}
+
+export function showVariables(vars) {
+  const el = document.getElementById("debug-vars");
+  if (!el) return;
+  el.textContent = JSON.stringify(vars, null, 2);
+}

--- a/frontend/src/terminal/index.js
+++ b/frontend/src/terminal/index.js
@@ -1,0 +1,17 @@
+import { Terminal } from "xterm";
+import "xterm/css/xterm.css";
+import { Command } from "@tauri-apps/api/shell";
+
+export function attachTerminal(element) {
+  const term = new Terminal();
+  term.open(element);
+
+  const shell = new Command("sh", [], { stdout: "piped", stderr: "piped" });
+
+  shell.stdout.on("data", (line) => term.write(line));
+  shell.stderr.on("data", (line) => term.write(line));
+  term.onData((data) => {
+    shell.write(data).catch(() => {});
+  });
+  shell.spawn();
+}

--- a/logs/.gitignore
+++ b/logs/.gitignore
@@ -1,0 +1,1 @@
+debug.log


### PR DESCRIPTION
## Summary
- add basic debugger API with run/step/break and logging
- expose debugger commands to frontend and provide UI helpers
- integrate xterm.js terminal and dependencies

## Testing
- `cargo test` *(fails: The system library `glib-2.0` required by crate `glib-sys` was not found)*
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_6898b8382bac8323be21487fef3e649f