### PR TITLE
Capture duplicate IDs during metadata parsing

### DIFF
--- a/backend/src/meta/mod.rs
+++ b/backend/src/meta/mod.rs
@@ -139,7 +139,9 @@ pub fn upsert(content: &str, meta: &VisualMeta) -> String {
 }
 
 /// Read all visual metadata comments from `content`.
-pub fn read_all(content: &str) -> Vec<VisualMeta> {
+///
+/// Returns the parsed metadata and a list of duplicate identifiers.
+pub fn read_all_with_dups(content: &str) -> (Vec<VisualMeta>, Vec<String>) {
     // Serialize access so that the registry isn't cleared while another
     // thread is using it, which previously could result in missing metadata
     // entries and test flakiness.
@@ -154,9 +156,17 @@ pub fn read_all(content: &str) -> Vec<VisualMeta> {
             ids.push(id);
         }
     }
-    ids.into_iter()
+    let metas = ids
+        .into_iter()
         .filter_map(|id| merge_base_meta(&id))
-        .collect()
+        .collect();
+    let dups = id_registry::duplicates();
+    (metas, dups)
+}
+
+/// Read all visual metadata comments from `content`, discarding duplicate IDs.
+pub fn read_all(content: &str) -> Vec<VisualMeta> {
+    read_all_with_dups(content).0
 }
 
 /// Recursively merge metadata with its base entries using the `extends` chain.

--- a/backend/tests/id_registry.rs
+++ b/backend/tests/id_registry.rs
@@ -2,11 +2,9 @@ use backend::meta::{self, id_registry};
 
 #[test]
 fn detects_duplicate_ids() {
-    id_registry::clear();
     let content = "# @VISUAL_META {\"id\":\"dup\",\"x\":0.0,\"y\":0.0}\n# @VISUAL_META {\"id\":\"dup\",\"x\":1.0,\"y\":1.0}";
-    // reading registers IDs
-    meta::read_all(content);
-    let dups = id_registry::duplicates();
+    // reading registers IDs and capturing duplicates
+    let (_metas, dups) = meta::read_all_with_dups(content);
     assert_eq!(dups, vec!["dup".to_string()]);
 }
 


### PR DESCRIPTION
## Summary
- add `read_all_with_dups` to gather duplicates while holding the registry lock
- expose `read_all` as thin wrapper and adjust id registry test

## Testing
- `cargo test`
- `cargo test --test id_registry`


------
https://chatgpt.com/codex/tasks/task_e_689c8d8c26e88323a668b582656b90a4