### PR TITLE
Add external file annotation and optional metadata export

### DIFF
--- a/backend/src/export.rs
+++ b/backend/src/export.rs
@@ -28,6 +28,18 @@ pub fn remove_meta_lines(content: &str) -> String {
     out
 }
 
+/// Prepare source content for export.
+///
+/// When `strip_meta` is true all `@VISUAL_META` comments are removed.
+/// Otherwise the content is returned unchanged.
+pub fn prepare_for_export(content: &str, strip_meta: bool) -> String {
+    if strip_meta {
+        remove_meta_lines(content)
+    } else {
+        content.to_string()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/backend/src/meta/mod.rs
+++ b/backend/src/meta/mod.rs
@@ -32,6 +32,9 @@ pub struct VisualMeta {
     pub x: f64,
     /// Y coordinate on the canvas.
     pub y: f64,
+    /// Optional reverse path to the original external file.
+    #[serde(default)]
+    pub origin: Option<String>,
     /// Optional translations for block labels.
     #[serde(default)]
     pub translations: Translations,

--- a/backend/src/server.rs
+++ b/backend/src/server.rs
@@ -50,13 +50,20 @@ async fn parse_endpoint(headers: HeaderMap, Json(req): Json<ParseRequest>) -> Re
 #[derive(Deserialize)]
 struct ExportRequest {
     content: String,
+    #[serde(default)]
+    strip_meta: bool,
 }
 
 async fn export_endpoint(headers: HeaderMap, Json(req): Json<ExportRequest>) -> Result<Json<String>, StatusCode> {
     if !auth(&headers) {
         return Err(StatusCode::UNAUTHORIZED);
     }
-    Ok(Json(remove_all(&req.content)))
+    let out = if req.strip_meta {
+        remove_all(&req.content)
+    } else {
+        req.content
+    };
+    Ok(Json(out))
 }
 
 #[derive(Deserialize)]

--- a/backend/tests/export.rs
+++ b/backend/tests/export.rs
@@ -1,9 +1,9 @@
-use backend::export::remove_meta_lines;
+use backend::export::prepare_for_export;
 
 #[test]
 fn remove_python_meta() {
     let src = "# @VISUAL_META {\"id\":\"1\",\"x\":1.0,\"y\":2.0}\nprint(\"hi\")";
-    let cleaned = remove_meta_lines(src);
+    let cleaned = prepare_for_export(src, true);
     assert!(!cleaned.contains("@VISUAL_META"));
     assert!(cleaned.contains("print"));
 }
@@ -11,7 +11,7 @@ fn remove_python_meta() {
 #[test]
 fn remove_js_meta() {
     let src = "// @VISUAL_META {\"id\":\"1\",\"x\":1.0,\"y\":2.0}\nconsole.log(\"hi\");";
-    let cleaned = remove_meta_lines(src);
+    let cleaned = prepare_for_export(src, true);
     assert!(!cleaned.contains("@VISUAL_META"));
     assert!(cleaned.contains("console.log"));
 }
@@ -19,7 +19,7 @@ fn remove_js_meta() {
 #[test]
 fn remove_css_meta() {
     let src = "/* @VISUAL_META {\"id\":\"1\",\"x\":1.0,\"y\":2.0} */\n.selector { color: red; }";
-    let cleaned = remove_meta_lines(src);
+    let cleaned = prepare_for_export(src, true);
     assert!(!cleaned.contains("@VISUAL_META"));
     assert!(cleaned.contains(".selector"));
 }
@@ -27,7 +27,15 @@ fn remove_css_meta() {
 #[test]
 fn remove_html_meta() {
     let src = "<!-- @VISUAL_META {\"id\":\"1\",\"x\":1.0,\"y\":2.0} -->\n<div></div>";
-    let cleaned = remove_meta_lines(src);
+    let cleaned = prepare_for_export(src, true);
     assert!(!cleaned.contains("@VISUAL_META"));
     assert!(cleaned.contains("<div>"));
+}
+
+#[test]
+fn keep_meta_when_requested() {
+    let src = "// @VISUAL_META {\"id\":\"1\",\"x\":1.0,\"y\":2.0}\nconsole.log(\"hi\");";
+    let kept = prepare_for_export(src, false);
+    assert!(kept.contains("@VISUAL_META"));
+    assert!(kept.contains("console.log"));
 }

--- a/frontend/src/editor/visual-meta-schema.json
+++ b/frontend/src/editor/visual-meta-schema.json
@@ -16,6 +16,10 @@
       "type": "number",
       "description": "Y coordinate on the canvas."
     },
+    "origin": {
+      "type": "string",
+      "description": "Reverse path to the original external file."
+    },
     "translations": {
       "type": "object",
       "description": "Optional translations for block labels.",

--- a/frontend/src/importer/annotate.js
+++ b/frontend/src/importer/annotate.js
@@ -1,0 +1,35 @@
+import { readTextFile, writeTextFile } from "@tauri-apps/api/fs";
+import { basename, join } from "@tauri-apps/api/path";
+import { insertVisualMeta } from "../editor/visual-meta.js";
+
+/**
+ * Copy an external file into the project and open it for annotation.
+ * A @VISUAL_META comment with a reverse path to the original file is
+ * inserted at the top of the copied file. The provided CodeMirror view
+ * is focused so the user can insert additional @VISUAL_META markers.
+ *
+ * @param {string} sourcePath Absolute path to the external file.
+ * @param {string} projectDir Project directory where the file should be copied.
+ * @param {import("@codemirror/view").EditorView} view Active editor view.
+ * @param {string} lang Language identifier used for visual meta templates.
+ * @returns {Promise<string>} Path to the copied file inside the project.
+ */
+export async function annotateExternalFile(sourcePath, projectDir, view, lang) {
+  const content = await readTextFile(sourcePath);
+  const fileName = await basename(sourcePath);
+  const destPath = await join(projectDir, fileName);
+
+  const meta = {
+    id: crypto.randomUUID(),
+    x: 0,
+    y: 0,
+    origin: sourcePath,
+  };
+  const comment = `// @VISUAL_META ${JSON.stringify(meta)}\n`;
+  await writeTextFile(destPath, comment + content);
+
+  // focus the editor and allow further annotations
+  view.focus();
+  insertVisualMeta(view, lang);
+  return destPath;
+}

--- a/frontend/src/importer/index.js
+++ b/frontend/src/importer/index.js
@@ -1,0 +1,1 @@
+export { annotateExternalFile } from './annotate.js';

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -80,7 +80,7 @@
         await save();
         const path = await saveDialog({ defaultPath: 'code.txt' });
         if (path) {
-          await invoke('export_clean', { path });
+          await invoke('export_file', { path, stripMeta: true });
         }
       } finally {
         exportProgress.style.display = 'none';


### PR DESCRIPTION
## Summary
- add importer utility to copy external files and seed them with `@VISUAL_META` linking back to the original
- allow VisualMeta schema to track origin paths and export endpoint to optionally strip metadata
- expose new `export_file` command for conditional metadata removal

## Testing
- `npm test --prefix frontend`
- `cargo test --manifest-path backend/Cargo.toml` *(fails: javascriptcoregtk-4.0 not found)*

------
https://chatgpt.com/codex/tasks/task_e_6898c85b8c108323a19687e1ef86843e