### PR TITLE
refactor: extract hotkey dialog component

### DIFF
--- a/frontend/src/hotkeys.css
+++ b/frontend/src/hotkeys.css
@@ -22,3 +22,11 @@
 #hotkey-help button {
   margin-top: 1rem;
 }
+
+#hotkey-help kbd {
+  background: #f5f5f5;
+  border: 1px solid #ccc;
+  border-radius: 3px;
+  padding: 0 0.25rem;
+  font-family: monospace;
+}

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <title>Multicode Editor</title>
+  <!-- Styles for the hotkey help dialog -->
   <link rel="stylesheet" href="./hotkeys.css" />
   <style>
     body { margin: 0; font-family: sans-serif; }

--- a/frontend/src/visual/hotkey-dialog.ts
+++ b/frontend/src/visual/hotkey-dialog.ts
@@ -1,0 +1,34 @@
+import type { HotkeyMap } from './hotkeys.ts';
+
+export function createHotkeyDialog(hotkeys: HotkeyMap): HTMLDialogElement {
+  const dialog = document.createElement('dialog');
+  dialog.id = 'hotkey-help';
+
+  const title = document.createElement('h2');
+  title.id = 'hotkey-help-title';
+  title.textContent = 'Hotkeys';
+  dialog.appendChild(title);
+  dialog.setAttribute('aria-labelledby', title.id);
+
+  const list = document.createElement('dl');
+  for (const [name, combo] of Object.entries(hotkeys)) {
+    const dt = document.createElement('dt');
+    const kbd = document.createElement('kbd');
+    kbd.textContent = combo;
+    dt.appendChild(kbd);
+
+    const dd = document.createElement('dd');
+    dd.textContent = name;
+    list.appendChild(dt);
+    list.appendChild(dd);
+  }
+  dialog.appendChild(list);
+
+  const closeBtn = document.createElement('button');
+  closeBtn.textContent = 'Close';
+  closeBtn.addEventListener('click', () => dialog.close());
+  dialog.appendChild(closeBtn);
+
+  document.body.appendChild(dialog);
+  return dialog;
+}

--- a/frontend/src/visual/hotkeys.ts
+++ b/frontend/src/visual/hotkeys.ts
@@ -1,8 +1,9 @@
 import settings from '../../settings.json' assert { type: 'json' };
 import { createBlock } from './blocks.js';
 import { getTheme } from './theme.ts';
+import { createHotkeyDialog } from './hotkey-dialog.ts';
 
-interface HotkeyMap {
+export interface HotkeyMap {
   copyBlock: string;
   pasteBlock: string;
   selectConnections: string;
@@ -154,41 +155,14 @@ export function focusSearch() {
 }
 
 export function showHotkeyHelp() {
-  if (!hotkeyDialog) buildHotkeyDialog();
-  hotkeyDialog!.showModal();
+  if (!hotkeyDialog) hotkeyDialog = createHotkeyDialog(hotkeys);
+  hotkeyDialog.showModal();
 }
 
 let canvasRef: any = null;
 let clipboard: any = null;
 
 let hotkeyDialog: HTMLDialogElement | null = null;
-
-function buildHotkeyDialog() {
-  hotkeyDialog = document.createElement('dialog');
-  hotkeyDialog.id = 'hotkey-help';
-
-  const title = document.createElement('h2');
-  title.textContent = 'Hotkeys';
-  hotkeyDialog.appendChild(title);
-
-  const list = document.createElement('dl');
-  for (const [name, combo] of Object.entries(hotkeys)) {
-    const dt = document.createElement('dt');
-    dt.textContent = combo;
-    const dd = document.createElement('dd');
-    dd.textContent = name;
-    list.appendChild(dt);
-    list.appendChild(dd);
-  }
-  hotkeyDialog.appendChild(list);
-
-  const closeBtn = document.createElement('button');
-  closeBtn.textContent = 'Close';
-  closeBtn.addEventListener('click', () => hotkeyDialog?.close());
-  hotkeyDialog.appendChild(closeBtn);
-
-  document.body.appendChild(hotkeyDialog);
-}
 
 export function setCanvas(vc: any) {
   canvasRef = vc;


### PR DESCRIPTION
## Summary
- refactor hotkey help to use a dedicated dialog component
- style keyboard shortcuts using `<kbd>` tags
- document hotkey dialog styles in index.html

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c2f6211d483239506872694a267c2