### PR TITLE
docs: add manual testing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,3 +361,16 @@ cargo build --target wasm32-unknown-unknown --release
 
 ## Лицензия
 Проект распространяется по лицензии MIT. Полный текст приведён в файле [LICENSE](LICENSE).
+
+## Ручное тестирование
+
+Сценарии ручной проверки описаны в [NODE_EDITOR_MANUAL_TESTS.md](NODE_EDITOR_MANUAL_TESTS.md).
+
+1. Выполните `npm run dev`.
+2. После запуска приложения следуйте шагам из документа.
+
+Например, чтобы открыть приложение с тестовым файлом `examples/test.js`:
+
+```bash
+npm run dev -- examples/test.js
+```


### PR DESCRIPTION
## Summary
- document manual test scenarios and startup instructions

## Testing
- `npm --prefix frontend test`
- `cargo test --manifest-path backend/Cargo.toml` *(fails: system library `javascriptcoregtk-4.1` missing)*

------
https://chatgpt.com/codex/tasks/task_e_689ad21d6944832382e7514b25264ce7