### PR TITLE
docs: describe new root dev script

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,10 +55,13 @@ Multicode V3 — редактор исходного кода, который о
    cd frontend && npm install && npm test
    cd ../backend && cargo test
    ```
-2. Запуск режима разработки:
+2. Запуск режима разработки (после добавления корневого скрипта `dev` доступен из корня репозитория):
    ```
-   cd frontend
    npm run dev
+   ```
+   или из каталога `frontend`:
+   ```
+   cd frontend && npm run dev
    ```
 3. Сборка десктопного приложения:
    ```


### PR DESCRIPTION
## Summary
- document that `npm run dev` now works from repo root
- keep `cd frontend && npm run dev` as alternative example

## Testing
- `npm install`
- `npm test`
- `cargo test` *(fails: could not find system library `libsoup-2.4`)*

------
https://chatgpt.com/codex/tasks/task_e_6899a0b90258832394b6644d2459732b