### PR TITLE
Refactor binary imports to use backend library

### DIFF
--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -2,6 +2,7 @@ pub mod blocks;
 pub mod config;
 pub mod debugger;
 pub mod export;
+pub mod git;
 mod i18n;
 pub mod meta;
 pub mod parser;


### PR DESCRIPTION
## Summary
- use backend library modules directly in binary entry point
- expose git module from library for reuse

## Testing
- `cargo test --lib` *(fails: search::tests::search_and_goto_work)*

------
https://chatgpt.com/codex/tasks/task_e_689a35e95f348323bfd87afc05535dd2