### PR TITLE
fix(meta): preserve explicit version

### DIFF
--- a/backend/src/meta/mod.rs
+++ b/backend/src/meta/mod.rs
@@ -13,7 +13,7 @@ pub use types::{AiNote, VisualMeta};
 const MARKER: &str = "@VISUAL_META";
 
 fn migrate(meta: &mut VisualMeta) {
-    if meta.version == 0 {
+    if meta.version < 1 {
         meta.version = 1;
     }
 }


### PR DESCRIPTION
## Summary
- keep explicit metadata versions by only migrating when version < 1

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_689a598e945883239dfd89f2dbd88796