### PR TITLE
Restrict git commit paths and harden diff logging

### DIFF
--- a/backend/src/git.rs
+++ b/backend/src/git.rs
@@ -1,9 +1,17 @@
 use git2::{Repository, IndexAddOption, DiffOptions, BranchType, Commit};
+use tracing::error;
 
 pub fn commit(message: &str) -> Result<(), git2::Error> {
+    if message.trim().is_empty() {
+        return Err(git2::Error::from_str("commit message cannot be empty"));
+    }
+
     let repo = Repository::discover(".")?;
     let mut index = repo.index()?;
-    index.add_all(["*"].iter(), IndexAddOption::DEFAULT, None)?;
+    // Limit the paths that can be added to the index to avoid accidentally
+    // committing large or unrelated directories.
+    let paths = ["backend", "frontend", "docs"];
+    index.add_all(paths.iter(), IndexAddOption::DEFAULT, None)?;
     index.write()?;
     let tree_id = index.write_tree()?;
     let tree = repo.find_tree(tree_id)?;
@@ -16,15 +24,33 @@ pub fn commit(message: &str) -> Result<(), git2::Error> {
 }
 
 pub fn diff() -> Result<String, git2::Error> {
+    const MAX_DIFF_LEN: usize = 100_000; // Limit diff output to ~100 KB
+
     let repo = Repository::discover(".")?;
     let mut opts = DiffOptions::new();
     opts.include_untracked(true);
     let diff = repo.diff_index_to_workdir(None, Some(&mut opts))?;
     let mut out = String::new();
+
     diff.print(git2::DiffFormat::Patch, |_delta, _hunk, line| {
-        out.push_str(std::str::from_utf8(line.content()).unwrap_or(""));
-        true
+        match std::str::from_utf8(line.content()) {
+            Ok(s) => {
+                if out.len() + s.len() <= MAX_DIFF_LEN {
+                    out.push_str(s);
+                    true
+                } else {
+                    let remaining = MAX_DIFF_LEN.saturating_sub(out.len());
+                    out.push_str(&s[..remaining]);
+                    false
+                }
+            }
+            Err(e) => {
+                error!("diff decode error: {e}");
+                true
+            }
+        }
     })?;
+
     Ok(out)
 }
 


### PR DESCRIPTION
## Summary
- guard against empty commit messages and restrict which paths are staged
- add error logging and size limit to git diff output

## Testing
- `cargo test` *(fails: The system library `javascriptcoregtk-4.1` required by crate `javascriptcore-rs-sys` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b381a2b648323935638156c26bd1e