### PR TITLE
refactor: use hashmap for translations

### DIFF
--- a/backend/src/i18n/mod.rs
+++ b/backend/src/i18n/mod.rs
@@ -1,28 +1,33 @@
-use crate::meta::Translations;
+use std::collections::HashMap;
 
 /// Return default translations for known block kinds.
-pub fn lookup(kind: &str) -> Option<Translations> {
+pub fn lookup(kind: &str) -> Option<HashMap<String, String>> {
+    let mut map = HashMap::new();
     match kind {
-        "Function" => Some(Translations {
-            ru: Some("Функция".into()),
-            en: Some("Function".into()),
-            es: Some("Función".into()),
-        }),
-        "Variable" => Some(Translations {
-            ru: Some("Переменная".into()),
-            en: Some("Variable".into()),
-            es: Some("Variable".into()),
-        }),
-        "Condition" => Some(Translations {
-            ru: Some("Условие".into()),
-            en: Some("Condition".into()),
-            es: Some("Condición".into()),
-        }),
-        "Loop" => Some(Translations {
-            ru: Some("Цикл".into()),
-            en: Some("Loop".into()),
-            es: Some("Bucle".into()),
-        }),
+        "Function" => {
+            map.insert("ru".into(), "Функция".into());
+            map.insert("en".into(), "Function".into());
+            map.insert("es".into(), "Función".into());
+            Some(map)
+        }
+        "Variable" => {
+            map.insert("ru".into(), "Переменная".into());
+            map.insert("en".into(), "Variable".into());
+            map.insert("es".into(), "Variable".into());
+            Some(map)
+        }
+        "Condition" => {
+            map.insert("ru".into(), "Условие".into());
+            map.insert("en".into(), "Condition".into());
+            map.insert("es".into(), "Condición".into());
+            Some(map)
+        }
+        "Loop" => {
+            map.insert("ru".into(), "Цикл".into());
+            map.insert("en".into(), "Loop".into());
+            map.insert("es".into(), "Bucle".into());
+            Some(map)
+        }
         _ => None,
     }
 }

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -6,7 +6,7 @@ pub mod plugins;
 pub mod search;
 pub mod server;
 
-use crate::meta::{AiNote, Translations};
+use crate::meta::AiNote;
 use once_cell::sync::Lazy;
 use plugins::{Plugin, WasmPlugin};
 use serde::{Deserialize, Serialize};
@@ -27,7 +27,7 @@ static BLOCK_CACHE: Lazy<Mutex<HashMap<String, (String, Vec<BlockInfo>)>>> =
 pub struct BlockInfo {
     pub visual_id: String,
     pub kind: String,
-    pub translations: Translations,
+    pub translations: HashMap<String, String>,
     pub range: (usize, usize),
     pub x: f64,
     pub y: f64,
@@ -146,10 +146,8 @@ pub struct PluginInfo {
     pub enabled: bool,
 }
 
-static ACTIVE_PLUGINS: Lazy<Mutex<Vec<Box<dyn Plugin>>>> =
-    Lazy::new(|| Mutex::new(Vec::new()));
-static PLUGIN_INFOS: Lazy<Mutex<Vec<PluginInfo>>> =
-    Lazy::new(|| Mutex::new(Vec::new()));
+static ACTIVE_PLUGINS: Lazy<Mutex<Vec<Box<dyn Plugin>>>> = Lazy::new(|| Mutex::new(Vec::new()));
+static PLUGIN_INFOS: Lazy<Mutex<Vec<PluginInfo>>> = Lazy::new(|| Mutex::new(Vec::new()));
 
 fn read_plugin_settings() -> HashMap<String, bool> {
     let mut map = HashMap::new();
@@ -169,8 +167,7 @@ fn read_plugin_settings() -> HashMap<String, bool> {
 
 fn write_plugin_settings(settings: &HashMap<String, bool>) -> std::io::Result<()> {
     use std::fs;
-    let mut json: serde_json::Value =
-        serde_json::from_str(&fs::read_to_string(SETTINGS_PATH)?)?;
+    let mut json: serde_json::Value = serde_json::from_str(&fs::read_to_string(SETTINGS_PATH)?)?;
     if let Some(obj) = json.as_object_mut() {
         obj.insert(
             "plugins".to_string(),

--- a/backend/tests/server_error_format.rs
+++ b/backend/tests/server_error_format.rs
@@ -1,11 +1,12 @@
 use axum::http::{HeaderMap, StatusCode};
 use axum::Json;
 use backend::config::ServerConfig;
-use backend::meta::{AiNote, Translations, VisualMeta};
+use backend::meta::{AiNote, VisualMeta};
 use backend::server::{
-    export_endpoint, metadata_endpoint, parse_endpoint, ErrorResponse, ExportRequest, MetadataRequest,
-    ParseRequest, SERVER_CONFIG,
+    export_endpoint, metadata_endpoint, parse_endpoint, ErrorResponse, ExportRequest,
+    MetadataRequest, ParseRequest, SERVER_CONFIG,
 };
+use std::collections::HashMap;
 
 #[tokio::test]
 async fn parse_endpoint_bad_request() {
@@ -69,7 +70,7 @@ async fn metadata_endpoint_unauthorized() {
             x: 0.0,
             y: 0.0,
             origin: None,
-            translations: Translations::default(),
+            translations: HashMap::new(),
             ai: Some(AiNote::default()),
         },
         lang: "rust".into(),

--- a/frontend/src/editor/visual-meta-schema.json
+++ b/frontend/src/editor/visual-meta-schema.json
@@ -22,13 +22,8 @@
     },
     "translations": {
       "type": "object",
-      "description": "Optional translations for block labels.",
-      "additionalProperties": false,
-      "properties": {
-        "ru": { "type": "string", "description": "Russian translation." },
-        "en": { "type": "string", "description": "English translation." },
-        "es": { "type": "string", "description": "Spanish translation." }
-      }
+      "description": "Optional translations for block labels keyed by language code.",
+      "additionalProperties": { "type": "string" }
     },
     "ai": {
       "type": "object",


### PR DESCRIPTION
## Summary
- represent visual-meta translations as `HashMap<String, String>`
- adjust backend logic and tests for dynamic translation maps
- document translation map structure in visual meta schema

## Testing
- `cargo test` *(fails: javascriptcoregtk-4.0 library missing)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68992aa4d9b88323a819e12614660104