### PR TITLE
Add canvas search and menu input

### DIFF
--- a/frontend/src/visual/canvas.js
+++ b/frontend/src/visual/canvas.js
@@ -144,6 +144,18 @@ export class VisualCanvas {
     });
   }
 
+  search(label) {
+    const query = (label || '').trim().toLowerCase();
+    if (!query) {
+      this.highlightBlocks([]);
+      return;
+    }
+    const ids = this.blocks
+      .filter(b => b.label.toLowerCase().includes(query))
+      .map(b => b.id);
+    this.highlightBlocks(ids);
+  }
+
   getGroupId(blockId) {
     for (const [id, set] of this.groups.entries()) {
       if (set.has(blockId)) return id;

--- a/frontend/src/visual/menu.ts
+++ b/frontend/src/visual/menu.ts
@@ -1,5 +1,16 @@
-import { hotkeys, showHotkeyHelp, zoomToFit } from './hotkeys';
+import { hotkeys, showHotkeyHelp, zoomToFit, focusSearch } from './hotkeys';
 import { exportPNG } from './canvas.js';
+
+export function createSearchInput(canvas: any) {
+  const input = document.createElement('input');
+  input.type = 'search';
+  input.placeholder = 'Search';
+  input.addEventListener('input', () => {
+    canvas.search(input.value);
+  });
+  document.body.appendChild(input);
+  return input;
+}
 
 export interface MenuItem {
   label: string;
@@ -25,7 +36,7 @@ export const mainMenu: MenuItem[] = [
       { label: 'Сгруппировать', action: () => console.log('group') },
       { label: 'Разгруппировать', action: () => console.log('ungroup') },
       { label: 'Select Connections', action: () => console.log('select'), shortcut: hotkeys.selectConnections },
-      { label: 'Focus Search', action: () => console.log('focus search'), shortcut: hotkeys.focusSearch }
+      { label: 'Focus Search', action: focusSearch, shortcut: hotkeys.focusSearch }
     ]
   },
   {


### PR DESCRIPTION
## Summary
- add search input creation to menu and hook to focus shortcut
- implement `VisualCanvas.search` to highlight blocks by label
- reset highlights when search query is empty

## Testing
- `npm test`
- `cargo test` *(fails: The system library `javascriptcoregtk-4.0` required by crate `javascriptcore-rs-sys` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899245639ac8323915de7914b3fe27c