### PR TITLE
Require auth token unless explicitly disabled in dev

### DIFF
--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -7,6 +7,8 @@ pub struct ServerConfig {
     pub port: u16,
     pub token: Option<String>,
     pub api_key: Option<String>,
+    /// Disable authentication (debug builds only)
+    pub disable_auth: bool,
 }
 
 impl Default for ServerConfig {
@@ -16,6 +18,7 @@ impl Default for ServerConfig {
             port: 3001,
             token: None,
             api_key: None,
+            disable_auth: false,
         }
     }
 }


### PR DESCRIPTION
## Summary
- require authentication token by default
- allow disabling auth through SERVER_DISABLE_AUTH in debug builds

## Testing
- `cargo test` *(fails: build did not complete; compiled dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_689b1f96f06c8323b9f829fc7c5df27a