### PR TITLE
feat: add theme selector

### DIFF
--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -30,6 +30,9 @@
     import { loadBlockPlugins } from "./visual/blocks.js";
     import { insertVisualMeta, updateMetaComment, visualMetaHighlighter, visualMetaTooltip } from "./editor/visual-meta.js";
     import { registerHotkeys, setCanvas } from "./visual/hotkeys.ts";
+    import settings from "../settings.json" assert { type: 'json' };
+    import { availableThemes, applyTheme, getThemeName } from "./visual/theme.ts";
+    import { writeTextFile, BaseDirectory } from "https://cdn.jsdelivr.net/npm/@tauri-apps/api@1.5.0/fs.js";
 
     await loadBlockPlugins(window.blockPlugins || []);
 
@@ -38,6 +41,22 @@
     const vc = new VisualCanvas(canvasEl, minimapEl);
     setCanvas(vc);
     registerHotkeys();
+
+    const themeSelect = document.getElementById('theme');
+    availableThemes.forEach(t => {
+      const opt = document.createElement('option');
+      opt.value = t;
+      opt.textContent = t;
+      if (t === getThemeName()) opt.selected = true;
+      themeSelect.appendChild(opt);
+    });
+    themeSelect.addEventListener('change', async e => {
+      const name = e.target.value;
+      applyTheme(name);
+      settings.visual = settings.visual || {};
+      settings.visual.theme = name;
+      await writeTextFile('settings.json', JSON.stringify(settings, null, 2), { dir: BaseDirectory.Resource });
+    });
 
     const ws = new WebSocket('ws://localhost:3000/ws');
     ws.addEventListener('message', ev => {
@@ -182,6 +201,7 @@
     <button id="undo">Undo</button>
     <button id="redo">Redo</button>
     <button id="insert-meta">Insert Meta</button>
+    <select id="theme"></select>
     <select id="locale">
       <option value="en">English</option>
       <option value="ru">Русский</option>

--- a/frontend/src/visual/canvas.js
+++ b/frontend/src/visual/canvas.js
@@ -1,5 +1,5 @@
 import { createBlock } from './blocks.js';
-import { getTheme } from './theme.ts';
+import { getTheme, onThemeChange } from './theme.ts';
 import { registerHoverHighlight, drawHoverHighlight } from './hover.ts';
 import { Minimap } from './minimap.ts';
 import settings from '../../settings.json' assert { type: 'json' };
@@ -103,6 +103,11 @@ export class VisualCanvas {
     this.tooltip.style.whiteSpace = 'pre';
     this.tooltip.style.display = 'none';
     document.body.appendChild(this.tooltip);
+
+    onThemeChange(t => {
+      this.tooltip.style.background = t.tooltipBg;
+      this.tooltip.style.color = t.tooltipText;
+    });
 
     this.resize();
     window.addEventListener('resize', () => this.resize());

--- a/frontend/src/visual/themes/dark.json
+++ b/frontend/src/visual/themes/dark.json
@@ -1,0 +1,16 @@
+{
+  "blockFill": "#333",
+  "blockStroke": "#bbb",
+  "blockText": "#fff",
+  "connection": "#fff",
+  "highlight": "#555",
+  "tooltipBg": "#eee",
+  "tooltipText": "#000",
+  "alignGuide": "#555",
+  "blockKinds": {
+    "Function": "#455a64",
+    "Variable": "#558b2f",
+    "Condition": "#827717",
+    "Loop": "#6d4c41"
+  }
+}


### PR DESCRIPTION
## Summary
- add theme list with applyTheme and dark theme
- subscribe canvas to theme change
- add theme selector in HTML saving to settings.json

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c3cd93a5083239d21a1e621ac5f35