### PR TITLE
chore: migrate Tauri config to v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,14 +39,17 @@ Multicode V3 — редактор исходного кода, который о
      ```
    - После установки перезапустите терминал и выполните `rustc --version`.
 3. **Tauri CLI**
-   - Установите глобально с помощью npm:
+   - Проект использует конфигурацию **Tauri v2**. Установите CLI версии 2:
      ```bash
-     npm install -g @tauri-apps/cli
+     npm install -g @tauri-apps/cli@^2
      ```
    - Либо через Cargo:
      ```bash
-     cargo install tauri-cli
+     cargo install tauri-cli --version ^2
      ```
+   - Если установлен CLI версии 1, команда `npm run dev` завершится ошибками вида
+     «`identifier` is a required property» и «Additional properties are not allowed».
+     Удалите старую версию и поставьте CLI v2.
    - Проверьте установку командой `tauri --version`.
 
 ## Инструкции по запуску и сборке

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -1,22 +1,18 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
+  "identifier": "com.example.multicode",
   "build": {
     "beforeDevCommand": "cargo run --manifest-path ../backend/Cargo.toml",
     "beforeBuildCommand": "cargo build --release --manifest-path ../backend/Cargo.toml",
-    "devPath": "../dist",
-    "distDir": "../dist"
+    "devUrl": "../dist",
+    "frontendDist": "../dist"
   },
-  "package": {
-    "productName": "multicode",
-    "version": "0.1.0"
+  "bundle": {
+    "externalBin": [
+      "../backend/target/release/backend"
+    ]
   },
-  "tauri": {
-    "bundle": {
-      "identifier": "com.example.multicode",
-      "externalBin": [
-        "../backend/target/release/backend"
-      ]
-    },
+  "app": {
     "windows": [
       {
         "title": "Multicode",


### PR DESCRIPTION
## Summary
- update Tauri configuration file to v2 schema
- document Tauri CLI v2 requirement in README

## Testing
- `npm test`
- `cargo test` *(fails: could not complete, compilation aborted)*

------
https://chatgpt.com/codex/tasks/task_e_6899a91aebb88323826ceca6f2f1150e