### PR TITLE
Add zoom-to-fit control for visual canvas

### DIFF
--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -25,11 +25,14 @@
     import { VisualCanvas } from "./visual/canvas.js";
     import { loadBlockPlugins } from "./visual/blocks.js";
     import { insertVisualMeta, updateMetaComment, visualMetaHighlighter, visualMetaTooltip } from "./editor/visual-meta.js";
+    import { registerHotkeys, setCanvas } from "./visual/hotkeys.ts";
 
     await loadBlockPlugins(window.blockPlugins || []);
 
     const canvasEl = document.getElementById('visual-canvas');
     const vc = new VisualCanvas(canvasEl);
+    setCanvas(vc);
+    registerHotkeys();
 
     vc.onBlockMove(async block => {
       if (updateMetaComment(view, { id: block.id, x: block.x, y: block.y })) {

--- a/frontend/src/visual/canvas.js
+++ b/frontend/src/visual/canvas.js
@@ -359,6 +359,26 @@ export class VisualCanvas {
     this.canvas.height = this.canvas.clientHeight;
   }
 
+  zoomToFit() {
+    if (this.blocks.length === 0) return;
+    let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+    for (const b of this.blocks) {
+      minX = Math.min(minX, b.x);
+      minY = Math.min(minY, b.y);
+      maxX = Math.max(maxX, b.x + b.w);
+      maxY = Math.max(maxY, b.y + b.h);
+    }
+    const width = maxX - minX;
+    const height = maxY - minY;
+    if (width === 0 || height === 0) return;
+    const scale = Math.min(this.canvas.width / width, this.canvas.height / height) * 0.9;
+    this.scale = scale;
+    const cx = (minX + maxX) / 2;
+    const cy = (minY + maxY) / 2;
+    this.offset.x = this.canvas.width / 2 - cx * scale;
+    this.offset.y = this.canvas.height / 2 - cy * scale;
+  }
+
   toWorld(x, y) {
     return {
       x: (x - this.offset.x) / this.scale,

--- a/frontend/src/visual/canvas.test.js
+++ b/frontend/src/visual/canvas.test.js
@@ -1,5 +1,6 @@
+// @vitest-environment jsdom
 import { describe, it, expect } from 'vitest';
-import { analyzeConnections } from './canvas.js';
+import { analyzeConnections, VisualCanvas } from './canvas.js';
 
 describe('analyzeConnections', () => {
   it('detects missing blocks and cycles', () => {
@@ -9,5 +10,28 @@ describe('analyzeConnections', () => {
     expect(Array.from(missing)).toEqual(['c']);
     expect(cycles.has('a->b')).toBe(true);
     expect(cycles.has('b->a')).toBe(true);
+  });
+});
+
+describe('zoomToFit', () => {
+  it('adjusts scale and offset to contain all blocks', () => {
+    const canvasEl = document.createElement('canvas');
+    Object.defineProperty(canvasEl, 'clientWidth', { value: 200 });
+    Object.defineProperty(canvasEl, 'clientHeight', { value: 200 });
+    canvasEl.getContext = () => ({ save(){}, setTransform(){}, clearRect(){}, beginPath(){}, stroke(){}, moveTo(){}, lineTo(){}, fillRect(){}, strokeRect(){}, fillText(){}, restore(){} });
+    globalThis.requestAnimationFrame = () => 0;
+    const vc = new VisualCanvas(canvasEl);
+    vc.blocks = [
+      { x: 0, y: 0, w: 50, h: 50 },
+      { x: 150, y: 150, w: 50, h: 50 }
+    ];
+    vc.zoomToFit();
+    const minX = 0; const minY = 0; const maxX = 200; const maxY = 200;
+    const topLeft = { x: minX * vc.scale + vc.offset.x, y: minY * vc.scale + vc.offset.y };
+    const bottomRight = { x: maxX * vc.scale + vc.offset.x, y: maxY * vc.scale + vc.offset.y };
+    expect(topLeft.x).toBeGreaterThanOrEqual(0);
+    expect(topLeft.y).toBeGreaterThanOrEqual(0);
+    expect(bottomRight.x).toBeLessThanOrEqual(canvasEl.width);
+    expect(bottomRight.y).toBeLessThanOrEqual(canvasEl.height);
   });
 });

--- a/frontend/src/visual/hotkeys.ts
+++ b/frontend/src/visual/hotkeys.ts
@@ -6,6 +6,7 @@ interface HotkeyMap {
   selectConnections: string;
   focusSearch: string;
   showHelp: string;
+  zoomToFit: string;
 }
 
 const cfg: { hotkeys?: Partial<HotkeyMap> } = settings as any;
@@ -15,7 +16,8 @@ export const hotkeys: HotkeyMap = {
   pasteBlock: cfg.hotkeys?.pasteBlock || 'Ctrl+V',
   selectConnections: cfg.hotkeys?.selectConnections || 'Ctrl+Shift+A',
   focusSearch: cfg.hotkeys?.focusSearch || 'Ctrl+F',
-  showHelp: cfg.hotkeys?.showHelp || 'Ctrl+?'
+  showHelp: cfg.hotkeys?.showHelp || 'Ctrl+?',
+  zoomToFit: cfg.hotkeys?.zoomToFit || 'Ctrl+0'
 };
 
 function buildCombo(e: KeyboardEvent) {
@@ -59,6 +61,10 @@ function handleKey(e: KeyboardEvent) {
       e.preventDefault();
       showHotkeyHelp();
       break;
+    case hotkeys.zoomToFit:
+      e.preventDefault();
+      zoomToFit();
+      break;
   }
 }
 
@@ -84,5 +90,15 @@ export function showHotkeyHelp() {
     .map(([name, combo]) => `${combo} - ${name}`)
     .join('\n');
   alert(list);
+}
+
+let canvasRef: any = null;
+
+export function setCanvas(vc: any) {
+  canvasRef = vc;
+}
+
+export function zoomToFit() {
+  canvasRef?.zoomToFit();
 }
 

--- a/frontend/src/visual/menu.ts
+++ b/frontend/src/visual/menu.ts
@@ -1,4 +1,4 @@
-import { hotkeys, showHotkeyHelp } from './hotkeys';
+import { hotkeys, showHotkeyHelp, zoomToFit } from './hotkeys';
 
 export interface MenuItem {
   label: string;
@@ -27,6 +27,12 @@ export const mainMenu: MenuItem[] = [
     ]
   },
   {
+    label: 'View',
+    submenu: [
+      { label: 'Zoom to Fit', action: zoomToFit, shortcut: hotkeys.zoomToFit }
+    ]
+  },
+  {
     label: 'Help',
     submenu: [
       { label: 'Hotkeys', action: showHotkeyHelp, shortcut: hotkeys.showHelp }
@@ -43,7 +49,8 @@ export const contextMenus = {
   ],
   canvas: [
     { label: 'Paste Block', action: () => console.log('paste'), shortcut: hotkeys.pasteBlock },
-    { label: 'Select Connections', action: () => console.log('select'), shortcut: hotkeys.selectConnections }
+    { label: 'Select Connections', action: () => console.log('select'), shortcut: hotkeys.selectConnections },
+    { label: 'Zoom to Fit', action: zoomToFit, shortcut: hotkeys.zoomToFit }
   ]
 };
 


### PR DESCRIPTION
## Summary
- implement `zoomToFit` on `VisualCanvas` to center all blocks in view
- introduce `Ctrl+0` hotkey and menu entries for zoom-to-fit
- wire hotkeys to canvas and add unit test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689914a0f54083239a6d064451f94b80