### PR TITLE
Fix store borrowing in Wasm plugin read_string

### DIFF
--- a/backend/src/plugins/mod.rs
+++ b/backend/src/plugins/mod.rs
@@ -86,11 +86,11 @@ impl WasmPlugin {
             func: &str,
         ) -> Option<String> {
             let f = instance
-                .get_typed_func::<(), (i32, i32)>(store, func)
+                .get_typed_func::<(), (i32, i32)>(&mut *store, func)
                 .ok()?;
-            let (ptr, len) = f.call(store, ()).ok()?;
+            let (ptr, len) = f.call(&mut *store, ()).ok()?;
             let data = memory
-                .data(store)
+                .data(&mut *store)
                 .get(ptr as usize..(ptr as usize + len as usize))?;
             String::from_utf8(data.to_vec()).ok()
         }


### PR DESCRIPTION
## Summary
- reborrow `store` when retrieving and calling wasm functions
- pass reborrowed store to `memory.data` to avoid moving

## Testing
- `cargo test` *(fails: unresolved import `crate::config`)*

------
https://chatgpt.com/codex/tasks/task_e_689a021153908323bc005bff25a0b973