### PR TITLE
ci: install glib build deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y libglib2.0-dev libgtk-3-dev pkg-config
       - name: Run backend tests
         run: cargo test
         working-directory: backend


### PR DESCRIPTION
## Summary
- install glib/gtk pkg-config packages in backend CI job so gobject-sys and glib-sys build scripts can locate system libraries

## Testing
- `cargo build` *(fails: The system library `libsoup-2.4` required by crate `soup2-sys` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899b729f9b08323afd8a733db52151b