### PR TITLE
Use local Codemirror packages

### DIFF
--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -9,8 +9,9 @@
     #controls { padding: 0.5rem; }
   </style>
   <script type="module">
-    import { EditorState } from "https://cdn.jsdelivr.net/npm/@codemirror/state@6.4.0/dist/index.js";
-    import { EditorView, basicSetup } from "https://cdn.jsdelivr.net/npm/@codemirror/basic-setup@0.20.0/dist/index.js";
+    import { EditorState } from "@codemirror/state";
+    import { EditorView } from "@codemirror/view";
+    import { basicSetup } from "https://cdn.jsdelivr.net/npm/@codemirror/basic-setup@0.20.0/dist/index.js";
     import { javascript } from "https://cdn.jsdelivr.net/npm/@codemirror/lang-javascript@0.19.7/dist/index.js";
     import { python } from "https://cdn.jsdelivr.net/npm/@codemirror/lang-python@0.19.7/dist/index.js";
     import { rust } from "https://cdn.jsdelivr.net/npm/@codemirror/lang-rust@0.20.2/dist/index.js";

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,9 @@
       "name": "frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@codemirror/language": "^6.10.1",
+        "@codemirror/state": "^6.4.0",
+        "@codemirror/view": "^6.21.3",
         "@tauri-apps/api": "^1.0.0",
         "ajv": "^8.17.1",
         "ajv-formats": "^2.1.1",
@@ -42,6 +45,41 @@
         "bidi-js": "^1.0.3",
         "css-tree": "^2.3.1",
         "is-potential-custom-element-name": "^1.0.1"
+      }
+    },
+    "node_modules/@codemirror/language": {
+      "version": "6.11.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.11.2.tgz",
+      "integrity": "sha512-p44TsNArL4IVXDTbapUmEkAlvWs2CFQbcfc0ymDsis1kH2wh0gcY96AS29c/vp2d0y2Tquk1EDSaawpzilUiAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.23.0",
+        "@lezer/common": "^1.1.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0",
+        "style-mod": "^4.0.0"
+      }
+    },
+    "node_modules/@codemirror/state": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.5.2.tgz",
+      "integrity": "sha512-FVqsPqtPWKVVL3dPSxy8wEF/ymIEuVzF1PK3VbUgrxXpJUSHQWWZz4JMToquRxnkw+36LTamCZG2iua2Ptq0fA==",
+      "license": "MIT",
+      "dependencies": {
+        "@marijn/find-cluster-break": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/view": {
+      "version": "6.38.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.38.1.tgz",
+      "integrity": "sha512-RmTOkE7hRU3OVREqFVITWHz6ocgBjv08GoePscAakgVQfciA3SGCEk7mb9IzwW61cKKmlTpHXG6DUE5Ubx+MGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.5.0",
+        "crelt": "^1.0.6",
+        "style-mod": "^4.1.0",
+        "w3c-keyname": "^2.2.4"
       }
     },
     "node_modules/@csstools/color-helpers": {
@@ -568,6 +606,36 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.4.tgz",
       "integrity": "sha512-VT2+G1VQs/9oz078bLrYbecdZKs912zQlkelYpuf+SXF+QvZDYJlbx/LSx+meSAwdDFnF8FVXW92AVjjkVmgFw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@lezer/common": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.2.3.tgz",
+      "integrity": "sha512-w7ojc8ejBqr2REPsWxJjrMFsA/ysDCFICn8zEOR9mrqzOu2amhITYuLD8ag6XZf0CFXDrhKqw7+tW8cX66NaDA==",
+      "license": "MIT"
+    },
+    "node_modules/@lezer/highlight": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.1.tgz",
+      "integrity": "sha512-Z5duk4RN/3zuVO7Jq0pGLJ3qynpxUVsh7IbUbGj88+uV2ApSAn6kWg2au3iJb+0Zi7kKtqffIESgNcRXWZWmSA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/lr": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.2.tgz",
+      "integrity": "sha512-pu0K1jCIdnQ12aWNaAVU5bzi7Bd1w54J3ECgANPmYLtQKP0HBj2cE/5coBD66MT10xbtIuUr7tg0Shbsvk0mDA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@marijn/find-cluster-break": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
+      "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
       "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -1136,6 +1204,12 @@
       "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
       "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/crelt": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
+      "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
@@ -2270,6 +2344,12 @@
         "url": "https://github.com/sponsors/antfu"
       }
     },
+    "node_modules/style-mod": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.2.tgz",
+      "integrity": "sha512-wnD1HyVqpJUI2+eKZ+eo1UwghftP6yuFheBqqe+bWCotBjC2K1YnteJILRMs3SM4V/0dLEW1SC27MWP5y+mwmw==",
+      "license": "MIT"
+    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -2519,6 +2599,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "license": "MIT"
     },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,9 @@
     "build": "tauri build"
   },
   "dependencies": {
+    "@codemirror/language": "^6.10.1",
+    "@codemirror/state": "^6.4.0",
+    "@codemirror/view": "^6.21.3",
     "@tauri-apps/api": "^1.0.0",
     "ajv": "^8.17.1",
     "ajv-formats": "^2.1.1",

--- a/frontend/src/editor/minimap.ts
+++ b/frontend/src/editor/minimap.ts
@@ -1,4 +1,4 @@
-import { EditorView } from "https://cdn.jsdelivr.net/npm/@codemirror/view@6.21.3/dist/index.js";
+import { EditorView } from "@codemirror/view";
 
 /**
  * Attach a simple minimap to a CodeMirror editor.

--- a/frontend/src/editor/visual-meta.js
+++ b/frontend/src/editor/visual-meta.js
@@ -1,6 +1,6 @@
-import { StateField, RangeSetBuilder } from "https://cdn.jsdelivr.net/npm/@codemirror/state@6.4.0/dist/index.js";
-import { Decoration, EditorView } from "https://cdn.jsdelivr.net/npm/@codemirror/view@6.21.3/dist/index.js";
-import { hoverTooltip } from "https://cdn.jsdelivr.net/npm/@codemirror/language@6.10.1/dist/index.js";
+import { StateField, RangeSetBuilder } from "@codemirror/state";
+import { Decoration, EditorView } from "@codemirror/view";
+import { hoverTooltip } from "@codemirror/language";
 import schema from "./meta.schema.json" with { type: "json" };
 
 const tmplObj = () => ({

--- a/frontend/src/importer/annotate.js
+++ b/frontend/src/importer/annotate.js
@@ -1,6 +1,6 @@
 import { readTextFile, writeTextFile } from "@tauri-apps/api/fs";
 import path from "path";
-import { EditorView } from "https://cdn.jsdelivr.net/npm/@codemirror/view@6.21.3/dist/index.js";
+import { EditorView } from "@codemirror/view";
 import { insertVisualMeta } from "../editor/visual-meta.js";
 
 /**

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -14,8 +14,9 @@
     .cm-invalid-meta { text-decoration: wavy underline red; }
   </style>
   <script type="module">
-    import { EditorState } from "https://cdn.jsdelivr.net/npm/@codemirror/state@6.4.0/dist/index.js";
-    import { EditorView, basicSetup } from "https://cdn.jsdelivr.net/npm/@codemirror/basic-setup@0.20.0/dist/index.js";
+    import { EditorState } from "@codemirror/state";
+    import { EditorView } from "@codemirror/view";
+    import { basicSetup } from "https://cdn.jsdelivr.net/npm/@codemirror/basic-setup@0.20.0/dist/index.js";
     import { javascript } from "https://cdn.jsdelivr.net/npm/@codemirror/lang-javascript@0.19.7/dist/index.js";
     import { python } from "https://cdn.jsdelivr.net/npm/@codemirror/lang-python@0.19.7/dist/index.js";
     import { rust } from "https://cdn.jsdelivr.net/npm/@codemirror/lang-rust@0.20.2/dist/index.js";

--- a/frontend/tests/visual_sync.test.ts
+++ b/frontend/tests/visual_sync.test.ts
@@ -1,17 +1,17 @@
 import { describe, it, expect, vi } from 'vitest';
 
 // Mock Codemirror modules used by visual-meta.js
-vi.mock('https://cdn.jsdelivr.net/npm/@codemirror/state@6.4.0/dist/index.js', () => ({
+vi.mock('@codemirror/state', () => ({
   StateField: { define: vi.fn() },
   RangeSetBuilder: class {},
 }));
 
-vi.mock('https://cdn.jsdelivr.net/npm/@codemirror/view@6.21.3/dist/index.js', () => ({
+vi.mock('@codemirror/view', () => ({
   Decoration: { mark: () => ({}) },
   EditorView: { decorations: { from: vi.fn() }, updateListener: { of: vi.fn() } },
 }));
 
-vi.mock('https://cdn.jsdelivr.net/npm/@codemirror/language@6.10.1/dist/index.js', () => ({
+vi.mock('@codemirror/language', () => ({
   hoverTooltip: () => ({})
 }));
 


### PR DESCRIPTION
## Summary
- install @codemirror/state, @codemirror/view and @codemirror/language
- replace Codemirror CDN imports with package imports in editor and tests
- configure HTML entry to reference installed packages

## Testing
- `npm test`
- `npm run build` *(fails: tauri not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899dda4ac148323b1cd6a58853c9ab3