### PR TITLE
ci: add PKG_CONFIG_PATH for glib

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,8 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y libglib2.0-dev libgtk-3-dev pkg-config
+      - name: Set PKG_CONFIG_PATH
+        run: echo "PKG_CONFIG_PATH=/usr/lib/x86_64-linux-gnu/pkgconfig" >> $GITHUB_ENV
       - name: Run backend tests
         run: cargo test
         working-directory: backend

--- a/README.md
+++ b/README.md
@@ -51,6 +51,13 @@ Multicode V3 — редактор исходного кода, который о
      «`identifier` is a required property» и «Additional properties are not allowed».
      Удалите старую версию и поставьте CLI v2.
    - Проверьте установку командой `tauri --version`.
+4. **Системные библиотеки GTK/GLib**
+   - Установите пакеты:
+     ```bash
+     sudo apt-get install -y libglib2.0-dev libgtk-3-dev pkg-config
+     ```
+   - После установки задайте переменную окружения `PKG_CONFIG_PATH`, указывающую на каталог с файлами `gobject-2.0.pc` и `glib-2.0.pc` (обычно `/usr/lib/x86_64-linux-gnu/pkgconfig` или `/usr/lib/pkgconfig`).
+   - Добавьте строку `export PKG_CONFIG_PATH=/usr/lib/x86_64-linux-gnu/pkgconfig` в `~/.bashrc` или аналогичный профиль, чтобы переменная сохранялась между сессиями.
 
 ## Инструкции по запуску и сборке
 1. Установите зависимости и выполните тесты:


### PR DESCRIPTION
## Summary
- ensure CI exports PKG_CONFIG_PATH so pkg-config finds glib/gobject
- document setting PKG_CONFIG_PATH after installing GTK/GLib packages

## Testing
- `cargo test` (failed: The system library `libsoup-2.4` required by crate `soup2-sys` was not found.)
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899bcae6a948323b039d61afb6180a7