### PR TITLE
Cache parsed blocks and reuse previous results

### DIFF
--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -10,12 +10,12 @@ mod meta;
 mod parser;
 mod plugins;
 mod server;
+pub use backend::BlockInfo;
+use backend::{get_document_tree, update_document_tree};
 use debugger::{debug_break, debug_run, debug_step};
 use export::prepare_for_export;
 use meta::{read_all, remove_all, upsert, AiNote, Translations, VisualMeta};
 use parser::{parse, parse_to_blocks, Lang};
-use backend::{get_document_tree, update_document_tree};
-use serde::Serialize;
 use syn::{File, Item};
 use tauri::State;
 
@@ -43,17 +43,6 @@ fn to_lang(s: &str) -> Option<Lang> {
     }
 }
 
-#[derive(Serialize)]
-pub struct BlockInfo {
-    visual_id: String,
-    kind: String,
-    translations: Translations,
-    range: (usize, usize),
-    x: f64,
-    y: f64,
-    ai: Option<AiNote>,
-}
-
 #[cfg_attr(not(test), tauri::command)]
 fn normalize_kind(kind: &str) -> String {
     let k = kind.to_lowercase();
@@ -72,6 +61,9 @@ fn normalize_kind(kind: &str) -> String {
 
 #[cfg_attr(not(test), tauri::command)]
 pub fn parse_blocks(content: String, lang: String) -> Option<Vec<BlockInfo>> {
+    if let Some(cached) = backend::get_cached_blocks("current", &content) {
+        return Some(cached);
+    }
     let lang = to_lang(&lang)?;
     let old = get_document_tree("current");
     let tree = parse(&content, lang, old.as_ref())?;
@@ -79,41 +71,41 @@ pub fn parse_blocks(content: String, lang: String) -> Option<Vec<BlockInfo>> {
     let blocks = parse_to_blocks(&tree);
     let metas = read_all(&content);
     let map: HashMap<_, _> = metas.into_iter().map(|m| (m.id.clone(), m)).collect();
-    Some(
-        blocks
-            .into_iter()
-            .map(|b| {
-                let label = normalize_kind(&b.kind);
-                let mut translations = i18n::lookup(&label).unwrap_or_else(|| Translations {
-                    ru: Some(label.clone()),
-                    en: Some(label.clone()),
-                    es: Some(label.clone()),
-                });
-                if let Some(meta) = map.get(&b.visual_id) {
-                    let t = &meta.translations;
-                    if let Some(ref v) = t.ru {
-                        translations.ru = Some(v.clone());
-                    }
-                    if let Some(ref v) = t.en {
-                        translations.en = Some(v.clone());
-                    }
-                    if let Some(ref v) = t.es {
-                        translations.es = Some(v.clone());
-                    }
+    let result = blocks
+        .into_iter()
+        .map(|b| {
+            let label = normalize_kind(&b.kind);
+            let mut translations = i18n::lookup(&label).unwrap_or_else(|| Translations {
+                ru: Some(label.clone()),
+                en: Some(label.clone()),
+                es: Some(label.clone()),
+            });
+            if let Some(meta) = map.get(&b.visual_id) {
+                let t = &meta.translations;
+                if let Some(ref v) = t.ru {
+                    translations.ru = Some(v.clone());
                 }
-                let pos = map.get(&b.visual_id);
-                BlockInfo {
-                    visual_id: b.visual_id,
-                    kind: label,
-                    translations,
-                    range: (b.range.start, b.range.end),
-                    x: pos.map(|m| m.x).unwrap_or(0.0),
-                    y: pos.map(|m| m.y).unwrap_or(0.0),
-                    ai: pos.and_then(|m| m.ai.clone()),
+                if let Some(ref v) = t.en {
+                    translations.en = Some(v.clone());
                 }
-            })
-            .collect(),
-    )
+                if let Some(ref v) = t.es {
+                    translations.es = Some(v.clone());
+                }
+            }
+            let pos = map.get(&b.visual_id);
+            BlockInfo {
+                visual_id: b.visual_id,
+                kind: label,
+                translations,
+                range: (b.range.start, b.range.end),
+                x: pos.map(|m| m.x).unwrap_or(0.0),
+                y: pos.map(|m| m.y).unwrap_or(0.0),
+                ai: pos.and_then(|m| m.ai.clone()),
+            }
+        })
+        .collect();
+    backend::update_cached_blocks("current".to_string(), content, result.clone());
+    Some(result)
 }
 
 #[cfg_attr(not(test), tauri::command)]


### PR DESCRIPTION
## Summary
- cache parsed blocks in backend to avoid reprocessing unchanged content
- reuse cached blocks when content matches and update cache on changes

## Testing
- `cargo test` *(fails: javascriptcore-rs-sys build error – `javascriptcoregtk-4.0` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899000e7864832397fba1eb7d6942af