### PR TITLE
feat: add grid snapping and grid rendering

### DIFF
--- a/frontend/settings.json
+++ b/frontend/settings.json
@@ -7,6 +7,7 @@
     "showHelp": "Ctrl+?"
   },
   "visual": {
-    "theme": "default"
+    "theme": "default",
+    "gridSize": 20
   }
 }


### PR DESCRIPTION
## Summary
- snap block dragging positions to a configurable grid size
- store grid size in `settings.json`
- render optional grid overlay on canvas

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6899096a79f88323b44cabd88cc34981