### PR TITLE
Use MemoryType API for plugin memory limits

### DIFF
--- a/backend/src/plugins/mod.rs
+++ b/backend/src/plugins/mod.rs
@@ -74,8 +74,8 @@ impl WasmPlugin {
         let memory = instance.get_memory(&mut store, "memory")?;
 
         // Restrict memory to a single page (64 KiB).
-        let limits = memory.ty(&store).limits();
-        if limits.minimum() > 1 || limits.maximum().map_or(true, |m| m > 1) {
+        let ty = memory.ty(&store);
+        if ty.minimum() > 1 || ty.maximum().map_or(true, |m| m > 1) {
             return None;
         }
 
@@ -86,11 +86,11 @@ impl WasmPlugin {
             func: &str,
         ) -> Option<String> {
             let f = instance
-                .get_typed_func::<(), (i32, i32)>(store, func)
+                .get_typed_func::<(), (i32, i32)>(&mut *store, func)
                 .ok()?;
-            let (ptr, len) = f.call(store, ()).ok()?;
+            let (ptr, len) = f.call(&mut *store, ()).ok()?;
             let data = memory
-                .data(store)
+                .data(&store)
                 .get(ptr as usize..(ptr as usize + len as usize))?;
             String::from_utf8(data.to_vec()).ok()
         }


### PR DESCRIPTION
## Summary
- switch wasm plugin memory checks to use `MemoryType` minimum/maximum
- adjust plugin string reading to reborrow store after API change

## Testing
- `cargo test` *(fails: mismatched types in backend/src/blocks.rs)*

------
https://chatgpt.com/codex/tasks/task_e_689a137b7b8883239e4965afefce50c6