### PR TITLE
feat: manage visual metadata via CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,12 +46,14 @@ Multicode V3 — редактор исходного кода, который о
    Скомпилированные бинарные файлы появятся в `frontend/src-tauri/target/release`.
 
 ## Использование CLI
-Бэкенд содержит минимальный интерфейс командной строки. Примеры запуска:
+Бэкенд содержит минимальный интерфейс командной строки для работы с кодом и метаданными. Примеры запуска:
 
 ```
 cargo run -- parse path/to/file.rs --lang rust
 cargo run -- export input.rs output.rs --strip-meta
-cargo run -- metadata path/to/file.rs
+cargo run -- meta list path/to/file.rs
+cargo run -- meta fix path/to/file.rs
+cargo run -- meta remove path/to/file.rs
 ```
 
 ## Добавление модулей

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -33,6 +33,7 @@ config = "0.13"
 libloading = "0.8"
 notify = "5"
 reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls"] }
+# CLI argument parser
 clap = { version = "4", features = ["derive"] }
 wasmtime = "10"
 chrono = { version = "0.4", features = ["serde"] }


### PR DESCRIPTION
## Summary
- expose `meta` CLI with list/fix/remove subcommands
- add helpers for listing and fixing `@VISUAL_META` entries
- document metadata CLI usage in README

## Testing
- `cargo test` *(fails: unresolved imports in backend crate)*

------
https://chatgpt.com/codex/tasks/task_e_68997123019c8323a57c60c32a04d6ab