### PR TITLE
feat: track metadata updates

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -233,6 +233,7 @@ name = "backend"
 version = "0.1.0"
 dependencies = [
  "axum",
+ "chrono",
  "clap",
  "config",
  "futures",
@@ -453,8 +454,10 @@ checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-link",
 ]
 

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -19,6 +19,7 @@ tree-sitter-css = "0.23"
 tree-sitter-html = "0.23"
 tree-sitter-go = "0.23"
 tree-sitter-typescript = "0.23"
+chrono = { version = "0.4", features = ["serde"] }
 syn = { version = "2", features = ["full"] }
 quote = "1"
 prettyplease = "0.2"

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -19,6 +19,7 @@ use clap::{Parser, Subcommand};
 use debugger::{debug_break, debug_run, debug_step};
 use export::prepare_for_export;
 use meta::{read_all, remove_all, upsert, AiNote, VisualMeta};
+use chrono::Utc;
 use parser::{parse, parse_to_blocks, Lang};
 use syn::{File, Item};
 use tauri::State;
@@ -214,6 +215,7 @@ pub fn upsert_meta(content: String, mut meta: VisualMeta, lang: String) -> Strin
             meta.ai = existing.ai.clone();
         }
     }
+    meta.updated_at = Utc::now();
     metas.retain(|m| m.id != meta.id);
     metas.push(meta);
 
@@ -329,6 +331,7 @@ fn main() {}
 #[cfg(test)]
 mod tests {
     use super::*;
+    use chrono::Utc;
 
     #[test]
     fn parses_source_into_blockinfo() {
@@ -351,6 +354,7 @@ mod tests {
                 m
             },
             ai: None,
+            updated_at: Utc::now(),
         };
         let updated = upsert_meta(src, meta.clone(), "rust".into());
         assert!(updated.contains("@VISUAL_META"));

--- a/backend/src/meta/mod.rs
+++ b/backend/src/meta/mod.rs
@@ -1,3 +1,4 @@
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 mod comment_detector;
@@ -34,14 +35,23 @@ pub struct VisualMeta {
     /// Optional AI-generated note.
     #[serde(default)]
     pub ai: Option<AiNote>,
+    /// Timestamp of the last update.
+    #[serde(default = "default_ts")]
+    pub updated_at: DateTime<Utc>,
+}
+
+fn default_ts() -> DateTime<Utc> {
+    Utc::now()
 }
 
 /// Insert or update a visual metadata comment in `content`.
 ///
 /// The comment will be placed at the top of the document if it does not exist.
 pub fn upsert(content: &str, meta: &VisualMeta) -> String {
+    let mut meta = meta.clone();
+    meta.updated_at = Utc::now();
     let marker = format!("<!-- {} ", MARKER);
-    let serialized = match serde_json::to_string(meta) {
+    let serialized = match serde_json::to_string(&meta) {
         Ok(s) => s,
         Err(_) => return content.to_string(),
     };
@@ -94,6 +104,7 @@ pub fn remove_all(content: &str) -> String {
 mod tests {
     use super::*;
     use std::collections::HashMap;
+    use chrono::Utc;
 
     #[test]
     fn upsert_and_read_roundtrip() {
@@ -107,6 +118,7 @@ mod tests {
                 description: Some("desc".into()),
                 hints: vec!["hint".into()],
             }),
+            updated_at: Utc::now(),
         };
         let content = "fn main() {}";
         let updated = upsert(content, &meta);

--- a/backend/src/search.rs
+++ b/backend/src/search.rs
@@ -57,8 +57,8 @@ mod tests {
         let dir = tempdir().unwrap();
         let file1 = dir.path().join("a.rs");
         let file2 = dir.path().join("b.rs");
-        fs::write(&file1, "// @VISUAL_META {\"id\":\"one\",\"x\":0,\"y\":0}\n").unwrap();
-        fs::write(&file2, "// @VISUAL_META {\"id\":\"two\",\"x\":0,\"y\":0}\n").unwrap();
+        fs::write(&file1, "// @VISUAL_META {\"id\":\"one\",\"x\":0,\"y\":0,\"updated_at\":\"2024-01-01T00:00:00Z\"}\n").unwrap();
+        fs::write(&file2, "// @VISUAL_META {\"id\":\"two\",\"x\":0,\"y\":0,\"updated_at\":\"2024-01-01T00:00:00Z\"}\n").unwrap();
 
         let res = search_metadata(dir.path(), "one");
         assert_eq!(res.len(), 1);

--- a/backend/tests/css.rs
+++ b/backend/tests/css.rs
@@ -2,7 +2,7 @@ use backend::meta::read_all;
 
 #[test]
 fn detect_css_comment() {
-    let src = "/* @VISUAL_META {\"id\":\"1\",\"x\":1.0,\"y\":2.0} */\n.selector { color: red; }";
+    let src = "/* @VISUAL_META {\"id\":\"1\",\"x\":1.0,\"y\":2.0,\"updated_at\":\"2024-01-01T00:00:00Z\"} */\n.selector { color: red; }";
     let metas = read_all(src);
     assert_eq!(metas.len(), 1);
     assert_eq!(metas[0].id, "1");

--- a/backend/tests/html.rs
+++ b/backend/tests/html.rs
@@ -2,7 +2,7 @@ use backend::meta::read_all;
 
 #[test]
 fn detect_html_comment() {
-    let src = "<!-- @VISUAL_META {\"id\":\"1\",\"x\":1.0,\"y\":2.0} -->\n<div></div>";
+    let src = "<!-- @VISUAL_META {\"id\":\"1\",\"x\":1.0,\"y\":2.0,\"updated_at\":\"2024-01-01T00:00:00Z\"} -->\n<div></div>";
     let metas = read_all(src);
     assert_eq!(metas.len(), 1);
     assert_eq!(metas[0].id, "1");

--- a/backend/tests/id_registry.rs
+++ b/backend/tests/id_registry.rs
@@ -3,7 +3,7 @@ use backend::meta::{self, id_registry};
 #[test]
 fn detects_duplicate_ids() {
     id_registry::clear();
-    let content = "# @VISUAL_META {\"id\":\"dup\",\"x\":0.0,\"y\":0.0}\n# @VISUAL_META {\"id\":\"dup\",\"x\":1.0,\"y\":1.0}";
+    let content = "# @VISUAL_META {\"id\":\"dup\",\"x\":0.0,\"y\":0.0,\"updated_at\":\"2024-01-01T00:00:00Z\"}\n# @VISUAL_META {\"id\":\"dup\",\"x\":1.0,\"y\":1.0,\"updated_at\":\"2024-01-01T00:00:00Z\"}"; 
     // reading registers IDs
     meta::read_all(content);
     let dups = id_registry::duplicates();
@@ -13,7 +13,7 @@ fn detects_duplicate_ids() {
 #[test]
 fn finds_registered_meta() {
     id_registry::clear();
-    let content = "# @VISUAL_META {\"id\":\"main\",\"x\":1.0,\"y\":2.0}";
+    let content = "# @VISUAL_META {\"id\":\"main\",\"x\":1.0,\"y\":2.0,\"updated_at\":\"2024-01-01T00:00:00Z\"}"; 
     meta::read_all(content);
     let found = id_registry::get("main").expect("meta not found");
     assert_eq!(found.x, 1.0);

--- a/backend/tests/javascript.rs
+++ b/backend/tests/javascript.rs
@@ -2,7 +2,10 @@ use backend::meta::read_all;
 
 #[test]
 fn detect_js_comment() {
-    let src = "// @VISUAL_META {\"id\":\"1\",\"x\":1.0,\"y\":2.0}\nconsole.log(\"hi\");";
+    let src = concat!(
+        "// @VISUAL_META {\\"id\\":\\"1\\",\\"x\\":1.0,\\"y\\":2.0,\\"updated_at\\":\\"2024-01-01T00:00:00Z\\"}\\n",
+        "console.log(\\"hi\\");"
+    );
     let metas = read_all(src);
     assert_eq!(metas.len(), 1);
     assert_eq!(metas[0].id, "1");

--- a/backend/tests/parse_sync.rs
+++ b/backend/tests/parse_sync.rs
@@ -2,7 +2,7 @@ use backend::meta::read_all;
 
 #[test]
 fn block_disappears_after_comment_removal() {
-    let with_comment = "// @VISUAL_META {\"id\":\"1\",\"x\":1.0,\"y\":2.0}\nfn main() {}";
+    let with_comment = "// @VISUAL_META {\"id\":\"1\",\"x\":1.0,\"y\":2.0,\"updated_at\":\"2024-01-01T00:00:00Z\"}\nfn main() {}";
     assert_eq!(read_all(with_comment).len(), 1);
 
     let without_comment = "fn main() {}";

--- a/backend/tests/python.rs
+++ b/backend/tests/python.rs
@@ -2,7 +2,7 @@ use backend::meta::read_all;
 
 #[test]
 fn detect_python_comment() {
-    let src = "# @VISUAL_META {\"id\":\"1\",\"x\":1.0,\"y\":2.0}\nprint(\"hi\")";
+    let src = "# @VISUAL_META {\"id\":\"1\",\"x\":1.0,\"y\":2.0,\"updated_at\":\"2024-01-01T00:00:00Z\"}\nprint(\"hi\")";
     let metas = read_all(src);
     assert_eq!(metas.len(), 1);
     assert_eq!(metas[0].id, "1");

--- a/backend/tests/rust.rs
+++ b/backend/tests/rust.rs
@@ -2,7 +2,7 @@ use backend::meta::read_all;
 
 #[test]
 fn detect_rust_comment() {
-    let src = "// @VISUAL_META {\"id\":\"1\",\"x\":1.0,\"y\":2.0}\nfn main() {}";
+    let src = "// @VISUAL_META {\"id\":\"1\",\"x\":1.0,\"y\":2.0,\"updated_at\":\"2024-01-01T00:00:00Z\"}\nfn main() {}";
     let metas = read_all(src);
     assert_eq!(metas.len(), 1);
     assert_eq!(metas[0].id, "1");

--- a/backend/tests/server_error_format.rs
+++ b/backend/tests/server_error_format.rs
@@ -7,6 +7,7 @@ use backend::server::{
     MetadataRequest, ParseRequest, SERVER_CONFIG,
 };
 use std::collections::HashMap;
+use chrono::Utc;
 
 #[tokio::test]
 async fn parse_endpoint_bad_request() {
@@ -72,6 +73,7 @@ async fn metadata_endpoint_unauthorized() {
             origin: None,
             translations: HashMap::new(),
             ai: Some(AiNote::default()),
+            updated_at: Utc::now(),
         },
         lang: "rust".into(),
     };

--- a/frontend/src/editor/visual-meta-schema.json
+++ b/frontend/src/editor/visual-meta-schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
-  "required": ["id", "x", "y"],
+  "required": ["id", "x", "y", "updated_at"],
   "additionalProperties": false,
   "properties": {
     "id": {
@@ -15,6 +15,11 @@
     "y": {
       "type": "number",
       "description": "Y coordinate on the canvas."
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Timestamp of the last update in UTC."
     },
     "origin": {
       "type": "string",

--- a/frontend/src/editor/visual-meta.js
+++ b/frontend/src/editor/visual-meta.js
@@ -4,11 +4,11 @@ import { hoverTooltip } from "https://cdn.jsdelivr.net/npm/@codemirror/language@
 import schema from "./visual-meta-schema.json" with { type: "json" };
 
 const templates = {
-  rust: () => `// @VISUAL_META ${JSON.stringify({id: crypto.randomUUID(), x:0, y:0})}`,
-  javascript: () => `// @VISUAL_META ${JSON.stringify({id: crypto.randomUUID(), x:0, y:0})}`,
-  python: () => `# @VISUAL_META ${JSON.stringify({id: crypto.randomUUID(), x:0, y:0})}`,
-  html: () => `<!-- @VISUAL_META ${JSON.stringify({id: crypto.randomUUID(), x:0, y:0})} -->`,
-  css: () => `/* @VISUAL_META ${JSON.stringify({id: crypto.randomUUID(), x:0, y:0})} */`,
+  rust: () => `// @VISUAL_META ${JSON.stringify({id: crypto.randomUUID(), x:0, y:0, updated_at: new Date().toISOString()})}`,
+  javascript: () => `// @VISUAL_META ${JSON.stringify({id: crypto.randomUUID(), x:0, y:0, updated_at: new Date().toISOString()})}`,
+  python: () => `# @VISUAL_META ${JSON.stringify({id: crypto.randomUUID(), x:0, y:0, updated_at: new Date().toISOString()})}`,
+  html: () => `<!-- @VISUAL_META ${JSON.stringify({id: crypto.randomUUID(), x:0, y:0, updated_at: new Date().toISOString()})} -->`,
+  css: () => `/* @VISUAL_META ${JSON.stringify({id: crypto.randomUUID(), x:0, y:0, updated_at: new Date().toISOString()})} */`,
 };
 
 export function insertVisualMeta(view, lang) {
@@ -28,6 +28,7 @@ export function updateMetaComment(view, meta) {
       if (obj.id === meta.id) {
         obj.x = meta.x;
         obj.y = meta.y;
+        obj.updated_at = new Date().toISOString();
         const newJson = JSON.stringify(obj);
         const start = m.index + m[0].indexOf(json);
         const end = start + json.length;

--- a/frontend/src/importer/annotate.js
+++ b/frontend/src/importer/annotate.js
@@ -24,6 +24,7 @@ export async function annotateExternalFile(sourcePath, projectDir, view, lang) {
     x: 0,
     y: 0,
     origin: sourcePath,
+    updated_at: new Date().toISOString(),
   };
   const comment = `// @VISUAL_META ${JSON.stringify(meta)}\n`;
   await writeTextFile(destPath, comment + content);

--- a/frontend/src/widget/codegen.js
+++ b/frontend/src/widget/codegen.js
@@ -7,6 +7,7 @@ export function widgetToCode(widget) {
     kind: widget.kind,
     x: widget.x,
     y: widget.y,
+    updated_at: new Date().toISOString(),
   };
   if (widget.kind === 'button') meta.label = widget.label;
   if (widget.kind === 'text') meta.text = widget.text;

--- a/frontend/tests/visual_sync.test.ts
+++ b/frontend/tests/visual_sync.test.ts
@@ -19,7 +19,7 @@ import { updateMetaComment } from '../src/editor/visual-meta.js';
 
 describe('visual-meta synchronization', () => {
   it('reflects block coordinate changes in comments', () => {
-    const original = '// @VISUAL_META {"id":"1","x":0,"y":0}\nfn main() {}';
+    const original = '// @VISUAL_META {"id":"1","x":0,"y":0,"updated_at":"2024-01-01T00:00:00Z"}\nfn main() {}';
     const view: any = {
       state: { doc: { toString: () => original } },
       dispatch: vi.fn(({ changes: { from, to, insert } }) => {


### PR DESCRIPTION
## Summary
- add chrono and updated_at timestamp to VisualMeta
- record update time when saving meta
- require updated_at in JSON schema and frontend generators

## Testing
- `cargo test` *(fails: system library `javascriptcoregtk-4.0` missing)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68992f30a1a08323a05de04774790e80