### PR TITLE
feat: add PNG export option

### DIFF
--- a/frontend/src/visual/canvas.js
+++ b/frontend/src/visual/canvas.js
@@ -547,3 +547,12 @@ export class VisualCanvas {
     }
   }
 }
+
+export function exportPNG() {
+  const canvas = document.getElementById('visual-canvas');
+  if (!(canvas instanceof HTMLCanvasElement)) return;
+  const link = document.createElement('a');
+  link.href = canvas.toDataURL('image/png');
+  link.download = 'canvas.png';
+  link.click();
+}

--- a/frontend/src/visual/menu.ts
+++ b/frontend/src/visual/menu.ts
@@ -1,4 +1,5 @@
 import { hotkeys, showHotkeyHelp, zoomToFit } from './hotkeys';
+import { exportPNG } from './canvas.js';
 
 export interface MenuItem {
   label: string;
@@ -12,7 +13,8 @@ export const mainMenu: MenuItem[] = [
     label: 'File',
     submenu: [
       { label: 'New', action: () => console.log('new file') },
-      { label: 'Open', action: () => console.log('open file') }
+      { label: 'Open', action: () => console.log('open file') },
+      { label: 'Экспорт в PNG', action: exportPNG }
     ]
   },
   {


### PR DESCRIPTION
## Summary
- add "Export to PNG" item to File menu
- implement PNG export via canvas data URL and download link

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68991750313c8323ba089adb1fec2307