### PR TITLE
Add tag support to VisualMeta metadata

### DIFF
--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -213,6 +213,9 @@ pub fn upsert_meta(content: String, mut meta: VisualMeta, lang: String) -> Strin
         if meta.ai.is_none() {
             meta.ai = existing.ai.clone();
         }
+        if meta.tags.is_empty() {
+            meta.tags = existing.tags.clone();
+        }
     }
     metas.retain(|m| m.id != meta.id);
     metas.push(meta);
@@ -345,6 +348,8 @@ mod tests {
             id: "0".into(),
             x: 1.0,
             y: 2.0,
+            tags: vec![],
+            origin: None,
             translations: {
                 let mut m = HashMap::new();
                 m.insert("en".into(), "Main".into());

--- a/backend/src/meta/mod.rs
+++ b/backend/src/meta/mod.rs
@@ -25,6 +25,9 @@ pub struct VisualMeta {
     pub x: f64,
     /// Y coordinate on the canvas.
     pub y: f64,
+    /// Optional tags associated with this block.
+    #[serde(default)]
+    pub tags: Vec<String>,
     /// Optional reverse path to the original external file.
     #[serde(default)]
     pub origin: Option<String>,
@@ -101,6 +104,7 @@ mod tests {
             id: "1".into(),
             x: 10.0,
             y: 20.0,
+            tags: vec!["alpha".into(), "beta".into()],
             origin: None,
             translations: HashMap::new(),
             ai: Some(AiNote {
@@ -114,6 +118,7 @@ mod tests {
         let metas = read_all(&updated);
         assert_eq!(metas.len(), 1);
         assert_eq!(metas[0].x, 10.0);
+        assert_eq!(metas[0].tags, vec!["alpha", "beta"]);
         assert_eq!(
             metas[0].ai.as_ref().unwrap().description.as_deref(),
             Some("desc")

--- a/backend/tests/server_error_format.rs
+++ b/backend/tests/server_error_format.rs
@@ -69,6 +69,7 @@ async fn metadata_endpoint_unauthorized() {
             id: "1".into(),
             x: 0.0,
             y: 0.0,
+            tags: vec![],
             origin: None,
             translations: HashMap::new(),
             ai: Some(AiNote::default()),

--- a/backend/tests/tags.rs
+++ b/backend/tests/tags.rs
@@ -1,0 +1,28 @@
+use backend::meta::{read_all, upsert, VisualMeta};
+use std::collections::HashMap;
+
+#[test]
+fn read_tags_from_comment() {
+    let src =
+        "// @VISUAL_META {\"id\":\"1\",\"x\":1.0,\"y\":2.0,\"tags\":[\"a\",\"b\"]}\nfn main() {}";
+    let metas = read_all(src);
+    assert_eq!(metas.len(), 1);
+    assert_eq!(metas[0].tags, vec!["a", "b"]);
+}
+
+#[test]
+fn upsert_preserves_tags() {
+    let meta = VisualMeta {
+        id: "1".into(),
+        x: 0.0,
+        y: 0.0,
+        tags: vec!["t".into()],
+        origin: None,
+        translations: HashMap::new(),
+        ai: None,
+    };
+    let updated = upsert("fn main() {}", &meta);
+    assert!(updated.contains("\"tags\":[\"t\"]"));
+    let metas = read_all(&updated);
+    assert_eq!(metas[0].tags, vec!["t"]);
+}

--- a/frontend/src/editor/visual-meta-schema.json
+++ b/frontend/src/editor/visual-meta-schema.json
@@ -16,6 +16,11 @@
       "type": "number",
       "description": "Y coordinate on the canvas."
     },
+    "tags": {
+      "type": "array",
+      "description": "Tags associated with this block.",
+      "items": { "type": "string" }
+    },
     "origin": {
       "type": "string",
       "description": "Reverse path to the original external file."

--- a/frontend/src/editor/visual-meta.js
+++ b/frontend/src/editor/visual-meta.js
@@ -3,12 +3,13 @@ import { Decoration, EditorView } from "https://cdn.jsdelivr.net/npm/@codemirror
 import { hoverTooltip } from "https://cdn.jsdelivr.net/npm/@codemirror/language@6.10.1/dist/index.js";
 import schema from "./visual-meta-schema.json" with { type: "json" };
 
+const tmplObj = () => ({ id: crypto.randomUUID(), x: 0, y: 0, tags: [] });
 const templates = {
-  rust: () => `// @VISUAL_META ${JSON.stringify({id: crypto.randomUUID(), x:0, y:0})}`,
-  javascript: () => `// @VISUAL_META ${JSON.stringify({id: crypto.randomUUID(), x:0, y:0})}`,
-  python: () => `# @VISUAL_META ${JSON.stringify({id: crypto.randomUUID(), x:0, y:0})}`,
-  html: () => `<!-- @VISUAL_META ${JSON.stringify({id: crypto.randomUUID(), x:0, y:0})} -->`,
-  css: () => `/* @VISUAL_META ${JSON.stringify({id: crypto.randomUUID(), x:0, y:0})} */`,
+  rust: () => `// @VISUAL_META ${JSON.stringify(tmplObj())}`,
+  javascript: () => `// @VISUAL_META ${JSON.stringify(tmplObj())}`,
+  python: () => `# @VISUAL_META ${JSON.stringify(tmplObj())}`,
+  html: () => `<!-- @VISUAL_META ${JSON.stringify(tmplObj())} -->`,
+  css: () => `/* @VISUAL_META ${JSON.stringify(tmplObj())} */`,
 };
 
 export function insertVisualMeta(view, lang) {
@@ -28,6 +29,9 @@ export function updateMetaComment(view, meta) {
       if (obj.id === meta.id) {
         obj.x = meta.x;
         obj.y = meta.y;
+        if (Array.isArray(meta.tags)) {
+          obj.tags = meta.tags;
+        }
         const newJson = JSON.stringify(obj);
         const start = m.index + m[0].indexOf(json);
         const end = start + json.length;


### PR DESCRIPTION
## Summary
- support optional `tags` on VisualMeta metadata and preserve them when updating
- extend visual-meta schema and editor utilities to handle tags
- test reading and writing metadata tags

## Testing
- `npm test --prefix frontend`
- `cargo test -q` *(fails: The system library `javascriptcoregtk-4.0` required by crate `javascriptcore-rs-sys` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68992ebd1568832380a607e365fdc8e0