### PR TITLE
feat: add hotkey help modal

### DIFF
--- a/frontend/src/hotkeys.css
+++ b/frontend/src/hotkeys.css
@@ -1,0 +1,24 @@
+#hotkey-help::backdrop {
+  background: rgba(0, 0, 0, 0.5);
+}
+
+#hotkey-help {
+  border: none;
+  padding: 1rem;
+  max-width: 400px;
+}
+
+#hotkey-help dl {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 0.5rem 1rem;
+  margin: 0;
+}
+
+#hotkey-help dt {
+  font-weight: bold;
+}
+
+#hotkey-help button {
+  margin-top: 1rem;
+}

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <title>Multicode Editor</title>
+  <link rel="stylesheet" href="./hotkeys.css" />
   <style>
     body { margin: 0; font-family: sans-serif; }
     #visual-canvas { width: 100%; height: 50vh; border: 1px solid #ccc; display: block; }

--- a/frontend/src/visual/hotkeys.ts
+++ b/frontend/src/visual/hotkeys.ts
@@ -154,14 +154,41 @@ export function focusSearch() {
 }
 
 export function showHotkeyHelp() {
-  const list = Object.entries(hotkeys)
-    .map(([name, combo]) => `${combo} - ${name}`)
-    .join('\n');
-  alert(list);
+  if (!hotkeyDialog) buildHotkeyDialog();
+  hotkeyDialog!.showModal();
 }
 
 let canvasRef: any = null;
 let clipboard: any = null;
+
+let hotkeyDialog: HTMLDialogElement | null = null;
+
+function buildHotkeyDialog() {
+  hotkeyDialog = document.createElement('dialog');
+  hotkeyDialog.id = 'hotkey-help';
+
+  const title = document.createElement('h2');
+  title.textContent = 'Hotkeys';
+  hotkeyDialog.appendChild(title);
+
+  const list = document.createElement('dl');
+  for (const [name, combo] of Object.entries(hotkeys)) {
+    const dt = document.createElement('dt');
+    dt.textContent = combo;
+    const dd = document.createElement('dd');
+    dd.textContent = name;
+    list.appendChild(dt);
+    list.appendChild(dd);
+  }
+  hotkeyDialog.appendChild(list);
+
+  const closeBtn = document.createElement('button');
+  closeBtn.textContent = 'Close';
+  closeBtn.addEventListener('click', () => hotkeyDialog?.close());
+  hotkeyDialog.appendChild(closeBtn);
+
+  document.body.appendChild(hotkeyDialog);
+}
 
 export function setCanvas(vc: any) {
   canvasRef = vc;


### PR DESCRIPTION
## Summary
- replace alert-based hotkey helper with semantic dialog
- include modal styles

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c273cbe2c8323803ea6a5b445cf54