### PR TITLE
Add update timestamp to VisualMeta metadata

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -233,6 +233,7 @@ name = "backend"
 version = "0.1.0"
 dependencies = [
  "axum",
+ "chrono",
  "clap",
  "config",
  "futures",
@@ -453,8 +454,10 @@ checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-link",
 ]
 

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -35,6 +35,7 @@ notify = "5"
 reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls"] }
 clap = { version = "4", features = ["derive"] }
 wasmtime = "10"
+chrono = { version = "0.4", features = ["serde"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -18,6 +18,7 @@ use backend::{
 use clap::{Parser, Subcommand};
 use debugger::{debug_break, debug_run, debug_step};
 use export::prepare_for_export;
+use chrono::Utc;
 use meta::{read_all, remove_all, upsert, AiNote, VisualMeta};
 use parser::{parse, parse_to_blocks, Lang};
 use syn::{File, Item};
@@ -205,6 +206,7 @@ fn regenerate_rust(content: &str, metas: &[VisualMeta]) -> Option<String> {
 
 #[cfg_attr(not(test), tauri::command)]
 pub fn upsert_meta(content: String, mut meta: VisualMeta, lang: String) -> String {
+    meta.updated_at = Utc::now();
     let mut metas = read_all(&content);
     if let Some(existing) = metas.iter().find(|m| m.id == meta.id) {
         if meta.translations.is_empty() {
@@ -332,6 +334,7 @@ fn main() {}
 #[cfg(test)]
 mod tests {
     use super::*;
+    use chrono::Utc;
 
     #[test]
     fn parses_source_into_blockinfo() {
@@ -356,6 +359,7 @@ mod tests {
                 m
             },
             ai: None,
+            updated_at: Utc::now(),
         };
         let updated = upsert_meta(src, meta.clone(), "rust".into());
         assert!(updated.contains("@VISUAL_META"));

--- a/backend/tests/server_error_format.rs
+++ b/backend/tests/server_error_format.rs
@@ -2,6 +2,7 @@ use axum::http::{HeaderMap, StatusCode};
 use axum::Json;
 use backend::config::ServerConfig;
 use backend::meta::{AiNote, VisualMeta};
+use chrono::Utc;
 use backend::server::{
     export_endpoint, metadata_endpoint, parse_endpoint, ErrorResponse, ExportRequest,
     MetadataRequest, ParseRequest, SERVER_CONFIG,
@@ -73,6 +74,7 @@ async fn metadata_endpoint_unauthorized() {
             origin: None,
             translations: HashMap::new(),
             ai: Some(AiNote::default()),
+            updated_at: Utc::now(),
         },
         lang: "rust".into(),
     };

--- a/backend/tests/tags.rs
+++ b/backend/tests/tags.rs
@@ -1,4 +1,5 @@
 use backend::meta::{read_all, upsert, VisualMeta};
+use chrono::Utc;
 use std::collections::HashMap;
 
 #[test]
@@ -20,6 +21,7 @@ fn upsert_preserves_tags() {
         origin: None,
         translations: HashMap::new(),
         ai: None,
+        updated_at: Utc::now(),
     };
     let updated = upsert("fn main() {}", &meta);
     assert!(updated.contains("\"tags\":[\"t\"]"));

--- a/frontend/src/editor/visual-meta-schema.json
+++ b/frontend/src/editor/visual-meta-schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
-  "required": ["id", "x", "y"],
+  "required": ["id", "x", "y", "updated_at"],
   "additionalProperties": false,
   "properties": {
     "id": {
@@ -42,6 +42,11 @@
           "items": { "type": "string" }
         }
       }
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Timestamp of last update in UTC."
     }
   }
 }

--- a/frontend/src/editor/visual-meta.js
+++ b/frontend/src/editor/visual-meta.js
@@ -3,7 +3,13 @@ import { Decoration, EditorView } from "https://cdn.jsdelivr.net/npm/@codemirror
 import { hoverTooltip } from "https://cdn.jsdelivr.net/npm/@codemirror/language@6.10.1/dist/index.js";
 import schema from "./visual-meta-schema.json" with { type: "json" };
 
-const tmplObj = () => ({ id: crypto.randomUUID(), x: 0, y: 0, tags: [] });
+const tmplObj = () => ({
+  id: crypto.randomUUID(),
+  x: 0,
+  y: 0,
+  tags: [],
+  updated_at: new Date().toISOString(),
+});
 const templates = {
   rust: () => `// @VISUAL_META ${JSON.stringify(tmplObj())}`,
   javascript: () => `// @VISUAL_META ${JSON.stringify(tmplObj())}`,


### PR DESCRIPTION
## Summary
- track last modification time in VisualMeta using `chrono`
- persist `updated_at` when inserting or updating metadata
- extend visual meta JSON schema with required `updated_at` field

## Testing
- `cargo test` *(fails: unresolved imports in server and plugin modules)*
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_6899352b59548323a5066ac9581b4815