### PR TITLE
ci: install libsoup and webkit dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
       - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y libglib2.0-dev libgtk-3-dev pkg-config
+        run: sudo apt-get update && sudo apt-get install -y libglib2.0-dev libgtk-3-dev libsoup-3.0-dev libwebkit2gtk-4.1-dev pkg-config
       - name: Set PKG_CONFIG_PATH
         run: echo "PKG_CONFIG_PATH=/usr/lib/x86_64-linux-gnu/pkgconfig" >> $GITHUB_ENV
       - name: Install cargo-audit


### PR DESCRIPTION
## Summary
- add libsoup-3.0-dev and libwebkit2gtk-4.1-dev to CI system dependencies for backend build

## Testing
- `cargo test` *(fails: meta::tests::fix_all_replaces_duplicate_ids)*

------
https://chatgpt.com/codex/tasks/task_e_689a54a0bfec8323a5ecb70ab2c41f29