### PR TITLE
Add extras field to VisualMeta metadata

### DIFF
--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -359,6 +359,7 @@ mod tests {
                 m
             },
             ai: None,
+            extras: None,
             updated_at: Utc::now(),
         };
         let updated = upsert_meta(src, meta.clone(), "rust".into());

--- a/backend/src/meta/mod.rs
+++ b/backend/src/meta/mod.rs
@@ -38,6 +38,9 @@ pub struct VisualMeta {
     /// Optional AI-generated note.
     #[serde(default)]
     pub ai: Option<AiNote>,
+    /// Optional plugin-specific metadata.
+    #[serde(default)]
+    pub extras: Option<serde_json::Value>,
     /// Timestamp of last update in UTC.
     #[serde(default)]
     pub updated_at: DateTime<Utc>,
@@ -104,6 +107,7 @@ mod tests {
     use super::*;
     use std::collections::HashMap;
     use chrono::Utc;
+    use serde_json::json;
 
     #[test]
     fn upsert_and_read_roundtrip() {
@@ -118,6 +122,7 @@ mod tests {
                 description: Some("desc".into()),
                 hints: vec!["hint".into()],
             }),
+            extras: Some(json!({"foo": "bar"})),
             updated_at: Utc::now(),
         };
         let content = "fn main() {}";
@@ -131,6 +136,7 @@ mod tests {
             metas[0].ai.as_ref().unwrap().description.as_deref(),
             Some("desc")
         );
+        assert_eq!(metas[0].extras, Some(json!({"foo": "bar"})));
         assert!(metas[0].updated_at.timestamp() > 0);
     }
 

--- a/backend/tests/server_error_format.rs
+++ b/backend/tests/server_error_format.rs
@@ -74,6 +74,7 @@ async fn metadata_endpoint_unauthorized() {
             origin: None,
             translations: HashMap::new(),
             ai: Some(AiNote::default()),
+            extras: None,
             updated_at: Utc::now(),
         },
         lang: "rust".into(),

--- a/backend/tests/tags.rs
+++ b/backend/tests/tags.rs
@@ -21,6 +21,7 @@ fn upsert_preserves_tags() {
         origin: None,
         translations: HashMap::new(),
         ai: None,
+        extras: None,
         updated_at: Utc::now(),
     };
     let updated = upsert("fn main() {}", &meta);

--- a/examples/plugins/README.md
+++ b/examples/plugins/README.md
@@ -36,9 +36,14 @@ impl Plugin for MyPlugin {
 // my-block.js
 export function register({ Block, registerBlock }) {
   class MyBlock extends Block {
+    constructor(id, x, y, w, h, label, color, extras = {}) {
+      super(id, x, y, w, h, label, color);
+      this.extras = extras;
+    }
+
     draw(ctx) {
       super.draw(ctx);
-      ctx.strokeStyle = 'red';
+      ctx.strokeStyle = this.extras.outline || 'red';
       ctx.strokeRect(this.x, this.y, this.w, this.h);
     }
   }
@@ -51,4 +56,12 @@ export function register({ Block, registerBlock }) {
 
 ```javascript
 await loadBlockPlugins(['./my-block.js']);
+```
+
+Поле `extras` из структуры [`VisualMeta`](../../backend/src/meta/mod.rs) позволяет
+передавать в блок произвольные данные плагина. В примере выше цвет обводки
+блока можно настроить с помощью метаданных:
+
+```text
+// @VISUAL_META {"id":"1","x":0,"y":0,"extras":{"outline":"blue"}}
 ```

--- a/examples/plugins/my-block.js
+++ b/examples/plugins/my-block.js
@@ -3,9 +3,13 @@
 // class and a helper for registration.
 export function register({ Block, registerBlock }) {
   class MyBlock extends Block {
+    constructor(id, x, y, w, h, label, color, extras = {}) {
+      super(id, x, y, w, h, label, color);
+      this.extras = extras;
+    }
     draw(ctx) {
       super.draw(ctx);
-      ctx.strokeStyle = 'red';
+      ctx.strokeStyle = this.extras.outline || 'red';
       ctx.strokeRect(this.x, this.y, this.w, this.h);
     }
   }

--- a/examples/plugins/my_plugin.rs
+++ b/examples/plugins/my_plugin.rs
@@ -1,4 +1,8 @@
 use backend::plugins::{Plugin, BlockDescriptor};
+use backend::meta::VisualMeta;
+use chrono::Utc;
+use std::collections::HashMap;
+use serde_json::json;
 
 pub struct MyPlugin;
 
@@ -17,5 +21,21 @@ impl Plugin for MyPlugin {
             label: Some("Мой блок".to_string()),
             version: env!("CARGO_PKG_VERSION").to_string(),
         }]
+    }
+}
+
+// Example of constructing `VisualMeta` with plugin-specific extras.
+#[allow(dead_code)]
+fn example_meta_with_extras() -> VisualMeta {
+    VisualMeta {
+        id: "1".into(),
+        x: 0.0,
+        y: 0.0,
+        tags: vec![],
+        origin: None,
+        translations: HashMap::new(),
+        ai: None,
+        extras: Some(json!({"outline": "blue"})),
+        updated_at: Utc::now(),
     }
 }

--- a/frontend/src/editor/visual-meta-schema.json
+++ b/frontend/src/editor/visual-meta-schema.json
@@ -43,6 +43,10 @@
         }
       }
     },
+    "extras": {
+      "type": "object",
+      "description": "Arbitrary plugin-specific data."
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time",


### PR DESCRIPTION
## Summary
- allow storing plugin-specific `extras` data in `VisualMeta`
- document `extras` in JSON schema and plugin examples
- test round-trip serialization of `extras`

## Testing
- `cargo test` *(fails: package javascriptcoregtk-4.0 not found)*
- `cargo test --no-default-features` *(fails: package javascriptcoregtk-4.0 not found)*

------
https://chatgpt.com/codex/tasks/task_e_68995de4d2ac83238a9ef12aef52193f