### PR TITLE
backend: configure HTTP client

### DIFF
--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -7,6 +7,9 @@ pub struct ServerConfig {
     pub port: u16,
     pub token: Option<String>,
     pub api_key: Option<String>,
+    pub api_base_url: String,
+    pub connect_timeout_secs: u64,
+    pub request_timeout_secs: u64,
     /// Disable authentication (debug builds only)
     pub disable_auth: bool,
 }
@@ -18,6 +21,9 @@ impl Default for ServerConfig {
             port: 3001,
             token: None,
             api_key: None,
+            api_base_url: "https://api.example.com".into(),
+            connect_timeout_secs: 5,
+            request_timeout_secs: 30,
             disable_auth: false,
         }
     }


### PR DESCRIPTION
## Summary
- make suggestion API base URL and timeouts configurable
- reuse a single reqwest client via OnceCell
- log external request errors

## Testing
- `cargo test`
- `npm test` *(fails: Tests failed after setup)*

------
https://chatgpt.com/codex/tasks/task_e_689b3ec502ec83239959a21e5c987613