### PR TITLE
Add version field to VisualMeta with schema and tests

### DIFF
--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -210,6 +210,9 @@ pub fn upsert_meta(content: String, mut meta: VisualMeta, lang: String) -> Strin
     meta.updated_at = Utc::now();
     let mut metas = read_all(&content);
     if let Some(existing) = metas.iter().find(|m| m.id == meta.id) {
+        if meta.version == 0 {
+            meta.version = existing.version;
+        }
         if meta.translations.is_empty() {
             meta.translations = existing.translations.clone();
         }
@@ -222,6 +225,9 @@ pub fn upsert_meta(content: String, mut meta: VisualMeta, lang: String) -> Strin
         if meta.links.is_empty() {
             meta.links = existing.links.clone();
         }
+    }
+    if meta.version == 0 {
+        meta.version = 1;
     }
     metas.retain(|m| m.id != meta.id);
     metas.push(meta);
@@ -352,6 +358,7 @@ mod tests {
     fn upsert_meta_synchronizes_data() {
         let src = "fn main() {}".to_string();
         let meta = VisualMeta {
+            version: 1,
             id: "0".into(),
             x: 1.0,
             y: 2.0,

--- a/backend/tests/links.rs
+++ b/backend/tests/links.rs
@@ -16,6 +16,7 @@ fn read_links_from_comment() {
 #[test]
 fn upsert_preserves_links() {
     let meta = VisualMeta {
+        version: 1,
         id: "1".into(),
         x: 0.0,
         y: 0.0,

--- a/backend/tests/server_error_format.rs
+++ b/backend/tests/server_error_format.rs
@@ -67,6 +67,7 @@ async fn metadata_endpoint_unauthorized() {
     let req = MetadataRequest {
         content: String::new(),
         meta: VisualMeta {
+            version: 1,
             id: "1".into(),
             x: 0.0,
             y: 0.0,

--- a/backend/tests/tags.rs
+++ b/backend/tests/tags.rs
@@ -14,6 +14,7 @@ fn read_tags_from_comment() {
 #[test]
 fn upsert_preserves_tags() {
     let meta = VisualMeta {
+        version: 1,
         id: "1".into(),
         x: 0.0,
         y: 0.0,

--- a/backend/tests/version.rs
+++ b/backend/tests/version.rs
@@ -1,0 +1,40 @@
+use backend::meta::{read_all, upsert, VisualMeta};
+use chrono::Utc;
+use std::collections::HashMap;
+
+#[test]
+fn defaults_to_version_one() {
+    let src = "// @VISUAL_META {\"id\":\"1\",\"x\":0.0,\"y\":0.0}\n";
+    let metas = read_all(src);
+    assert_eq!(metas.len(), 1);
+    assert_eq!(metas[0].version, 1);
+}
+
+#[test]
+fn reads_explicit_version() {
+    let src = "// @VISUAL_META {\"id\":\"1\",\"x\":0.0,\"y\":0.0,\"version\":2}\n";
+    let metas = read_all(src);
+    assert_eq!(metas.len(), 1);
+    assert_eq!(metas[0].version, 2);
+}
+
+#[test]
+fn upsert_preserves_version() {
+    let meta = VisualMeta {
+        version: 3,
+        id: "1".into(),
+        x: 0.0,
+        y: 0.0,
+        tags: vec![],
+        links: vec![],
+        origin: None,
+        translations: HashMap::new(),
+        ai: None,
+        extras: None,
+        updated_at: Utc::now(),
+    };
+    let updated = upsert("fn main() {}", &meta);
+    assert!(updated.contains("\"version\":3"));
+    let metas = read_all(&updated);
+    assert_eq!(metas[0].version, 3);
+}

--- a/examples/plugins/my_plugin.rs
+++ b/examples/plugins/my_plugin.rs
@@ -28,6 +28,7 @@ impl Plugin for MyPlugin {
 #[allow(dead_code)]
 fn example_meta_with_extras() -> VisualMeta {
     VisualMeta {
+        version: 1,
         id: "1".into(),
         x: 0.0,
         y: 0.0,

--- a/frontend/src/editor/visual-meta-schema.json
+++ b/frontend/src/editor/visual-meta-schema.json
@@ -8,6 +8,11 @@
       "type": "string",
       "description": "Identifier linking this metadata to blocks."
     },
+    "version": {
+      "type": "integer",
+      "description": "Schema version of the metadata.",
+      "default": 1
+    },
     "x": {
       "type": "number",
       "description": "X coordinate on the canvas."

--- a/frontend/src/editor/visual-meta.js
+++ b/frontend/src/editor/visual-meta.js
@@ -5,6 +5,7 @@ import schema from "./visual-meta-schema.json" with { type: "json" };
 
 const tmplObj = () => ({
   id: crypto.randomUUID(),
+  version: 1,
   x: 0,
   y: 0,
   tags: [],
@@ -34,6 +35,9 @@ export function updateMetaComment(view, meta) {
     try {
       const obj = JSON.parse(json);
       if (obj.id === meta.id) {
+        if (typeof obj.version !== "number") {
+          obj.version = 1;
+        }
         obj.x = meta.x;
         obj.y = meta.y;
         if (Array.isArray(meta.tags)) {

--- a/frontend/src/importer/annotate.js
+++ b/frontend/src/importer/annotate.js
@@ -21,6 +21,7 @@ export async function annotateExternalFile(sourcePath, projectDir, view, lang) {
 
   const meta = {
     id: crypto.randomUUID(),
+    version: 1,
     x: 0,
     y: 0,
     origin: sourcePath,


### PR DESCRIPTION
## Summary
- track metadata schema with new `version` field (default `1`)
- update frontend templates and schema to include version
- fill missing versions during metadata migration and syncing
- add tests for multiple metadata versions

## Testing
- `cargo test` *(fails: The system library `javascriptcoregtk-4.0` required by crate `javascriptcore-rs-sys` was not found)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68996d291ac08323a9339ae53cb5a149