### PR TITLE
feat: add alignment guides

### DIFF
--- a/frontend/src/visual/theme.ts
+++ b/frontend/src/visual/theme.ts
@@ -9,6 +9,7 @@ export interface VisualTheme {
   highlight: string;
   tooltipBg: string;
   tooltipText: string;
+  alignGuide: string;
   blockKinds: Record<string, string>;
 }
 

--- a/frontend/src/visual/themes/default.json
+++ b/frontend/src/visual/themes/default.json
@@ -6,6 +6,7 @@
   "highlight": "#ffcccc",
   "tooltipBg": "#333",
   "tooltipText": "#fff",
+  "alignGuide": "#888",
   "blockKinds": {
     "Function": "#e0f7fa",
     "Variable": "#f1f8e9",


### PR DESCRIPTION
## Summary
- compute alignment matches against neighboring blocks when dragging
- draw temporary alignment guides using theme color

## Testing
- `CI=1 npm test`


------
https://chatgpt.com/codex/tasks/task_e_689912261010832397137fd9920de80e