### PR TITLE
Return generic Bad Request for unsupported languages

### DIFF
--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1,5 +1,7 @@
-use std::path::Path;
 use std::sync::Mutex;
+
+#[cfg(not(test))]
+use std::path::Path;
 
 #[cfg(not(test))]
 use backend::blocks::{__cmd__parse_blocks, __cmd__upsert_meta};

--- a/backend/src/server.rs
+++ b/backend/src/server.rs
@@ -108,7 +108,7 @@ pub async fn parse_endpoint(
             status,
             Json(ErrorResponse {
                 code: status.as_u16(),
-                message: format!("Unsupported language: {}", req.lang),
+                message: "Bad Request".into(),
             }),
         ));
     }
@@ -184,7 +184,7 @@ pub async fn metadata_upsert_endpoint(
             status,
             Json(ErrorResponse {
                 code: status.as_u16(),
-                message: format!("Unsupported language: {}", req.lang),
+                message: "Bad Request".into(),
             }),
         ));
     }
@@ -369,7 +369,7 @@ async fn suggest_endpoint(
             status,
             Json(ErrorResponse {
                 code: status.as_u16(),
-                message: format!("Unsupported language: {}", req.lang),
+                message: "Bad Request".into(),
             }),
         ));
     }


### PR DESCRIPTION
## Summary
- respond with a generic "Bad Request" when language is unsupported
- gate `Path` import in `main.rs` behind `#[cfg(not(test))]` to avoid warnings

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_689b2dee62ac83238ca845bf7aba6da7