### PR TITLE
Expose backend config module

### DIFF
--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod blocks;
+pub mod config;
 pub mod debugger;
 pub mod export;
 mod i18n;


### PR DESCRIPTION
## Summary
- make backend configuration available by exporting the `config` module

## Testing
- `cargo fmt`
- `cargo test` *(fails: could not compile `backend` (lib test) due to 5 previous errors)*

------
https://chatgpt.com/codex/tasks/task_e_689a0d7dc64c8323b41351dbf60d251a