### PR TITLE
Fix CLI test for new missing file error message

### DIFF
--- a/backend/tests/cli.rs
+++ b/backend/tests/cli.rs
@@ -14,7 +14,7 @@ fn parse_reports_missing_file() {
     assert!(!output.status.success());
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        stderr.contains("Failed to read file"),
+        stderr.contains("does not exist"),
         "unexpected stderr: {stderr}"
     );
 }


### PR DESCRIPTION
## Summary
- adjust CLI test to match current "file not found" message

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_689b192713488323951619001e0a9b98