### PR TITLE
feat: add layout export/import

### DIFF
--- a/docs/layout-format.md
+++ b/docs/layout-format.md
@@ -1,0 +1,29 @@
+# Layout export format
+
+The visual editor can save and restore its state through JSON. Use the **Export** and **Import** buttons in the interface or call the methods directly on `VisualCanvas`.
+
+## JSON structure
+
+```json
+{
+  "blocks": [],
+  "connections": [["a", "b"]],
+  "offset": { "x": 0, "y": 0 },
+  "scale": 1
+}
+```
+
+- `blocks` — array of block metadata (`blocksData`).
+- `connections` — list of edges as pairs of block `visual_id`s.
+- `offset` — current pan offset of the canvas.
+- `scale` — zoom level.
+
+## Example
+
+```js
+// Export current layout
+const json = JSON.stringify(vc.serialize(), null, 2);
+
+// Restore layout
+vc.load(JSON.parse(json));
+```

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -124,11 +124,45 @@
       }
     }
 
+    function exportLayout() {
+      const data = JSON.stringify(vc.serialize());
+      const blob = new Blob([data], { type: 'application/json' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = 'layout.json';
+      a.click();
+      URL.revokeObjectURL(url);
+    }
+
+    function importLayout() {
+      const input = document.createElement('input');
+      input.type = 'file';
+      input.accept = 'application/json';
+      input.addEventListener('change', e => {
+        const file = e.target.files[0];
+        if (!file) return;
+        const reader = new FileReader();
+        reader.onload = ev => {
+          try {
+            const layout = JSON.parse(ev.target.result);
+            vc.load(layout);
+          } catch (err) {
+            console.error('Invalid layout', err);
+          }
+        };
+        reader.readAsText(file);
+      });
+      input.click();
+    }
+
     const exportProgress = document.getElementById('export-progress');
 
     document.getElementById('save').addEventListener('click', save);
     document.getElementById('load').addEventListener('click', load);
     document.getElementById('export-clean').addEventListener('click', exportWithoutMeta);
+    document.getElementById('layout-export').addEventListener('click', exportLayout);
+    document.getElementById('layout-import').addEventListener('click', importLayout);
     document.getElementById('undo').addEventListener('click', () => vc.undo());
     document.getElementById('redo').addEventListener('click', () => vc.redo());
     document.getElementById('insert-meta').addEventListener('click', () => insertVisualMeta(view, currentLang));
@@ -198,6 +232,8 @@
     <button id="load">Load</button>
     <button id="export-clean">Экспорт без метаданных</button>
     <span id="export-progress" style="display:none">Exporting…</span>
+    <button id="layout-export">Export</button>
+    <button id="layout-import">Import</button>
     <button id="undo">Undo</button>
     <button id="redo">Redo</button>
     <button id="insert-meta">Insert Meta</button>

--- a/frontend/src/visual/canvas.js
+++ b/frontend/src/visual/canvas.js
@@ -206,6 +206,33 @@ export class VisualCanvas {
     this.blocks.push(block);
   }
 
+  serialize() {
+    return {
+      blocks: this.blocksData,
+      connections: this.connections.map(([a, b]) => [a.id, b.id]),
+      offset: this.offset,
+      scale: this.scale
+    };
+  }
+
+  load(layout) {
+    if (!layout) return;
+    this.blocksData = layout.blocks || [];
+    this.blockDataMap = new Map(this.blocksData.map(b => [b.visual_id, b]));
+    this.updateLabels();
+    const byId = new Map(this.blocks.map(b => [b.id, b]));
+    this.connections = (layout.connections || [])
+      .map(([a, b]) => {
+        const from = byId.get(a);
+        const to = byId.get(b);
+        return from && to ? [from, to] : null;
+      })
+      .filter(Boolean);
+    this.offset = layout.offset || { x: 0, y: 0 };
+    this.scale = layout.scale ?? 1;
+    this.analyze();
+  }
+
   connect(a, b) {
     this.connections.push([a, b]);
     this.analyze();

--- a/frontend/src/visual/canvas.test.js
+++ b/frontend/src/visual/canvas.test.js
@@ -94,3 +94,40 @@ describe('undo and redo', () => {
     expect(vc.connections[0][1]).toBe(b);
   });
 });
+
+describe('serialize and load', () => {
+  function createCanvas() {
+    const canvasEl = document.createElement('canvas');
+    Object.defineProperty(canvasEl, 'clientWidth', { value: 200 });
+    Object.defineProperty(canvasEl, 'clientHeight', { value: 200 });
+    canvasEl.getContext = () => ({ save(){}, setTransform(){}, clearRect(){}, beginPath(){}, stroke(){}, moveTo(){}, lineTo(){}, fillRect(){}, strokeRect(){}, fillText(){}, restore(){} });
+    globalThis.requestAnimationFrame = () => 0;
+    return canvasEl;
+  }
+
+  it('restores blocks, connections and view', () => {
+    const vc1 = new VisualCanvas(createCanvas());
+    const a = { id: 'a' };
+    const b = { id: 'b' };
+    vc1.blocks = [a, b];
+    vc1.blocksData = [
+      { visual_id: 'a', kind: 'Function', x: 0, y: 0 },
+      { visual_id: 'b', kind: 'Function', x: 10, y: 10 }
+    ];
+    vc1.connections = [[a, b]];
+    vc1.offset = { x: 5, y: 6 };
+    vc1.scale = 2;
+
+    const data = vc1.serialize();
+
+    const vc2 = new VisualCanvas(createCanvas());
+    vc2.load(data);
+
+    expect(vc2.blocksData).toEqual(vc1.blocksData);
+    expect(vc2.connections.length).toBe(1);
+    expect(vc2.connections[0][0].id).toBe('a');
+    expect(vc2.connections[0][1].id).toBe('b');
+    expect(vc2.offset).toEqual({ x: 5, y: 6 });
+    expect(vc2.scale).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary
- add `serialize()` and `load()` to visual canvas for storing layout
- add Export/Import buttons in interface to save and restore layouts
- document JSON layout format

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c5da35c308323894273c27b02644e