### PR TITLE
Limit request body size and validate language parameter

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -237,6 +237,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-tungstenite",
+ "tower-http 0.4.4",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
@@ -1883,6 +1884,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-range-header"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "add0ab9360ddbd88cfeb3bd9574a1d85cfdfa14db10b3e21d3700dbc4328758f"
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2744,7 +2751,7 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77e878c846a8abae00dd069496dbe8751b16ac1c3d6bd2a7283a938e8228f90d"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 2.0.0",
  "proc-macro2",
  "quote",
  "syn 2.0.104",
@@ -3707,7 +3714,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tower 0.5.2",
- "tower-http",
+ "tower-http 0.6.6",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -5121,6 +5128,24 @@ dependencies = [
  "pin-project-lite",
  "sync_wrapper 1.0.2",
  "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c5bb1d698276a2443e5ecfabc1008bf15a36c12e6a7176e7bf089ea9131140"
+dependencies = [
+ "bitflags 2.9.1",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "http-range-header",
+ "pin-project-lite",
  "tower-layer",
  "tower-service",
 ]

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -40,6 +40,7 @@ chrono = { version = "0.4", features = ["serde"] }
 sqlx = { version = "0.8", default-features = false, features = ["sqlite", "runtime-tokio-rustls"] }
 
 schemars = { version = "0.8", features = ["derive", "chrono"] }
+tower-http = { version = "0.4", features = ["limit"] }
 
 [dev-dependencies]
 tempfile = "3"


### PR DESCRIPTION
## Summary
- add tower-http dependency and limit request body to 1 MiB
- validate `lang` against supported languages in API endpoints

## Testing
- `cargo test` *(build in progress; terminated early after compiling crates)*

------
https://chatgpt.com/codex/tasks/task_e_689b27279a4483238cf9e6211effb0b7