### PR TITLE
feat: move active block with arrow keys

### DIFF
--- a/frontend/src/visual/hotkeys.ts
+++ b/frontend/src/visual/hotkeys.ts
@@ -9,7 +9,8 @@ interface HotkeyMap {
   zoomToFit: string;
 }
 
-const cfg: { hotkeys?: Partial<HotkeyMap> } = settings as any;
+const cfg: { hotkeys?: Partial<HotkeyMap>; visual?: { gridSize?: number } } = settings as any;
+const MOVE_STEP = cfg.visual?.gridSize || 10;
 
 export const hotkeys: HotkeyMap = {
   copyBlock: cfg.hotkeys?.copyBlock || 'Ctrl+C',
@@ -64,6 +65,30 @@ function handleKey(e: KeyboardEvent) {
     case hotkeys.zoomToFit:
       e.preventDefault();
       zoomToFit();
+      break;
+    case 'ArrowUp':
+    case 'ArrowDown':
+    case 'ArrowLeft':
+    case 'ArrowRight':
+      if (canvasRef?.selected?.size === 1) {
+        e.preventDefault();
+        const block = Array.from(canvasRef.selected)[0];
+        switch (combo) {
+          case 'ArrowUp':
+            block.y -= MOVE_STEP;
+            break;
+          case 'ArrowDown':
+            block.y += MOVE_STEP;
+            break;
+          case 'ArrowLeft':
+            block.x -= MOVE_STEP;
+            break;
+          case 'ArrowRight':
+            block.x += MOVE_STEP;
+            break;
+        }
+        canvasRef.moveCallback?.(block);
+      }
       break;
   }
 }


### PR DESCRIPTION
## Summary
- allow arrow keys to move the currently selected block
- use grid size as movement step and call move callback

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689918e67c2c8323acf6e32b3a730309