### PR TITLE
feat: integrate tracing for backend logging

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -159,6 +159,8 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-tungstenite",
+ "tracing",
+ "tracing-subscriber",
  "tree-sitter",
  "tree-sitter-css",
  "tree-sitter-html",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -24,6 +24,8 @@ git2 = "0.18"
 regex = "1"
 once_cell = "1"
 walkdir = "2"
+tracing = "0.1"
+tracing-subscriber = "0.3"
 
 [dev-dependencies]
 tempfile = "3"

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -228,6 +228,7 @@ fn git_log_cmd() -> Result<Vec<String>, String> {
 
 #[cfg(not(test))]
 fn main() {
+    tracing_subscriber::fmt::init();
     tauri::async_runtime::spawn(async {
         server::run().await;
     });

--- a/backend/src/server.rs
+++ b/backend/src/server.rs
@@ -10,6 +10,7 @@ use tokio::sync::broadcast;
 use axum::extract::ws::Message;
 use serde::Deserialize;
 use std::{env, net::SocketAddr};
+use tracing::{info, error};
 
 use crate::{parse_blocks, upsert_meta, BlockInfo};
 use crate::meta::{remove_all, VisualMeta, AiNote};
@@ -132,9 +133,11 @@ pub async fn run() {
         .with_state(state);
 
     let addr = SocketAddr::from(([127, 0, 0, 1], 3001));
-    println!("Listening on {}", addr);
-    axum::Server::bind(&addr)
+    info!("Listening on {}", addr);
+    if let Err(e) = axum::Server::bind(&addr)
         .serve(app.into_make_service())
         .await
-        .unwrap();
+    {
+        error!("server error: {e}");
+    }
 }


### PR DESCRIPTION
## Summary
- add tracing and tracing-subscriber dependencies
- initialize tracing subscriber in main
- replace println with tracing info/error logging in server

## Testing
- `cargo test` *(fails: unable to read Tauri config file)*

------
https://chatgpt.com/codex/tasks/task_e_6898e8cff3448323ba8a2822f11bdc5f