### PR TITLE
feat(visual): add minimap for canvas

### DIFF
--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -6,6 +6,7 @@
   <style>
     body { margin: 0; font-family: sans-serif; }
     #visual-canvas { width: 100%; height: 50vh; border: 1px solid #ccc; display: block; }
+    #visual-minimap { position: fixed; bottom: 10px; right: 10px; width: 200px; height: 150px; border: 1px solid #ccc; background: #fff; opacity: 0.8; }
     #editor { height: 40vh; border: 1px solid #ccc; }
     #controls { padding: 0.5rem; }
     #git-panel { padding: 0.5rem; border-top: 1px solid #ccc; }
@@ -30,7 +31,8 @@
     await loadBlockPlugins(window.blockPlugins || []);
 
     const canvasEl = document.getElementById('visual-canvas');
-    const vc = new VisualCanvas(canvasEl);
+    const minimapEl = document.getElementById('visual-minimap');
+    const vc = new VisualCanvas(canvasEl, minimapEl);
     setCanvas(vc);
     registerHotkeys();
 
@@ -157,6 +159,7 @@
 </head>
 <body>
   <canvas id="visual-canvas"></canvas>
+  <canvas id="visual-minimap" width="200" height="150"></canvas>
   <div id="editor"></div>
   <div id="controls">
     <button id="save">Save</button>

--- a/frontend/src/visual/canvas.js
+++ b/frontend/src/visual/canvas.js
@@ -1,6 +1,7 @@
 import { createBlock } from './blocks.js';
 import { getTheme } from './theme.ts';
 import { registerHoverHighlight, drawHoverHighlight } from './hover.ts';
+import { Minimap } from './minimap.ts';
 import settings from '../../settings.json' assert { type: 'json' };
 
 const cfg = settings.visual || {};
@@ -58,9 +59,10 @@ export function analyzeConnections(blockIds, edges) {
 }
 
 export class VisualCanvas {
-  constructor(canvas) {
+  constructor(canvas, minimapCanvas = null) {
     this.canvas = canvas;
     this.ctx = canvas.getContext('2d');
+    this.minimap = minimapCanvas ? new Minimap(minimapCanvas) : null;
     this.scale = 1;
     this.offset = { x: 0, y: 0 };
     this.blocks = [];
@@ -556,6 +558,7 @@ export class VisualCanvas {
     }
 
     this.ctx.restore();
+    if (this.minimap) this.minimap.render(this);
     requestAnimationFrame(() => this.draw());
   }
 

--- a/frontend/src/visual/minimap.ts
+++ b/frontend/src/visual/minimap.ts
@@ -1,0 +1,50 @@
+import type { VisualCanvas } from './canvas.js';
+import { getTheme } from './theme.ts';
+
+export class Minimap {
+  canvas: HTMLCanvasElement;
+  ctx: CanvasRenderingContext2D;
+
+  constructor(canvas: HTMLCanvasElement) {
+    this.canvas = canvas;
+    this.ctx = canvas.getContext('2d')!;
+  }
+
+  render(vc: VisualCanvas) {
+    const ctx = this.ctx;
+    const width = this.canvas.width;
+    const height = this.canvas.height;
+    ctx.clearRect(0, 0, width, height);
+
+    const blocks = vc.blocks;
+    if (!blocks || blocks.length === 0) return;
+
+    let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+    for (const b of blocks) {
+      minX = Math.min(minX, b.x);
+      minY = Math.min(minY, b.y);
+      maxX = Math.max(maxX, b.x + b.w);
+      maxY = Math.max(maxY, b.y + b.h);
+    }
+    const worldW = maxX - minX || 1;
+    const worldH = maxY - minY || 1;
+    const scale = Math.min(width / worldW, height / worldH);
+    const originX = -minX * scale + (width - worldW * scale) / 2;
+    const originY = -minY * scale + (height - worldH * scale) / 2;
+
+    const theme = getTheme();
+    ctx.fillStyle = theme.blockFill;
+    for (const b of blocks) {
+      ctx.fillRect(b.x * scale + originX, b.y * scale + originY, b.w * scale, b.h * scale);
+    }
+
+    const viewX = -vc.offset.x / vc.scale;
+    const viewY = -vc.offset.y / vc.scale;
+    const viewW = vc.canvas.width / vc.scale;
+    const viewH = vc.canvas.height / vc.scale;
+
+    ctx.strokeStyle = theme.connection;
+    ctx.lineWidth = 1;
+    ctx.strokeRect(viewX * scale + originX, viewY * scale + originY, viewW * scale, viewH * scale);
+  }
+}


### PR DESCRIPTION
## Summary
- add `Minimap` component rendering a scaled overview of blocks with viewport marker
- wire `VisualCanvas` to synchronize its viewport with the minimap
- embed minimap canvas in the demo interface

## Testing
- `cd frontend && npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68991df58b7c832397bc98b14d8b276b