### PR TITLE
feat: add metadata query search

### DIFF
--- a/backend/src/meta/mod.rs
+++ b/backend/src/meta/mod.rs
@@ -6,6 +6,7 @@ pub mod db;
 pub mod id_registry;
 pub mod watch;
 mod types;
+pub mod query;
 pub use types::{AiNote, VisualMeta};
 
 /// Marker used to identify visual metadata comments in documents.

--- a/backend/src/meta/query.rs
+++ b/backend/src/meta/query.rs
@@ -1,0 +1,106 @@
+use crate::meta::VisualMeta;
+use serde_json::Value;
+
+/// Boolean query expression for filtering [`VisualMeta`] entries.
+#[derive(Debug, Clone)]
+pub enum Expr {
+    /// All sub-expressions must match.
+    And(Vec<Expr>),
+    /// Any sub-expression may match.
+    Or(Vec<Expr>),
+    /// Field contains value (case sensitive).
+    Cond { field: String, value: String },
+}
+
+/// Parse simple `AND`/`OR` expressions composed of `field:value` conditions.
+/// Examples: `id:foo AND tags:bar`, `id:foo OR id:bar`.
+pub fn parse(input: &str) -> Expr {
+    let tokens: Vec<&str> = input.split_whitespace().collect();
+    parse_or(&tokens, 0).0
+}
+
+fn parse_or(tokens: &[&str], mut pos: usize) -> (Expr, usize) {
+    let (mut expr, mut i) = parse_and(tokens, pos);
+    while i < tokens.len() {
+        if tokens[i].eq_ignore_ascii_case("OR") {
+            let (rhs, j) = parse_and(tokens, i + 1);
+            expr = Expr::Or(vec![expr, rhs]);
+            i = j;
+        } else {
+            break;
+        }
+    }
+    (expr, i)
+}
+
+fn parse_and(tokens: &[&str], mut pos: usize) -> (Expr, usize) {
+    let (mut expr, mut i) = parse_term(tokens, pos);
+    let mut terms = vec![expr];
+    while i < tokens.len() {
+        if tokens[i].eq_ignore_ascii_case("AND") {
+            let (rhs, j) = parse_term(tokens, i + 1);
+            terms.push(rhs);
+            i = j;
+        } else if tokens[i].eq_ignore_ascii_case("OR") {
+            break;
+        } else {
+            // implicit AND
+            let (rhs, j) = parse_term(tokens, i);
+            terms.push(rhs);
+            i = j;
+        }
+    }
+    if terms.len() == 1 {
+        (terms.remove(0), i)
+    } else {
+        (Expr::And(terms), i)
+    }
+}
+
+fn parse_term(tokens: &[&str], pos: usize) -> (Expr, usize) {
+    if pos >= tokens.len() {
+        return (Expr::And(vec![]), pos);
+    }
+    let tok = tokens[pos];
+    if let Some(idx) = tok.find(':') {
+        let field = tok[..idx].to_string();
+        let value = tok[idx + 1..].to_string();
+        (Expr::Cond { field, value }, pos + 1)
+    } else {
+        // treat bare word as value search in any field
+        (
+            Expr::Cond {
+                field: String::from("*"),
+                value: tok.to_string(),
+            },
+            pos + 1,
+        )
+    }
+}
+
+/// Check whether a [`VisualMeta`] satisfies the expression.
+pub fn matches(meta: &VisualMeta, expr: &Expr) -> bool {
+    match expr {
+        Expr::And(list) => list.iter().all(|e| matches(meta, e)),
+        Expr::Or(list) => list.iter().any(|e| matches(meta, e)),
+        Expr::Cond { field, value } => {
+            let val = serde_json::to_value(meta).unwrap_or(Value::Null);
+            match_field(&val, field, value)
+        }
+    }
+}
+
+fn match_field(val: &Value, field: &str, target: &str) -> bool {
+    if field == "*" {
+        return val.to_string().contains(target);
+    }
+    match val.get(field) {
+        Some(Value::String(s)) => s.contains(target),
+        Some(Value::Array(arr)) => arr.iter().any(|v| match v {
+            Value::String(s) => s.contains(target),
+            _ => false,
+        }),
+        Some(v) => v.to_string().contains(target),
+        None => false,
+    }
+}

--- a/backend/tests/server_error_format.rs
+++ b/backend/tests/server_error_format.rs
@@ -1,10 +1,9 @@
-use axum::http::{HeaderMap, StatusCode};
-use axum::Json;
+use axum::{extract::State, http::{HeaderMap, StatusCode}, Json};
 use backend::config::ServerConfig;
 use backend::meta::{AiNote, VisualMeta};
 use backend::server::{
-    export_endpoint, metadata_endpoint, parse_endpoint, ErrorResponse, ExportRequest,
-    MetadataRequest, ParseRequest, SERVER_CONFIG,
+    export_endpoint, metadata_upsert_endpoint, metadata_endpoint, parse_endpoint, test_state, ErrorResponse,
+    ExportRequest, MetadataRequest, ParseRequest, SERVER_CONFIG,
 };
 use chrono::Utc;
 use std::collections::HashMap;
@@ -82,7 +81,9 @@ async fn metadata_endpoint_unauthorized() {
         },
         lang: "rust".into(),
     };
-    let (status, Json(err)) = metadata_endpoint(headers, Json(req)).await.unwrap_err();
+    let (status, Json(err)) = metadata_upsert_endpoint(State(test_state()), headers, Json(req))
+        .await
+        .unwrap_err();
     assert_eq!(status, StatusCode::UNAUTHORIZED);
     assert_eq!(
         err,

--- a/frontend/src/visual/menu.ts
+++ b/frontend/src/visual/menu.ts
@@ -4,11 +4,15 @@ import { exportPNG } from './canvas.js';
 export function createSearchInput(canvas: any) {
   const input = document.createElement('input');
   input.type = 'search';
-  input.placeholder = 'Search';
+  input.placeholder = 'Search (e.g. id:foo AND tag:bar)';
   input.addEventListener('input', () => {
     canvas.search(input.value);
   });
+  const hint = document.createElement('div');
+  hint.textContent = 'Use field:value and combine with AND/OR';
+  hint.className = 'search-hint';
   document.body.appendChild(input);
+  document.body.appendChild(hint);
   return input;
 }
 


### PR DESCRIPTION
## Summary
- parse simple AND/OR `field:value` expressions to filter VisualMeta entries
- expose GET /metadata with query parameter `q`
- show syntax hints in visual search box

## Testing
- `cargo test --quiet` *(fails: The system library `javascriptcoregtk-4.0` required by crate `javascriptcore-rs-sys` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899adcdcc98832384238a40fc159bd9