### PR TITLE
Add serde and chrono build deps

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -48,3 +48,5 @@ tempfile = "3"
 tauri-build = { version = "1", default-features = false }
 schemars = { version = "0.8", features = ["derive", "chrono"] }
 serde_json = "1"
+serde = { version = "1", features = ["derive"] }
+chrono = { version = "0.4", features = ["serde"] }


### PR DESCRIPTION
## Summary
- include serde and chrono as build dependencies for backend schema generation

## Testing
- `cargo check` *(fails: The system library `javascriptcoregtk-4.0` required by crate `javascriptcore-rs-sys` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68998e5d2a908323a79b06fdb3e5a578