### PR TITLE
Add inheritance support to visual metadata

### DIFF
--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -15,10 +15,10 @@ pub use backend::BlockInfo;
 use backend::{
     get_cached_blocks, get_document_tree, update_block_cache, update_document_tree, BlockInfo,
 };
+use chrono::Utc;
 use clap::{Parser, Subcommand};
 use debugger::{debug_break, debug_run, debug_step};
 use export::prepare_for_export;
-use chrono::Utc;
 use meta::{fix_all, read_all, remove_all, upsert, AiNote, VisualMeta};
 use parser::{parse, parse_to_blocks, Lang};
 use syn::{File, Item};
@@ -395,6 +395,7 @@ mod tests {
             y: 2.0,
             tags: vec![],
             links: vec![],
+            extends: None,
             origin: None,
             translations: {
                 let mut m = HashMap::new();

--- a/backend/tests/links.rs
+++ b/backend/tests/links.rs
@@ -7,7 +7,8 @@ use tempfile::tempdir;
 
 #[test]
 fn read_links_from_comment() {
-    let src = "// @VISUAL_META {\"id\":\"1\",\"x\":0.0,\"y\":0.0,\"links\":[\"a\",\"b\"]}\nfn main() {}";
+    let src =
+        "// @VISUAL_META {\"id\":\"1\",\"x\":0.0,\"y\":0.0,\"links\":[\"a\",\"b\"]}\nfn main() {}";
     let metas = read_all(src);
     assert_eq!(metas.len(), 1);
     assert_eq!(metas[0].links, vec!["a", "b"]);
@@ -22,6 +23,7 @@ fn upsert_preserves_links() {
         y: 0.0,
         tags: vec![],
         links: vec!["l".into()],
+        extends: None,
         origin: None,
         translations: HashMap::new(),
         ai: None,
@@ -48,4 +50,3 @@ fn search_finds_by_link() {
     assert_eq!(res[0].file, file);
     assert_eq!(res[0].meta.links, vec!["target"]);
 }
-

--- a/backend/tests/server_error_format.rs
+++ b/backend/tests/server_error_format.rs
@@ -2,11 +2,11 @@ use axum::http::{HeaderMap, StatusCode};
 use axum::Json;
 use backend::config::ServerConfig;
 use backend::meta::{AiNote, VisualMeta};
-use chrono::Utc;
 use backend::server::{
     export_endpoint, metadata_endpoint, parse_endpoint, ErrorResponse, ExportRequest,
     MetadataRequest, ParseRequest, SERVER_CONFIG,
 };
+use chrono::Utc;
 use std::collections::HashMap;
 
 #[tokio::test]
@@ -73,6 +73,7 @@ async fn metadata_endpoint_unauthorized() {
             y: 0.0,
             tags: vec![],
             links: vec![],
+            extends: None,
             origin: None,
             translations: HashMap::new(),
             ai: Some(AiNote::default()),

--- a/backend/tests/tags.rs
+++ b/backend/tests/tags.rs
@@ -20,6 +20,7 @@ fn upsert_preserves_tags() {
         y: 0.0,
         tags: vec!["t".into()],
         links: vec![],
+        extends: None,
         origin: None,
         translations: HashMap::new(),
         ai: None,

--- a/backend/tests/version.rs
+++ b/backend/tests/version.rs
@@ -27,6 +27,7 @@ fn upsert_preserves_version() {
         y: 0.0,
         tags: vec![],
         links: vec![],
+        extends: None,
         origin: None,
         translations: HashMap::new(),
         ai: None,

--- a/examples/plugins/my_plugin.rs
+++ b/examples/plugins/my_plugin.rs
@@ -34,6 +34,7 @@ fn example_meta_with_extras() -> VisualMeta {
         y: 0.0,
         tags: vec![],
         links: vec![],
+        extends: None,
         origin: None,
         translations: HashMap::new(),
         ai: None,

--- a/frontend/src/editor/visual-meta-schema.json
+++ b/frontend/src/editor/visual-meta-schema.json
@@ -31,6 +31,10 @@
       "description": "Links to other blocks by id.",
       "items": { "type": "string" }
     },
+    "extends": {
+      "type": "string",
+      "description": "Identifier of a base metadata entry to inherit from."
+    },
     "origin": {
       "type": "string",
       "description": "Reverse path to the original external file."
@@ -62,5 +66,14 @@
       "format": "date-time",
       "description": "Timestamp of last update in UTC."
     }
-  }
+  },
+  "examples": [
+    {
+      "id": "child",
+      "extends": "parent",
+      "x": 0,
+      "y": 0,
+      "updated_at": "2024-01-01T00:00:00Z"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- support `extends` field in visual metadata and recursively merge base entries
- document `extends` in editor schema with example usage
- tests for metadata inheritance

## Testing
- `cargo test` *(fails: The system library `javascriptcoregtk-4.0` required by crate `javascriptcore-rs-sys` was not found)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68997525ee7c83238a756221177f4ed2