### PR TITLE
Expose SuggestRequest for serialization

### DIFF
--- a/backend/src/server.rs
+++ b/backend/src/server.rs
@@ -315,7 +315,7 @@ async fn plugins_update(
     Ok(Json(get_plugins_info()))
 }
 
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 struct SuggestRequest {
     content: String,
     lang: String,


### PR DESCRIPTION
## Summary
- derive `Serialize` for `SuggestRequest`
- ensure `serde` imports both Serialize and Deserialize

## Testing
- `cargo test --manifest-path backend/Cargo.toml` *(fails: mismatched types and missing method errors)*

------
https://chatgpt.com/codex/tasks/task_e_689a1099f308832397567f182dc79b2e