### PR TITLE
feat: sync canvas with meta comments

### DIFF
--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -30,7 +30,7 @@
     import { save as saveDialog } from "https://cdn.jsdelivr.net/npm/@tauri-apps/api@1.5.0/dialog.js";
     import { VisualCanvas } from "./visual/canvas.js";
     import { loadBlockPlugins } from "./visual/blocks.js";
-    import { insertVisualMeta, updateMetaComment, visualMetaHighlighter, visualMetaTooltip, foldMetaBlock } from "./editor/visual-meta.js";
+    import { insertVisualMeta, updateMetaComment, visualMetaHighlighter, visualMetaTooltip, foldMetaBlock, visualMetaMessenger } from "./editor/visual-meta.js";
     import { registerHotkeys, setCanvas } from "./visual/hotkeys.ts";
     import settings from "../settings.json" assert { type: 'json' };
     import { availableThemes, applyTheme, getThemeName } from "./visual/theme.ts";
@@ -94,7 +94,7 @@
       state: EditorState.create({
         doc: '',
         extensions: [
-          basicSetup, javascript(), python(), rust(), html(), css(), visualMetaHighlighter, visualMetaTooltip,
+          basicSetup, javascript(), python(), rust(), html(), css(), visualMetaHighlighter, visualMetaTooltip, visualMetaMessenger,
           foldGutter(), keymap.of(foldKeymap),
           EditorView.updateListener.of(update => {
             if (update.docChanged) parseAndRender();

--- a/frontend/src/visual/canvas.js
+++ b/frontend/src/visual/canvas.js
@@ -114,6 +114,12 @@ export class VisualCanvas {
     window.addEventListener('resize', () => this.resize());
     this.registerEvents();
     registerHoverHighlight(this);
+    window.addEventListener('message', e => {
+      const { source, id } = e.data || {};
+      if (source === 'visual-meta' && id) {
+        this.highlightBlocks([id]);
+      }
+    });
     requestAnimationFrame(() => this.draw());
   }
 
@@ -159,6 +165,12 @@ export class VisualCanvas {
       const base = data ? theme.blockKinds[data.kind] || theme.blockFill : theme.blockFill;
       b.color = this.highlighted.has(b.id) ? theme.highlight : base;
     });
+  }
+
+  selectBlock(id) {
+    if (id) this.highlightBlocks([id]);
+    else this.highlightBlocks([]);
+    window.postMessage({ source: 'visual-canvas', id }, '*');
   }
 
   search(label) {
@@ -266,6 +278,8 @@ export class VisualCanvas {
     this.canvas.addEventListener('mousedown', e => {
       const pos = this.toWorld(e.offsetX, e.offsetY);
       const block = this.blocks.find(b => b.contains(pos.x, pos.y));
+
+      if (block) this.selectBlock(block.id); else this.selectBlock(null);
 
       if (block) {
         const exit = { x: block.x + block.w, y: block.y + block.h / 2 };


### PR DESCRIPTION
## Summary
- post selected block id to `window` and highlight blocks on incoming messages
- listen for block selections in meta editor and post id back to canvas
- wire editor messaging plugin into page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c83f6b0948323aae946645b89df3a