### PR TITLE
Add CI workflow for backend and frontend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  backend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Run backend tests
+        run: cargo test
+        working-directory: backend
+  frontend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - name: Install dependencies
+        run: npm install
+        working-directory: frontend
+      - name: Run frontend tests
+        run: npm test
+        working-directory: frontend


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow running backend and frontend tests

## Testing
- `cargo test` *(fails: javascriptcoregtk-4.0 not found)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898fffb775c8323a8e39219ad5a0ba1