### PR TITLE
refactor: split block parsing into modules

### DIFF
--- a/backend/src/blocks/cache.rs
+++ b/backend/src/blocks/cache.rs
@@ -1,0 +1,21 @@
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+
+use crate::{get_cached_blocks, update_block_cache, BlockInfo};
+
+/// Generate a stable cache key based on the file `content`.
+pub fn key(content: &str) -> String {
+    let mut hasher = DefaultHasher::new();
+    content.hash(&mut hasher);
+    hasher.finish().to_string()
+}
+
+/// Try to retrieve cached block information for `key` and `content`.
+pub fn get(key: &str, content: &str) -> Option<Vec<BlockInfo>> {
+    get_cached_blocks(key, content)
+}
+
+/// Store parsed block information in the cache under `key`.
+pub fn store(key: String, content: String, blocks: Vec<BlockInfo>) {
+    update_block_cache(key, content, blocks);
+}

--- a/backend/src/blocks/enrich.rs
+++ b/backend/src/blocks/enrich.rs
@@ -1,0 +1,95 @@
+use std::collections::HashMap;
+
+use crate::{i18n, meta::read_all, parser::Block, BlockInfo};
+
+/// Combine raw `blocks` with metadata extracted from `content`.
+///
+/// Each block receives default translations based on its kind and is then
+/// enriched with positional and custom metadata when available.
+pub fn enrich_blocks(blocks: Vec<Block>, content: &str) -> Vec<BlockInfo> {
+    let metas = read_all(content);
+    let map: HashMap<_, _> = metas.into_iter().map(|m| (m.id.clone(), m)).collect();
+
+    blocks
+        .into_iter()
+        .map(|b| {
+            let label = normalize_kind(&b.kind);
+            let mut translations = i18n::lookup(&label).unwrap_or_else(|| {
+                let mut m = HashMap::new();
+                m.insert("ru".into(), label.clone());
+                m.insert("en".into(), label.clone());
+                m.insert("es".into(), label.clone());
+                m
+            });
+            if let Some(meta) = map.get(&b.visual_id) {
+                translations.extend(meta.translations.clone());
+            }
+            let pos = map.get(&b.visual_id);
+            BlockInfo {
+                visual_id: b.visual_id,
+                node_id: Some(b.node_id),
+                kind: label,
+                translations,
+                range: (b.range.start, b.range.end),
+                x: pos.map(|m| m.x).unwrap_or(0.0),
+                y: pos.map(|m| m.y).unwrap_or(0.0),
+                ai: pos.and_then(|m| m.ai.clone()),
+                links: pos.map(|m| m.links.clone()).unwrap_or_default(),
+            }
+        })
+        .collect()
+}
+
+fn normalize_kind(kind: &str) -> String {
+    let k = kind.to_lowercase();
+    if k.contains("function") {
+        "Function".into()
+    } else if k.contains("if") {
+        "Condition".into()
+    } else if k.contains("for") || k.contains("while") || k.contains("loop") {
+        "Loop".into()
+    } else if k.contains("identifier") || k.contains("variable") {
+        "Variable".into()
+    } else {
+        kind.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parser::Block;
+
+    #[test]
+    fn enrich_without_metadata() {
+        let block = Block {
+            visual_id: "1".into(),
+            node_id: 1,
+            kind: "function".into(),
+            range: 0..5,
+        };
+        let res = enrich_blocks(vec![block], "");
+        assert_eq!(res.len(), 1);
+        let b = &res[0];
+        assert_eq!(b.x, 0.0);
+        assert_eq!(b.y, 0.0);
+        assert!(b.translations.get("en").is_some());
+    }
+
+    #[test]
+    fn enrich_with_metadata() {
+        let block = Block {
+            visual_id: "42".into(),
+            node_id: 1,
+            kind: "function".into(),
+            range: 0..5,
+        };
+        let content = "<!-- @VISUAL_META {\"id\":\"42\",\"x\":1.0,\"y\":2.0,\"translations\":{\"en\":\"Test\"}} -->";
+        let res = enrich_blocks(vec![block], content);
+        assert_eq!(res.len(), 1);
+        let b = &res[0];
+        assert_eq!(b.x, 1.0);
+        assert_eq!(b.y, 2.0);
+        assert_eq!(b.translations.get("en").unwrap(), "Test");
+    }
+}

--- a/backend/src/blocks/parsing.rs
+++ b/backend/src/blocks/parsing.rs
@@ -1,0 +1,43 @@
+use tree_sitter::{InputEdit, Point};
+
+use crate::{get_document_tree, update_document_tree};
+use crate::parser::{parse as ts_parse, parse_to_blocks, Block, Lang};
+
+/// Parse source `content` of language `lang` into syntax `Block`s.
+///
+/// Reuses the previously stored parse tree for incremental parsing when
+/// available, updating the cached tree after parsing.
+pub fn parse(content: &str, lang: Lang) -> Option<Vec<Block>> {
+    let old = get_document_tree("current");
+    let tree = if let Some(mut old_tree) = old {
+        let old_root = old_tree.root_node();
+        let old_end_byte = old_root.end_byte();
+        let old_end_position = old_root.end_position();
+        let new_end_byte = content.as_bytes().len();
+        let mut row = 0;
+        let mut column = 0;
+        for b in content.bytes() {
+            if b == b'\n' {
+                row += 1;
+                column = 0;
+            } else {
+                column += 1;
+            }
+        }
+        let new_end_position = Point { row, column };
+        let edit = InputEdit {
+            start_byte: 0,
+            old_end_byte,
+            new_end_byte,
+            start_position: Point { row: 0, column: 0 },
+            old_end_position,
+            new_end_position,
+        };
+        old_tree.edit(&edit);
+        ts_parse(content, lang, Some(&old_tree))?
+    } else {
+        ts_parse(content, lang, None)?
+    };
+    update_document_tree("current".to_string(), tree.clone());
+    Some(parse_to_blocks(&tree))
+}


### PR DESCRIPTION
## Summary
- separate block parsing into cache, parsing, and metadata enrichment modules
- document each module and add edge case tests

## Testing
- `cargo test` *(fails: The system library `gobject-2.0` required by crate `gobject-sys` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b508da0e883239a94054bfdf114af