### PR TITLE
Add Go and TypeScript parser support

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -176,10 +176,12 @@ dependencies = [
  "tracing-subscriber",
  "tree-sitter",
  "tree-sitter-css",
+ "tree-sitter-go",
  "tree-sitter-html",
  "tree-sitter-javascript",
  "tree-sitter-python",
  "tree-sitter-rust",
+ "tree-sitter-typescript",
  "walkdir",
 ]
 
@@ -3604,6 +3606,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree-sitter-go"
+version = "0.23.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b13d476345220dbe600147dd444165c5791bf85ef53e28acbedd46112ee18431"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
 name = "tree-sitter-html"
 version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3644,6 +3656,16 @@ name = "tree-sitter-rust"
 version = "0.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca8ccb3e3a3495c8a943f6c3fd24c3804c471fd7f4f16087623c7fa4c0068e8a"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-typescript"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c5f76ed8d947a75cc446d5fccd8b602ebf0cde64ccf2ffa434d873d7a575eff"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -17,6 +17,8 @@ tree-sitter-python = "0.23"
 tree-sitter-javascript = "0.23"
 tree-sitter-css = "0.23"
 tree-sitter-html = "0.23"
+tree-sitter-go = "0.23"
+tree-sitter-typescript = "0.23"
 syn = { version = "2", features = ["full"] }
 quote = "1"
 prettyplease = "0.2"

--- a/backend/src/parser/go.rs
+++ b/backend/src/parser/go.rs
@@ -1,0 +1,11 @@
+use tree_sitter::{Language, Parser, Tree};
+
+pub fn language() -> Language {
+    tree_sitter_go::LANGUAGE.into()
+}
+
+pub fn parse(source: &str) -> Option<Tree> {
+    let mut parser = Parser::new();
+    parser.set_language(&language()).ok()?;
+    parser.parse(source, None)
+}

--- a/backend/src/parser/mod.rs
+++ b/backend/src/parser/mod.rs
@@ -3,10 +3,12 @@ use std::ops::Range;
 use tree_sitter::{Language, Node, Parser, Tree};
 
 pub mod css;
+pub mod go;
 pub mod html;
 pub mod javascript;
 pub mod python;
 pub mod rust;
+pub mod typescript;
 
 /// Supported languages for parsing.
 #[derive(Clone, Copy)]
@@ -16,6 +18,8 @@ pub enum Lang {
     JavaScript,
     Css,
     Html,
+    Go,
+    TypeScript,
 }
 
 /// Get a tree-sitter [`Language`] from [`Lang`].
@@ -26,6 +30,8 @@ fn language(lang: Lang) -> Language {
         Lang::JavaScript => javascript::language(),
         Lang::Css => css::language(),
         Lang::Html => html::language(),
+        Lang::Go => go::language(),
+        Lang::TypeScript => typescript::language(),
     }
 }
 
@@ -96,6 +102,11 @@ mod tests {
             (Lang::JavaScript, "function main() { console.log('hi'); }"),
             (Lang::Css, "body { color: red; }"),
             (Lang::Html, "<html></html>"),
+            (Lang::Go, "package main\nfunc main() { println(\"hi\") }"),
+            (
+                Lang::TypeScript,
+                "function main(): void { console.log('hi'); }",
+            ),
         ];
 
         for (lang, source) in cases {

--- a/backend/src/parser/typescript.rs
+++ b/backend/src/parser/typescript.rs
@@ -1,0 +1,11 @@
+use tree_sitter::{Language, Parser, Tree};
+
+pub fn language() -> Language {
+    tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into()
+}
+
+pub fn parse(source: &str) -> Option<Tree> {
+    let mut parser = Parser::new();
+    parser.set_language(&language()).ok()?;
+    parser.parse(source, None)
+}


### PR DESCRIPTION
## Summary
- add tree-sitter based parsers for Go and TypeScript
- extend Lang enum and parsing tests with Go and TypeScript
- include tree-sitter-go and tree-sitter-typescript crates

## Testing
- `cargo test` *(fails: missing field `origin` in `VisualMeta`)*

------
https://chatgpt.com/codex/tasks/task_e_6898f91c526883238df614dfb89fa53e