### PR TITLE
feat: store visual meta in dedicated block

### DIFF
--- a/frontend/tests/visual_sync.test.ts
+++ b/frontend/tests/visual_sync.test.ts
@@ -19,11 +19,12 @@ import { updateMetaComment } from '../src/editor/visual-meta.js';
 
 describe('visual-meta synchronization', () => {
   it('reflects block coordinate changes in comments', () => {
-    const original = '// @VISUAL_META {"id":"1","x":0,"y":0}\nfn main() {}';
+    const original = '// @VISUAL_META 1\nfn main() {}\n/* @VISUAL_META\n{"id":"1","x":0,"y":0}\n*/';
     const view: any = {
       state: { doc: { toString: () => original } },
       dispatch: vi.fn(({ changes: { from, to, insert } }) => {
-        const updated = original.slice(0, from) + insert + original.slice(to);
+        const current = view.state.doc.toString();
+        const updated = current.slice(0, from) + insert + current.slice(to);
         view.state.doc.toString = () => updated;
       }),
     };
@@ -33,5 +34,6 @@ describe('visual-meta synchronization', () => {
     const text = view.state.doc.toString();
     expect(text).toContain('"x":5');
     expect(text).toContain('"y":7');
+    expect(text).toContain('// @VISUAL_META 1');
   });
 });


### PR DESCRIPTION
## Summary
- keep short `@VISUAL_META` markers and move metadata objects to a shared block
- update comment synchronization via id→position map
- adjust tests for new marker format

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c65e0de6c8323b586c79b7ae44b8f