### PR TITLE
docs: add environment setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ Multicode V3 — редактор исходного кода, который о
 ```
 Комментарий не влияет на выполнение программы и может быть удалён при экспорте.
 
+## Установка окружения
+- **Node.js:** перейдите на [nodejs.org](https://nodejs.org) или используйте `nvm`, например `nvm install --lts`.
+- **Rust:** установка через `rustup`, например `curl https://sh.rustup.rs -sSf | sh`.
+- **Tauri CLI:** установка через `npm install -g @tauri-apps/cli` или `cargo install tauri-cli`, проверка `tauri --version`.
+
 ## Инструкции по запуску и сборке
 1. Установите Rust, Node.js и [Tauri CLI](https://tauri.app).
 2. Установите зависимости и выполните тесты:


### PR DESCRIPTION
## Summary
- document Node.js, Rust, and Tauri CLI setup in README

## Testing
- `npm test -- --run`
- `cargo test` *(fails: javascriptcoregtk-4.0.pc not found)*

------
https://chatgpt.com/codex/tasks/task_e_689995fffe6c8323a3c536727d99eb37