### PR TITLE
Add editor minimap, hover highlights, search and theming

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -156,6 +156,7 @@ dependencies = [
  "syn 2.0.104",
  "tauri",
  "tauri-build",
+ "tempfile",
  "tokio",
  "tokio-tungstenite",
  "tree-sitter",
@@ -164,6 +165,7 @@ dependencies = [
  "tree-sitter-javascript",
  "tree-sitter-python",
  "tree-sitter-rust",
+ "walkdir",
 ]
 
 [[package]]

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -23,6 +23,10 @@ prettyplease = "0.2"
 git2 = "0.18"
 regex = "1"
 once_cell = "1"
+walkdir = "2"
+
+[dev-dependencies]
+tempfile = "3"
 
 [build-dependencies]
 tauri-build = { version = "1", default-features = false }

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod export;
 pub mod meta;
 pub mod debugger;
+pub mod search;

--- a/backend/src/search.rs
+++ b/backend/src/search.rs
@@ -1,0 +1,74 @@
+use std::{fs, path::{Path, PathBuf}};
+
+use once_cell::sync::Lazy;
+use regex::Regex;
+use walkdir::WalkDir;
+
+use crate::meta::VisualMeta;
+
+static META_RE: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"@VISUAL_META\s*(\{.*?\})").unwrap()
+});
+
+#[derive(Debug, Clone)]
+pub struct SearchResult {
+    pub file: PathBuf,
+    pub line: usize,
+    pub meta: VisualMeta,
+}
+
+/// Recursively search `root` for metadata containing `query` string.
+pub fn search_metadata(root: &Path, query: &str) -> Vec<SearchResult> {
+    let mut out = Vec::new();
+    for entry in WalkDir::new(root).into_iter().filter_map(Result::ok) {
+        if !entry.file_type().is_file() {
+            continue;
+        }
+        let path = entry.path();
+        if let Ok(content) = fs::read_to_string(path) {
+            for caps in META_RE.captures_iter(&content) {
+                let json = &caps[1];
+                if let Ok(meta) = serde_json::from_str::<VisualMeta>(json) {
+                    if serde_json::to_string(&meta).unwrap_or_default().contains(query) {
+                        let start = caps.get(0).map(|m| m.start()).unwrap_or(0);
+                        let line = content[..start].lines().count() + 1;
+                        out.push(SearchResult { file: path.to_path_buf(), line, meta });
+                    }
+                }
+            }
+        }
+    }
+    out
+}
+
+/// Find definition of metadata with a specific `id`.
+pub fn goto_definition(root: &Path, id: &str) -> Option<SearchResult> {
+    search_metadata(root, id).into_iter().find(|r| r.meta.id == id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    #[test]
+    fn search_and_goto_work() {
+        let dir = tempdir().unwrap();
+        let file1 = dir.path().join("a.rs");
+        let file2 = dir.path().join("b.rs");
+        fs::write(&file1, "// @VISUAL_META {\"id\":\"one\",\"x\":0,\"y\":0}\n").unwrap();
+        fs::write(&file2, "// @VISUAL_META {\"id\":\"two\",\"x\":0,\"y\":0}\n").unwrap();
+
+        let res = search_metadata(dir.path(), "one");
+        assert_eq!(res.len(), 1);
+        assert_eq!(res[0].file, file1);
+        assert_eq!(res[0].line, 1);
+
+        let def = goto_definition(dir.path(), "two").unwrap();
+        assert_eq!(def.file, file2);
+        assert_eq!(def.line, 1);
+        assert_eq!(def.meta.id, "two");
+    }
+}
+

--- a/frontend/src/editor/minimap.ts
+++ b/frontend/src/editor/minimap.ts
@@ -1,0 +1,43 @@
+import { EditorView } from "https://cdn.jsdelivr.net/npm/@codemirror/view@6.21.3/dist/index.js";
+
+/**
+ * Attach a simple minimap to a CodeMirror editor.
+ * The minimap renders a tiny representation of the document and highlights
+ * the current viewport of the editor.
+ */
+export function attachMinimap(view: EditorView, container: HTMLElement) {
+  const canvas = document.createElement("canvas");
+  canvas.style.width = "100%";
+  canvas.style.height = "100%";
+  canvas.style.display = "block";
+  container.appendChild(canvas);
+
+  function draw() {
+    const lineHeight = 2;
+    const lines = view.state.doc.lines;
+    canvas.width = container.clientWidth;
+    canvas.height = lines * lineHeight;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+    ctx.fillStyle = "#bbb";
+    for (let i = 0; i < lines; i++) {
+      ctx.fillRect(0, i * lineHeight, canvas.width, 1);
+    }
+
+    const totalHeight = view.scrollDOM.scrollHeight;
+    const visible = view.scrollDOM.clientHeight;
+    const scrollTop = view.scrollDOM.scrollTop;
+    const ratio = visible / totalHeight;
+    const top = (scrollTop / totalHeight) * canvas.height;
+    const height = ratio * canvas.height;
+
+    ctx.fillStyle = "rgba(0,0,0,0.2)";
+    ctx.fillRect(0, top, canvas.width, height);
+  }
+
+  view.scrollDOM.addEventListener("scroll", draw);
+  draw();
+}
+

--- a/frontend/src/visual/blocks.js
+++ b/frontend/src/visual/blocks.js
@@ -1,5 +1,7 @@
+import { getTheme } from './theme.ts';
+
 export class Block {
-  constructor(id, x, y, w, h, label, color = '#fff') {
+  constructor(id, x, y, w, h, label, color = getTheme().blockFill) {
     this.id = id;
     this.x = x;
     this.y = y;
@@ -10,12 +12,13 @@ export class Block {
   }
 
   draw(ctx) {
+    const theme = getTheme();
     ctx.fillStyle = this.color;
-    ctx.strokeStyle = '#333';
+    ctx.strokeStyle = theme.blockStroke;
     ctx.lineWidth = 2;
     ctx.fillRect(this.x, this.y, this.w, this.h);
     ctx.strokeRect(this.x, this.y, this.w, this.h);
-    ctx.fillStyle = '#000';
+    ctx.fillStyle = theme.blockText;
     ctx.font = '16px sans-serif';
     ctx.textAlign = 'center';
     ctx.textBaseline = 'middle';
@@ -62,25 +65,25 @@ export async function loadBlockPlugins(urls) {
 
 export class FunctionBlock extends Block {
   constructor(id, x, y) {
-    super(id, x, y, 120, 50, 'Function', '#e0f7fa');
+    super(id, x, y, 120, 50, 'Function', getTheme().blockKinds.Function);
   }
 }
 
 export class VariableBlock extends Block {
   constructor(id, x, y) {
-    super(id, x, y, 120, 50, 'Variable', '#f1f8e9');
+    super(id, x, y, 120, 50, 'Variable', getTheme().blockKinds.Variable);
   }
 }
 
 export class ConditionBlock extends Block {
   constructor(id, x, y) {
-    super(id, x, y, 120, 50, 'Condition', '#fff9c4');
+    super(id, x, y, 120, 50, 'Condition', getTheme().blockKinds.Condition);
   }
 }
 
 export class LoopBlock extends Block {
   constructor(id, x, y) {
-    super(id, x, y, 120, 50, 'Loop', '#fce4ec');
+    super(id, x, y, 120, 50, 'Loop', getTheme().blockKinds.Loop);
   }
 }
 

--- a/frontend/src/visual/hover.ts
+++ b/frontend/src/visual/hover.ts
@@ -1,0 +1,48 @@
+import { getTheme } from './theme.ts';
+
+// Minimal interface of VisualCanvas used in this module.
+export interface HoverCanvas {
+  canvas: HTMLCanvasElement;
+  connections: Array<[any, any]>;
+  blocks: any[];
+  hovered: any | null;
+  ctx: CanvasRenderingContext2D;
+  toWorld(x: number, y: number): { x: number; y: number };
+}
+
+/**
+ * Register listeners to track hovered block on the canvas.
+ */
+export function registerHoverHighlight(vc: HoverCanvas) {
+  vc.hovered = null;
+  vc.canvas.addEventListener('mousemove', e => {
+    const pos = vc.toWorld(e.offsetX, e.offsetY);
+    vc.hovered = vc.blocks.find(b => b.contains(pos.x, pos.y)) || null;
+  });
+  vc.canvas.addEventListener('mouseleave', () => {
+    vc.hovered = null;
+  });
+}
+
+/**
+ * Draw highlighted connections for the hovered block.
+ */
+export function drawHoverHighlight(vc: HoverCanvas) {
+  if (!vc.hovered) return;
+  const theme = getTheme();
+  vc.connections.forEach(([a, b]) => {
+    if (a === vc.hovered || b === vc.hovered) {
+      const ac = a.center();
+      const bc = b.center();
+      vc.ctx.save();
+      vc.ctx.beginPath();
+      vc.ctx.moveTo(ac.x, ac.y);
+      vc.ctx.lineTo(bc.x, bc.y);
+      vc.ctx.strokeStyle = theme.highlight;
+      vc.ctx.lineWidth = 3;
+      vc.ctx.stroke();
+      vc.ctx.restore();
+    }
+  });
+}
+

--- a/frontend/src/visual/theme.ts
+++ b/frontend/src/visual/theme.ts
@@ -1,0 +1,44 @@
+export interface VisualTheme {
+  blockFill: string;
+  blockStroke: string;
+  blockText: string;
+  connection: string;
+  highlight: string;
+  tooltipBg: string;
+  tooltipText: string;
+  blockKinds: Record<string, string>;
+}
+
+export const defaultTheme: VisualTheme = {
+  blockFill: '#fff',
+  blockStroke: '#333',
+  blockText: '#000',
+  connection: '#000',
+  highlight: '#ffcccc',
+  tooltipBg: '#333',
+  tooltipText: '#fff',
+  blockKinds: {
+    Function: '#e0f7fa',
+    Variable: '#f1f8e9',
+    Condition: '#fff9c4',
+    Loop: '#fce4ec',
+  }
+};
+
+let current: VisualTheme = {
+  ...defaultTheme,
+  blockKinds: { ...defaultTheme.blockKinds }
+};
+
+export function setTheme(theme: Partial<VisualTheme>) {
+  current = {
+    ...current,
+    ...theme,
+    blockKinds: { ...current.blockKinds, ...theme.blockKinds }
+  };
+}
+
+export function getTheme(): VisualTheme {
+  return current;
+}
+


### PR DESCRIPTION
## Summary
- add simple canvas-based minimap to CodeMirror editor
- highlight connected edges when hovering blocks
- support user themes for visual blocks and connections
- implement cross-file metadata search with navigation helpers

## Testing
- `npm test -- --run`
- `cargo test` *(fails: path matching ../backend/target/release/backend-x86_64-unknown-linux-gnu not found)*

------
https://chatgpt.com/codex/tasks/task_e_6898ce4baf388323b3676cf4f1093282