### PR TITLE
feat: add plugin management

### DIFF
--- a/frontend/settings.json
+++ b/frontend/settings.json
@@ -9,5 +9,6 @@
   "visual": {
     "theme": "default",
     "gridSize": 20
-  }
+  },
+  "plugins": {}
 }

--- a/frontend/src/plugins/manager.ts
+++ b/frontend/src/plugins/manager.ts
@@ -1,0 +1,30 @@
+export interface PluginInfo {
+  name: string;
+  version: string;
+  enabled: boolean;
+}
+
+export async function initPluginManager(container: HTMLElement) {
+  const res = await fetch('/plugins');
+  if (!res.ok) return;
+  const plugins: PluginInfo[] = await res.json();
+  container.innerHTML = '';
+  plugins.forEach(p => {
+    const row = document.createElement('div');
+    const label = document.createElement('label');
+    const checkbox = document.createElement('input');
+    checkbox.type = 'checkbox';
+    checkbox.checked = p.enabled;
+    checkbox.addEventListener('change', async () => {
+      await fetch('/plugins', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: p.name, enabled: checkbox.checked })
+      });
+    });
+    label.appendChild(checkbox);
+    label.append(` ${p.name} (${p.version})`);
+    row.appendChild(label);
+    container.appendChild(row);
+  });
+}


### PR DESCRIPTION
## Summary
- add backend `/plugins` endpoint with reload support
- introduce frontend plugin manager component
- persist plugin enable state in settings.json

## Testing
- `npm test`
- `cargo test` *(fails: required library `javascriptcoregtk-4.0` not found)*

------
https://chatgpt.com/codex/tasks/task_e_689925dcbc348323915f560014c468f0