### PR TITLE
feat(frontend): load theme from json configuration

### DIFF
--- a/frontend/settings.json
+++ b/frontend/settings.json
@@ -5,5 +5,8 @@
     "selectConnections": "Ctrl+Shift+A",
     "focusSearch": "Ctrl+F",
     "showHelp": "Ctrl+?"
+  },
+  "visual": {
+    "theme": "default"
   }
 }

--- a/frontend/src/visual/theme.ts
+++ b/frontend/src/visual/theme.ts
@@ -1,3 +1,6 @@
+import settings from '../../settings.json' assert { type: 'json' };
+import defaultThemeJson from './themes/default.json' assert { type: 'json' };
+
 export interface VisualTheme {
   blockFill: string;
   blockStroke: string;
@@ -9,25 +12,19 @@ export interface VisualTheme {
   blockKinds: Record<string, string>;
 }
 
-export const defaultTheme: VisualTheme = {
-  blockFill: '#fff',
-  blockStroke: '#333',
-  blockText: '#000',
-  connection: '#000',
-  highlight: '#ffcccc',
-  tooltipBg: '#333',
-  tooltipText: '#fff',
-  blockKinds: {
-    Function: '#e0f7fa',
-    Variable: '#f1f8e9',
-    Condition: '#fff9c4',
-    Loop: '#fce4ec',
-  }
+export const defaultTheme: VisualTheme = defaultThemeJson as VisualTheme;
+
+const themes: Record<string, VisualTheme> = {
+  default: defaultTheme
 };
 
+const cfg: { visual?: { theme?: string } } = settings as any;
+const themeName = cfg.visual?.theme || 'default';
+const base = themes[themeName] || defaultTheme;
+
 let current: VisualTheme = {
-  ...defaultTheme,
-  blockKinds: { ...defaultTheme.blockKinds }
+  ...base,
+  blockKinds: { ...base.blockKinds }
 };
 
 export function setTheme(theme: Partial<VisualTheme>) {

--- a/frontend/src/visual/themes/default.json
+++ b/frontend/src/visual/themes/default.json
@@ -1,0 +1,15 @@
+{
+  "blockFill": "#fff",
+  "blockStroke": "#333",
+  "blockText": "#000",
+  "connection": "#000",
+  "highlight": "#ffcccc",
+  "tooltipBg": "#333",
+  "tooltipText": "#fff",
+  "blockKinds": {
+    "Function": "#e0f7fa",
+    "Variable": "#f1f8e9",
+    "Condition": "#fff9c4",
+    "Loop": "#fce4ec"
+  }
+}


### PR DESCRIPTION
## Summary
- load default visual theme from a JSON file
- allow selecting theme via `settings.json`

## Testing
- `npm test`
- `cargo test` *(fails: The system library `javascriptcoregtk-4.0` required by crate `javascriptcore-rs-sys` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_6898ffff1824832387f01bba301e5b29