### PR TITLE
test: add coverage for git and plugins

### DIFF
--- a/backend/src/server.rs
+++ b/backend/src/server.rs
@@ -339,12 +339,12 @@ async fn plugins_get(headers: HeaderMap) -> Result<Json<Vec<PluginInfo>>, Status
 }
 
 #[derive(Deserialize)]
-struct PluginToggle {
-    name: String,
-    enabled: bool,
+pub struct PluginToggle {
+    pub name: String,
+    pub enabled: bool,
 }
 
-async fn plugins_update(
+pub async fn plugins_update(
     headers: HeaderMap,
     Json(req): Json<PluginToggle>,
 ) -> Result<Json<Vec<PluginInfo>>, StatusCode> {

--- a/backend/tests/commit.rs
+++ b/backend/tests/commit.rs
@@ -1,0 +1,44 @@
+use backend::git::commit;
+use git2::Repository;
+use tempfile::tempdir;
+use std::fs;
+use std::env;
+
+#[test]
+fn commit_creates_commit() {
+    let dir = tempdir().unwrap();
+    let repo = Repository::init(dir.path()).unwrap();
+    {
+        let mut cfg = repo.config().unwrap();
+        cfg.set_str("user.name", "Tester").unwrap();
+        cfg.set_str("user.email", "test@example.com").unwrap();
+    }
+    fs::create_dir(dir.path().join("backend")).unwrap();
+    fs::write(dir.path().join("backend/file.txt"), "hello").unwrap();
+
+    let prev = env::current_dir().unwrap();
+    env::set_current_dir(dir.path()).unwrap();
+    commit("initial commit").unwrap();
+    env::set_current_dir(prev).unwrap();
+
+    let head = repo.head().unwrap().peel_to_commit().unwrap();
+    assert_eq!(head.summary(), Some("initial commit"));
+}
+
+#[test]
+fn commit_empty_message_error() {
+    let dir = tempdir().unwrap();
+    let repo = Repository::init(dir.path()).unwrap();
+    {
+        let mut cfg = repo.config().unwrap();
+        cfg.set_str("user.name", "Tester").unwrap();
+        cfg.set_str("user.email", "test@example.com").unwrap();
+    }
+
+    let prev = env::current_dir().unwrap();
+    env::set_current_dir(dir.path()).unwrap();
+    let err = commit("").unwrap_err();
+    env::set_current_dir(prev).unwrap();
+    assert_eq!(err.message(), "commit message cannot be empty");
+}
+

--- a/backend/tests/diff.rs
+++ b/backend/tests/diff.rs
@@ -1,0 +1,40 @@
+use backend::git::{commit, diff};
+use git2::{Repository, ErrorCode};
+use tempfile::tempdir;
+use std::fs;
+use std::env;
+
+#[test]
+fn diff_shows_changes() {
+    let dir = tempdir().unwrap();
+    let repo = Repository::init(dir.path()).unwrap();
+    {
+        let mut cfg = repo.config().unwrap();
+        cfg.set_str("user.name", "Tester").unwrap();
+        cfg.set_str("user.email", "test@example.com").unwrap();
+    }
+    fs::create_dir(dir.path().join("backend")).unwrap();
+    let file_path = dir.path().join("backend/file.txt");
+    fs::write(&file_path, "line1\n").unwrap();
+
+    let prev = env::current_dir().unwrap();
+    env::set_current_dir(dir.path()).unwrap();
+    commit("initial").unwrap();
+    fs::write(&file_path, "line1\nline2\n").unwrap();
+    let out = diff().unwrap();
+    env::set_current_dir(prev).unwrap();
+
+    assert!(out.contains("line2"));
+    assert!(out.contains("backend/file.txt"));
+}
+
+#[test]
+fn diff_errors_outside_repo() {
+    let dir = tempdir().unwrap();
+    let prev = env::current_dir().unwrap();
+    env::set_current_dir(dir.path()).unwrap();
+    let err = diff().unwrap_err();
+    env::set_current_dir(prev).unwrap();
+    assert_eq!(err.code(), ErrorCode::NotFound);
+}
+

--- a/backend/tests/plugins_update.rs
+++ b/backend/tests/plugins_update.rs
@@ -1,0 +1,44 @@
+use axum::{http::{HeaderMap, StatusCode, header}, Json};
+use backend::config::ServerConfig;
+use backend::server::{plugins_update, PluginToggle, SERVER_CONFIG};
+use backend::reload_plugins_state;
+use std::path::PathBuf;
+use std::fs;
+
+struct SettingsGuard {
+    path: PathBuf,
+    data: String,
+}
+impl Drop for SettingsGuard {
+    fn drop(&mut self) {
+        fs::write(&self.path, &self.data).unwrap();
+        reload_plugins_state();
+    }
+}
+
+#[tokio::test]
+async fn plugins_update_toggles_plugin() {
+    let settings_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../frontend/settings.json");
+    let original = fs::read_to_string(&settings_path).unwrap();
+    let _guard = SettingsGuard { path: settings_path.clone(), data: original };
+
+    let _ = SERVER_CONFIG.set(ServerConfig { token: Some("secret".into()), ..Default::default() });
+    let mut headers = HeaderMap::new();
+    headers.insert(header::AUTHORIZATION, "Bearer secret".parse().unwrap());
+    let body = PluginToggle { name: "test".into(), enabled: false };
+
+    let _ = plugins_update(headers, Json(body)).await.unwrap();
+
+    let json: serde_json::Value = serde_json::from_str(&fs::read_to_string(&settings_path).unwrap()).unwrap();
+    assert_eq!(json["plugins"]["test"], false);
+}
+
+#[tokio::test]
+async fn plugins_update_requires_auth() {
+    let _ = SERVER_CONFIG.set(ServerConfig { token: Some("secret".into()), ..Default::default() });
+    let headers = HeaderMap::new();
+    let body = PluginToggle { name: "test".into(), enabled: true };
+    let err = plugins_update(headers, Json(body)).await.err().unwrap();
+    assert_eq!(err, StatusCode::UNAUTHORIZED);
+}
+


### PR DESCRIPTION
## Summary
- test git commit helper with temp repositories
- test git diff helper and error case
- test plugins update endpoint including auth failure

## Testing
- `cargo test --test commit`
- `cargo test --test diff`
- `cargo test --test plugins_update`


------
https://chatgpt.com/codex/tasks/task_e_689b7ae4bfc08323be8ba88b9c524521