### PR TITLE
feat: open block in text mode on canvas double-click

### DIFF
--- a/frontend/src/editor/visual-meta.js
+++ b/frontend/src/editor/visual-meta.js
@@ -24,6 +24,8 @@ const tmplObj = () => ({
 // Map id -> start position of JSON object inside the meta block
 export const metaPositions = new Map();
 
+let currentView = null;
+
 function getMetaBlock(text) {
   const start = text.indexOf("/* @VISUAL_META");
   if (start === -1) return null;
@@ -81,6 +83,12 @@ function highlightMetaById(view, id) {
   const end = text.indexOf("\n", pos);
   const to = end === -1 ? text.length : end;
   view.dispatch({ selection: { anchor: pos, head: to }, scrollIntoView: true });
+}
+
+export function scrollToMeta(id) {
+  if (currentView) {
+    highlightMetaById(currentView, id);
+  }
 }
 
 export function foldMetaBlock(view) {
@@ -242,6 +250,7 @@ export const visualMetaTooltip = hoverTooltip((view, pos) => {
 export const visualMetaMessenger = ViewPlugin && ViewPlugin.fromClass ? ViewPlugin.fromClass(class {
   constructor(view) {
     this.view = view;
+    currentView = view;
     this.onMessage = this.onMessage.bind(this);
     this.onClick = this.onClick.bind(this);
     window.addEventListener('message', this.onMessage);
@@ -250,6 +259,7 @@ export const visualMetaMessenger = ViewPlugin && ViewPlugin.fromClass ? ViewPlug
   destroy() {
     window.removeEventListener('message', this.onMessage);
     this.view.dom.removeEventListener('click', this.onClick);
+    if (currentView === this.view) currentView = null;
   }
   onMessage(e) {
     const { source, id } = e.data || {};

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -30,7 +30,7 @@
     import { save as saveDialog } from "https://cdn.jsdelivr.net/npm/@tauri-apps/api@1.5.0/dialog.js";
     import { VisualCanvas } from "./visual/canvas.js";
     import { loadBlockPlugins } from "./visual/blocks.js";
-    import { insertVisualMeta, updateMetaComment, visualMetaHighlighter, visualMetaTooltip, foldMetaBlock, visualMetaMessenger } from "./editor/visual-meta.js";
+    import { insertVisualMeta, updateMetaComment, visualMetaHighlighter, visualMetaTooltip, foldMetaBlock, visualMetaMessenger, scrollToMeta } from "./editor/visual-meta.js";
     import { registerHotkeys, setCanvas } from "./visual/hotkeys.ts";
     import settings from "../settings.json" assert { type: 'json' };
     import { availableThemes, applyTheme, getThemeName } from "./visual/theme.ts";
@@ -103,6 +103,14 @@
       }),
       parent: document.getElementById('editor')
     });
+
+    window.openInTextEditor = id => {
+      document.getElementById('visual-canvas').style.display = 'none';
+      document.getElementById('visual-minimap').style.display = 'none';
+      document.getElementById('editor').style.height = '90vh';
+      scrollToMeta(id);
+      view.focus();
+    };
 
     async function save() {
       await invoke('save_state', { content: view.state.doc.toString() });

--- a/frontend/src/visual/canvas.js
+++ b/frontend/src/visual/canvas.js
@@ -317,6 +317,14 @@ export class VisualCanvas {
       this.tooltip.style.display = 'none';
     });
 
+    this.canvas.addEventListener('dblclick', e => {
+      const pos = this.toWorld(e.offsetX, e.offsetY);
+      const block = this.blocks.find(b => b.contains(pos.x, pos.y));
+      if (block && typeof window.openInTextEditor === 'function') {
+        window.openInTextEditor(block.id);
+      }
+    });
+
     this.canvas.addEventListener('mousemove', e => {
       const pos = this.toWorld(e.offsetX, e.offsetY);
       if (this.selectionBox) {


### PR DESCRIPTION
## Summary
- open text editor when a visual block is double-clicked
- expose scrollToMeta to position the cursor inside metadata
- add UI hook for text mode and focus on requested block

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c95a62cdc832381df5aee75a71658