### PR TITLE
Add structured API error responses

### DIFF
--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -4,6 +4,7 @@ pub mod debugger;
 pub mod search;
 pub mod plugins;
 pub mod parser;
+pub mod server;
 
 use once_cell::sync::Lazy;
 use plugins::Plugin;

--- a/backend/tests/server_error_format.rs
+++ b/backend/tests/server_error_format.rs
@@ -1,0 +1,86 @@
+use axum::http::{HeaderMap, StatusCode};
+use axum::Json;
+use backend::config::ServerConfig;
+use backend::meta::{AiNote, Translations, VisualMeta};
+use backend::server::{
+    export_endpoint, metadata_endpoint, parse_endpoint, ErrorResponse, ExportRequest, MetadataRequest,
+    ParseRequest, SERVER_CONFIG,
+};
+
+#[tokio::test]
+async fn parse_endpoint_bad_request() {
+    let _ = SERVER_CONFIG.set(ServerConfig {
+        token: Some("secret".into()),
+        ..Default::default()
+    });
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        axum::http::header::AUTHORIZATION,
+        "Bearer secret".parse().unwrap(),
+    );
+    let req = ParseRequest {
+        content: "test".into(),
+        lang: "unknown".into(),
+    };
+    let (status, Json(err)) = parse_endpoint(headers, Json(req)).await.unwrap_err();
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(
+        err,
+        ErrorResponse {
+            code: StatusCode::BAD_REQUEST.as_u16(),
+            message: "Bad Request".into(),
+        }
+    );
+}
+
+#[tokio::test]
+async fn export_endpoint_unauthorized() {
+    let _ = SERVER_CONFIG.set(ServerConfig {
+        token: Some("secret".into()),
+        ..Default::default()
+    });
+    let headers = HeaderMap::new();
+    let req = ExportRequest {
+        content: "code".into(),
+        strip_meta: false,
+    };
+    let (status, Json(err)) = export_endpoint(headers, Json(req)).await.unwrap_err();
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+    assert_eq!(
+        err,
+        ErrorResponse {
+            code: StatusCode::UNAUTHORIZED.as_u16(),
+            message: "Unauthorized".into(),
+        }
+    );
+}
+
+#[tokio::test]
+async fn metadata_endpoint_unauthorized() {
+    let _ = SERVER_CONFIG.set(ServerConfig {
+        token: Some("secret".into()),
+        ..Default::default()
+    });
+    let headers = HeaderMap::new();
+    let req = MetadataRequest {
+        content: String::new(),
+        meta: VisualMeta {
+            id: "1".into(),
+            x: 0.0,
+            y: 0.0,
+            origin: None,
+            translations: Translations::default(),
+            ai: Some(AiNote::default()),
+        },
+        lang: "rust".into(),
+    };
+    let (status, Json(err)) = metadata_endpoint(headers, Json(req)).await.unwrap_err();
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+    assert_eq!(
+        err,
+        ErrorResponse {
+            code: StatusCode::UNAUTHORIZED.as_u16(),
+            message: "Unauthorized".into(),
+        }
+    );
+}


### PR DESCRIPTION
## Summary
- define `ErrorResponse` for unified API errors
- return structured errors from parse, export and metadata endpoints
- expose server module and add tests covering error formats

## Testing
- `cargo test` *(fails: failed to run custom build command for `javascriptcore-rs-sys v0.4.0`)*

------
https://chatgpt.com/codex/tasks/task_e_68991dccba9483238c2ef4dd3bcfe952