### PR TITLE
refactor: move block helpers into module

### DIFF
--- a/backend/src/blocks.rs
+++ b/backend/src/blocks.rs
@@ -1,0 +1,203 @@
+use std::cmp::Ordering;
+use std::collections::{hash_map::DefaultHasher, HashMap};
+use std::hash::{Hash, Hasher};
+
+use chrono::Utc;
+use tree_sitter::{InputEdit, Point};
+use syn::{File, Item};
+
+use crate::{
+    get_cached_blocks, get_document_tree, update_block_cache, update_document_tree, BlockInfo,
+    i18n,
+    meta::{read_all, remove_all, upsert, VisualMeta},
+    parser::{parse, parse_to_blocks, Lang},
+};
+
+#[cfg_attr(not(test), tauri::command)]
+pub fn parse_blocks(content: String, lang: String) -> Option<Vec<BlockInfo>> {
+    let lang = to_lang(&lang)?;
+    let mut hasher = DefaultHasher::new();
+    content.hash(&mut hasher);
+    let key = hasher.finish().to_string();
+    if let Some(blocks) = get_cached_blocks(&key, &content) {
+        return Some(blocks);
+    }
+    let old = get_document_tree("current");
+    let tree = if let Some(mut old_tree) = old {
+        let old_root = old_tree.root_node();
+        let old_end_byte = old_root.end_byte();
+        let old_end_position = old_root.end_position();
+        let new_end_byte = content.as_bytes().len();
+        let mut row = 0;
+        let mut column = 0;
+        for b in content.bytes() {
+            if b == b'\n' {
+                row += 1;
+                column = 0;
+            } else {
+                column += 1;
+            }
+        }
+        let new_end_position = Point { row, column };
+        let edit = InputEdit {
+            start_byte: 0,
+            old_end_byte,
+            new_end_byte,
+            start_position: Point { row: 0, column: 0 },
+            old_end_position,
+            new_end_position,
+        };
+        old_tree.edit(&edit);
+        parse(&content, lang, Some(&old_tree))?
+    } else {
+        parse(&content, lang, None)?
+    };
+    update_document_tree("current".to_string(), tree.clone());
+    let blocks = parse_to_blocks(&tree);
+    let metas = read_all(&content);
+    let map: HashMap<_, _> = metas.into_iter().map(|m| (m.id.clone(), m)).collect();
+    let result: Vec<BlockInfo> = blocks
+        .into_iter()
+        .map(|b| {
+            let label = normalize_kind(&b.kind);
+            let mut translations = i18n::lookup(&label).unwrap_or_else(|| {
+                let mut m = HashMap::new();
+                m.insert("ru".into(), label.clone());
+                m.insert("en".into(), label.clone());
+                m.insert("es".into(), label.clone());
+                m
+            });
+            if let Some(meta) = map.get(&b.visual_id) {
+                translations.extend(meta.translations.clone());
+            }
+            let pos = map.get(&b.visual_id);
+            BlockInfo {
+                visual_id: b.visual_id,
+                node_id: Some(b.node_id),
+                kind: label,
+                translations,
+                range: (b.range.start, b.range.end),
+                x: pos.map(|m| m.x).unwrap_or(0.0),
+                y: pos.map(|m| m.y).unwrap_or(0.0),
+                ai: pos.and_then(|m| m.ai.clone()),
+                links: pos.map(|m| m.links.clone()).unwrap_or_default(),
+            }
+        })
+        .collect();
+    update_block_cache(key, content, result.clone());
+    Some(result)
+}
+
+#[cfg_attr(not(test), tauri::command)]
+pub fn upsert_meta(content: String, mut meta: VisualMeta, lang: String) -> String {
+    meta.updated_at = Utc::now();
+    let mut metas = read_all(&content);
+    if let Some(existing) = metas.iter().find(|m| m.id == meta.id) {
+        if meta.version == 0 {
+            meta.version = existing.version;
+        }
+        if meta.translations.is_empty() {
+            meta.translations = existing.translations.clone();
+        }
+        if meta.ai.is_none() {
+            meta.ai = existing.ai.clone();
+        }
+        if meta.tags.is_empty() {
+            meta.tags = existing.tags.clone();
+        }
+        if meta.links.is_empty() {
+            meta.links = existing.links.clone();
+        }
+    }
+    if meta.version == 0 {
+        meta.version = 1;
+    }
+    metas.retain(|m| m.id != meta.id);
+    metas.push(meta);
+
+    let cleaned = remove_all(&content);
+    let lang = to_lang(&lang).unwrap_or(Lang::Rust);
+    let regenerated = regenerate_code(&cleaned, lang, &metas).unwrap_or(cleaned);
+
+    metas.into_iter().fold(regenerated, |acc, m| upsert(&acc, &m))
+}
+
+fn regenerate_code(content: &str, lang: Lang, metas: &[VisualMeta]) -> Option<String> {
+    match lang {
+        Lang::Rust => regenerate_rust(content, metas),
+        _ => Some(content.to_string()),
+    }
+}
+
+fn regenerate_rust(content: &str, metas: &[VisualMeta]) -> Option<String> {
+    let mut file: File = syn::parse_file(content).ok()?;
+    let tree = parse(content, Lang::Rust, None)?;
+    let blocks = parse_to_blocks(&tree);
+    let map: HashMap<_, _> = blocks
+        .into_iter()
+        .map(|b| (b.node_id, b.visual_id))
+        .collect();
+
+    let mut cursor = tree.root_node().walk();
+    let mut roots = Vec::new();
+    if cursor.goto_first_child() {
+        loop {
+            roots.push(cursor.node().id());
+            if !cursor.goto_next_sibling() {
+                break;
+            }
+        }
+    }
+
+    let mut items: Vec<(Item, (f64, f64))> = file
+        .items
+        .into_iter()
+        .zip(roots.into_iter())
+        .map(|(it, id)| {
+            let vid = map.get(&id).cloned().unwrap_or_default();
+            let pos = metas
+                .iter()
+                .find(|m| m.id == vid)
+                .map(|m| (m.y, m.x))
+                .unwrap_or((0.0, 0.0));
+            (it, pos)
+        })
+        .collect();
+
+    items.sort_by(|a, b| {
+        a.1 .0
+            .partial_cmp(&b.1 .0)
+            .unwrap_or(Ordering::Equal)
+            .then_with(|| a.1 .1.partial_cmp(&b.1 .1).unwrap_or(Ordering::Equal))
+    });
+
+    file.items = items.into_iter().map(|(it, _)| it).collect();
+    Some(prettyplease::unparse(&file))
+}
+
+pub fn to_lang(s: &str) -> Option<Lang> {
+    match s.to_lowercase().as_str() {
+        "rust" => Some(Lang::Rust),
+        "python" => Some(Lang::Python),
+        "javascript" => Some(Lang::JavaScript),
+        "css" => Some(Lang::Css),
+        "html" => Some(Lang::Html),
+        _ => None,
+    }
+}
+
+fn normalize_kind(kind: &str) -> String {
+    let k = kind.to_lowercase();
+    if k.contains("function") {
+        "Function".into()
+    } else if k.contains("if") {
+        "Condition".into()
+    } else if k.contains("for") || k.contains("while") || k.contains("loop") {
+        "Loop".into()
+    } else if k.contains("identifier") || k.contains("variable") {
+        "Variable".into()
+    } else {
+        kind.to_string()
+    }
+}
+

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -1,10 +1,14 @@
+pub mod blocks;
 pub mod debugger;
 pub mod export;
+mod i18n;
 pub mod meta;
 pub mod parser;
 pub mod plugins;
 pub mod search;
 pub mod server;
+
+pub use blocks::{parse_blocks, upsert_meta};
 
 use crate::meta::AiNote;
 use once_cell::sync::Lazy;

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1,29 +1,21 @@
-use std::cmp::Ordering;
-use std::collections::{hash_map::DefaultHasher, HashMap};
-use std::hash::{Hash, Hasher};
+use std::collections::HashMap;
 use std::sync::Mutex;
 mod config;
 mod debugger;
 mod export;
 mod git;
-mod i18n;
 mod meta;
 mod parser;
 mod plugins;
 mod server;
 pub use backend::BlockInfo;
-use backend::{
-    get_cached_blocks, get_document_tree, update_block_cache, update_document_tree, BlockInfo,
-};
-use chrono::Utc;
+use backend::blocks::{parse_blocks, to_lang, upsert_meta};
 use clap::{Parser, Subcommand};
 use debugger::{debug_break, debug_run, debug_step};
 use export::prepare_for_export;
 use meta::{fix_all, read_all, remove_all, upsert, AiNote, VisualMeta};
 use parser::{parse, parse_to_blocks, Lang};
-use syn::{File, Item};
 use tauri::State;
-use tree_sitter::{InputEdit, Point};
 
 #[derive(Default)]
 struct EditorState(Mutex<String>);
@@ -91,108 +83,6 @@ fn load_state(state: State<EditorState>) -> String {
     state.0.lock().unwrap().clone()
 }
 
-fn to_lang(s: &str) -> Option<Lang> {
-    match s.to_lowercase().as_str() {
-        "rust" => Some(Lang::Rust),
-        "python" => Some(Lang::Python),
-        "javascript" => Some(Lang::JavaScript),
-        "css" => Some(Lang::Css),
-        "html" => Some(Lang::Html),
-        _ => None,
-    }
-}
-
-#[cfg_attr(not(test), tauri::command)]
-fn normalize_kind(kind: &str) -> String {
-    let k = kind.to_lowercase();
-    if k.contains("function") {
-        "Function".into()
-    } else if k.contains("if") {
-        "Condition".into()
-    } else if k.contains("for") || k.contains("while") || k.contains("loop") {
-        "Loop".into()
-    } else if k.contains("identifier") || k.contains("variable") {
-        "Variable".into()
-    } else {
-        kind.to_string()
-    }
-}
-
-#[cfg_attr(not(test), tauri::command)]
-pub fn parse_blocks(content: String, lang: String) -> Option<Vec<BlockInfo>> {
-    let lang = to_lang(&lang)?;
-    let mut hasher = DefaultHasher::new();
-    content.hash(&mut hasher);
-    let key = hasher.finish().to_string();
-    if let Some(blocks) = get_cached_blocks(&key, &content) {
-        return Some(blocks);
-    }
-    let old = get_document_tree("current");
-    let tree = if let Some(mut old_tree) = old {
-        let old_root = old_tree.root_node();
-        let old_end_byte = old_root.end_byte();
-        let old_end_position = old_root.end_position();
-        let new_end_byte = content.as_bytes().len();
-        let mut row = 0;
-        let mut column = 0;
-        for b in content.bytes() {
-            if b == b'\n' {
-                row += 1;
-                column = 0;
-            } else {
-                column += 1;
-            }
-        }
-        let new_end_position = Point { row, column };
-        let edit = InputEdit {
-            start_byte: 0,
-            old_end_byte,
-            new_end_byte,
-            start_position: Point { row: 0, column: 0 },
-            old_end_position,
-            new_end_position,
-        };
-        old_tree.edit(&edit);
-        parse(&content, lang, Some(&old_tree))?
-    } else {
-        parse(&content, lang, None)?
-    };
-    update_document_tree("current".to_string(), tree.clone());
-    let blocks = parse_to_blocks(&tree);
-    let metas = read_all(&content);
-    let map: HashMap<_, _> = metas.into_iter().map(|m| (m.id.clone(), m)).collect();
-    let result: Vec<BlockInfo> = blocks
-        .into_iter()
-        .map(|b| {
-            let label = normalize_kind(&b.kind);
-            let mut translations = i18n::lookup(&label).unwrap_or_else(|| {
-                let mut m = HashMap::new();
-                m.insert("ru".into(), label.clone());
-                m.insert("en".into(), label.clone());
-                m.insert("es".into(), label.clone());
-                m
-            });
-            if let Some(meta) = map.get(&b.visual_id) {
-                translations.extend(meta.translations.clone());
-            }
-            let pos = map.get(&b.visual_id);
-            BlockInfo {
-                visual_id: b.visual_id,
-                node_id: Some(b.node_id),
-                kind: label,
-                translations,
-                range: (b.range.start, b.range.end),
-                x: pos.map(|m| m.x).unwrap_or(0.0),
-                y: pos.map(|m| m.y).unwrap_or(0.0),
-                ai: pos.and_then(|m| m.ai.clone()),
-                links: pos.map(|m| m.links.clone()).unwrap_or_default(),
-            }
-        })
-        .collect();
-    update_block_cache(key, content, result.clone());
-    Some(result)
-}
-
 #[cfg_attr(not(test), tauri::command)]
 fn suggest_ai_note(_content: String, _lang: String) -> AiNote {
     AiNote {
@@ -201,94 +91,7 @@ fn suggest_ai_note(_content: String, _lang: String) -> AiNote {
     }
 }
 
-fn regenerate_code(content: &str, lang: Lang, metas: &[VisualMeta]) -> Option<String> {
-    match lang {
-        Lang::Rust => regenerate_rust(content, metas),
-        _ => Some(content.to_string()),
-    }
-}
 
-fn regenerate_rust(content: &str, metas: &[VisualMeta]) -> Option<String> {
-    let mut file: File = syn::parse_file(content).ok()?;
-    let tree = parse(content, Lang::Rust, None)?;
-    let blocks = parse_to_blocks(&tree);
-    let map: HashMap<_, _> = blocks
-        .into_iter()
-        .map(|b| (b.node_id, b.visual_id))
-        .collect();
-
-    let mut cursor = tree.root_node().walk();
-    let mut roots = Vec::new();
-    if cursor.goto_first_child() {
-        loop {
-            roots.push(cursor.node().id());
-            if !cursor.goto_next_sibling() {
-                break;
-            }
-        }
-    }
-
-    let mut items: Vec<(Item, (f64, f64))> = file
-        .items
-        .into_iter()
-        .zip(roots.into_iter())
-        .map(|(it, id)| {
-            let vid = map.get(&id).cloned().unwrap_or_default();
-            let pos = metas
-                .iter()
-                .find(|m| m.id == vid)
-                .map(|m| (m.y, m.x))
-                .unwrap_or((0.0, 0.0));
-            (it, pos)
-        })
-        .collect();
-
-    items.sort_by(|a, b| {
-        a.1 .0
-            .partial_cmp(&b.1 .0)
-            .unwrap_or(Ordering::Equal)
-            .then_with(|| a.1 .1.partial_cmp(&b.1 .1).unwrap_or(Ordering::Equal))
-    });
-
-    file.items = items.into_iter().map(|(it, _)| it).collect();
-    Some(prettyplease::unparse(&file))
-}
-
-#[cfg_attr(not(test), tauri::command)]
-pub fn upsert_meta(content: String, mut meta: VisualMeta, lang: String) -> String {
-    meta.updated_at = Utc::now();
-    let mut metas = read_all(&content);
-    if let Some(existing) = metas.iter().find(|m| m.id == meta.id) {
-        if meta.version == 0 {
-            meta.version = existing.version;
-        }
-        if meta.translations.is_empty() {
-            meta.translations = existing.translations.clone();
-        }
-        if meta.ai.is_none() {
-            meta.ai = existing.ai.clone();
-        }
-        if meta.tags.is_empty() {
-            meta.tags = existing.tags.clone();
-        }
-        if meta.links.is_empty() {
-            meta.links = existing.links.clone();
-        }
-    }
-    if meta.version == 0 {
-        meta.version = 1;
-    }
-    metas.retain(|m| m.id != meta.id);
-    metas.push(meta);
-
-    let cleaned = remove_all(&content);
-    let lang = to_lang(&lang).unwrap_or(Lang::Rust);
-    let regenerated = regenerate_code(&cleaned, lang, &metas).unwrap_or(cleaned);
-
-    metas
-        .into_iter()
-        .fold(regenerated, |acc, m| upsert(&acc, &m))
-}
 
 #[cfg_attr(not(test), tauri::command)]
 fn export_file(path: String, strip_meta: bool, state: State<EditorState>) -> Result<(), String> {
@@ -407,6 +210,7 @@ fn main() {}
 #[cfg(test)]
 mod tests {
     use super::*;
+    use backend::blocks::{parse_blocks, upsert_meta};
     use chrono::Utc;
 
     #[test]

--- a/backend/src/meta/watch.rs
+++ b/backend/src/meta/watch.rs
@@ -1,4 +1,4 @@
-use crate::{parser::parse_blocks, BlockInfo};
+use crate::{blocks::parse_blocks, BlockInfo};
 use notify::{recommended_watcher, Event, EventKind, RecursiveMode, Watcher};
 use std::{env, fs, path::PathBuf, sync::mpsc::channel, thread};
 use tokio::sync::broadcast::Sender;

--- a/backend/src/server.rs
+++ b/backend/src/server.rs
@@ -28,8 +28,8 @@ use tracing::{error, info};
 use crate::meta::db;
 use crate::meta::{remove_all, watch, AiNote, VisualMeta};
 use crate::{
-    get_plugins_info, parse_blocks, reload_plugins_state, set_plugin_enabled, upsert_meta,
-    BlockInfo, PluginInfo,
+    blocks::{parse_blocks, upsert_meta},
+    get_plugins_info, reload_plugins_state, set_plugin_enabled, BlockInfo, PluginInfo,
 };
 use sqlx::{sqlite::SqlitePoolOptions, SqlitePool};
 


### PR DESCRIPTION
## Summary
- extract `parse_blocks` and `upsert_meta` into new `blocks` module
- expose module through `lib.rs` and update imports
- clean up references in server and metadata watcher

## Testing
- `cargo test -q` *(fails: could not compile `backend`)*

------
https://chatgpt.com/codex/tasks/task_e_6899f664b9ec832382473464627c3dca