### PR TITLE
Ensure VisualMeta defaults to version 1

### DIFF
--- a/backend/src/meta/mod.rs
+++ b/backend/src/meta/mod.rs
@@ -7,14 +7,14 @@ pub mod id_registry;
 pub mod watch;
 mod types;
 pub mod query;
-pub use types::{AiNote, VisualMeta};
+pub use types::{AiNote, VisualMeta, DEFAULT_VERSION};
 
 /// Marker used to identify visual metadata comments in documents.
 const MARKER: &str = "@VISUAL_META";
 
 fn migrate(meta: &mut VisualMeta) {
-    if meta.version < 1 {
-        meta.version = 1;
+    if meta.version < DEFAULT_VERSION {
+        meta.version = DEFAULT_VERSION;
     }
 }
 

--- a/backend/src/meta/types.rs
+++ b/backend/src/meta/types.rs
@@ -4,8 +4,11 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
 
+/// Начальное значение версии схемы метаданных.
+pub const DEFAULT_VERSION: u32 = 1;
+
 fn default_version() -> u32 {
-    1
+    DEFAULT_VERSION
 }
 
 /// Additional notes provided by AI.


### PR DESCRIPTION
## Summary
- introduce `DEFAULT_VERSION` constant for metadata
- use the constant in migration logic

## Testing
- `cargo test --test version -- --nocapture`
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_689aa7a5c10c832396a2e49d5bfa3575