### PR TITLE
Handle plugin manager server errors gracefully

### DIFF
--- a/frontend/src/plugins/manager.test.ts
+++ b/frontend/src/plugins/manager.test.ts
@@ -1,0 +1,56 @@
+/* @vitest-environment jsdom */
+
+import { describe, it, expect, vi } from 'vitest';
+import { initPluginManager } from './manager';
+
+describe('initPluginManager', () => {
+  it('alerts when plugin list fails to load', async () => {
+    const container = document.createElement('div');
+    const fetchMock = vi.fn().mockResolvedValue({ ok: false });
+    const alertMock = vi.fn();
+    const originalFetch = globalThis.fetch;
+    const originalAlert = (globalThis as any).alert;
+    // @ts-ignore
+    globalThis.fetch = fetchMock;
+    // @ts-ignore
+    globalThis.alert = alertMock;
+
+    await initPluginManager(container);
+
+    expect(alertMock).toHaveBeenCalled();
+
+    globalThis.fetch = originalFetch;
+    // @ts-ignore
+    globalThis.alert = originalAlert;
+  });
+
+  it('alerts when plugin update fails', async () => {
+    const container = document.createElement('div');
+    const plugins = [{ name: 'test', version: '1.0.0', enabled: false }];
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => plugins })
+      .mockResolvedValueOnce({ ok: false });
+    const alertMock = vi.fn();
+    const originalFetch = globalThis.fetch;
+    const originalAlert = (globalThis as any).alert;
+    // @ts-ignore
+    globalThis.fetch = fetchMock;
+    // @ts-ignore
+    globalThis.alert = alertMock;
+
+    await initPluginManager(container);
+
+    const checkbox = container.querySelector('input') as HTMLInputElement;
+    checkbox.checked = true;
+    checkbox.dispatchEvent(new Event('change'));
+    await Promise.resolve();
+
+    expect(alertMock).toHaveBeenCalled();
+    expect(checkbox.checked).toBe(false);
+
+    globalThis.fetch = originalFetch;
+    // @ts-ignore
+    globalThis.alert = originalAlert;
+  });
+});

--- a/frontend/src/plugins/manager.ts
+++ b/frontend/src/plugins/manager.ts
@@ -6,7 +6,10 @@ export interface PluginInfo {
 
 export async function initPluginManager(container: HTMLElement) {
   const res = await fetch('/plugins');
-  if (!res.ok) return;
+  if (!res.ok) {
+    alert('Failed to load plugins');
+    return;
+  }
   const plugins: PluginInfo[] = await res.json();
   container.innerHTML = '';
   plugins.forEach(p => {
@@ -16,14 +19,24 @@ export async function initPluginManager(container: HTMLElement) {
     checkbox.type = 'checkbox';
     checkbox.checked = p.enabled;
     checkbox.addEventListener('change', async () => {
-      await fetch('/plugins', {
+      const res = await fetch('/plugins', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ name: p.name, enabled: checkbox.checked })
       });
+      if (!res.ok) {
+        alert('Failed to update plugin');
+        checkbox.checked = !checkbox.checked;
+      }
     });
     label.appendChild(checkbox);
-    label.append(` ${p.name} (${p.version})`);
+    label.append(' ');
+    const nameSpan = document.createElement('span');
+    nameSpan.textContent = p.name;
+    label.appendChild(nameSpan);
+    const versionSpan = document.createElement('span');
+    versionSpan.textContent = ' (' + p.version + ')';
+    label.appendChild(versionSpan);
     row.appendChild(label);
     container.appendChild(row);
   });


### PR DESCRIPTION
## Summary
- alert user when loading plugins fails or toggling plugin fails
- sanitize plugin names using textContent
- add tests for server error scenarios

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b54a21c848323bc1ffdfe4241cd8b