### PR TITLE
feat: support plugin reloading without page refresh

### DIFF
--- a/examples/plugins/README.md
+++ b/examples/plugins/README.md
@@ -6,7 +6,8 @@
 * **Backend** – реализует трейт [`Plugin`](../../backend/src/plugins/mod.rs) и
   сообщает о дополнительных типах блоков.
 * **Frontend** – предоставляет визуальный компонент для нового блока и
-  регистрирует его через функцию `registerBlock`.
+  регистрирует его через функцию `registerBlock`, а при необходимости
+  удаляет через `unregisterBlock`.
 
 ## Backend API
 
@@ -56,6 +57,18 @@ export function register({ Block, registerBlock }) {
 
 ```javascript
 await loadBlockPlugins(['./my-block.js']);
+```
+
+При обновлении кода плагина его можно перезагрузить без перезагрузки страницы:
+
+```javascript
+await reloadPlugins(['./my-block.js']);
+```
+
+Если блок больше не нужен, его можно удалить из реестра:
+
+```javascript
+unregisterBlock('MyBlock');
 ```
 
 Поле `extras` из структуры [`VisualMeta`](../../backend/src/meta/mod.rs) позволяет

--- a/examples/plugins/my-block.js
+++ b/examples/plugins/my-block.js
@@ -1,6 +1,7 @@
 // Example block plugin used in documentation.
 // The module exposes a `register` function which receives the base Block
-// class and a helper for registration.
+// class and a helper for registration. The plugin can be reloaded at runtime
+// with `reloadPlugins(['./my-block.js'])`.
 export function register({ Block, registerBlock }) {
   class MyBlock extends Block {
     constructor(id, x, y, w, h, label, color, extras = {}) {

--- a/frontend/src/visual/blocks.test.js
+++ b/frontend/src/visual/blocks.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { Block, registerBlock, createBlock } from './blocks.js';
+import { Block, registerBlock, unregisterBlock, createBlock } from './blocks.js';
 
 describe('block utilities', () => {
   it('checks point containment and center', () => {
@@ -15,5 +15,15 @@ describe('block utilities', () => {
     registerBlock('custom', Custom);
     const b = createBlock('custom', '2', 0, 0, 'c');
     expect(b).toBeInstanceOf(Custom);
+  });
+
+  it('unregisters a block type', () => {
+    class Custom extends Block {
+      constructor(id, x, y) { super(id, x, y, 10, 10, 'c'); }
+    }
+    registerBlock('temp', Custom);
+    unregisterBlock('temp');
+    const b = createBlock('temp', '3', 0, 0, 'c');
+    expect(b).toBeInstanceOf(Block);
   });
 });


### PR DESCRIPTION
## Summary
- allow unregistering block types and reloading plugins
- automatically refresh block plugins when re-imported
- document runtime plugin reloading and removal in examples

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c5867225c8323bf19f6494d16eb36