### PR TITLE
Persist view and cursor state across modes

### DIFF
--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -28,7 +28,7 @@
     import { css } from "https://cdn.jsdelivr.net/npm/@codemirror/lang-css@0.19.7/dist/index.js";
     import { invoke } from "https://cdn.jsdelivr.net/npm/@tauri-apps/api@1.5.0/tauri.js";
     import { save as saveDialog } from "https://cdn.jsdelivr.net/npm/@tauri-apps/api@1.5.0/dialog.js";
-    import { VisualCanvas } from "./visual/canvas.js";
+    import { VisualCanvas, VIEW_STATE_KEY } from "./visual/canvas.js";
     import { loadBlockPlugins } from "./visual/blocks.js";
     import { insertVisualMeta, updateMetaComment, visualMetaHighlighter, visualMetaTooltip, foldMetaBlock, visualMetaMessenger, scrollToMeta } from "./editor/visual-meta.js";
     import { registerHotkeys, setCanvas } from "./visual/hotkeys.ts";
@@ -36,11 +36,26 @@
     import { availableThemes, applyTheme, getThemeName } from "./visual/theme.ts";
     import { writeTextFile, BaseDirectory } from "https://cdn.jsdelivr.net/npm/@tauri-apps/api@1.5.0/fs.js";
 
+    const TEXT_CURSOR_KEY = 'text-cursor-pos';
+
     await loadBlockPlugins(window.blockPlugins || []);
 
     const canvasEl = document.getElementById('visual-canvas');
     const minimapEl = document.getElementById('visual-minimap');
     const vc = new VisualCanvas(canvasEl, minimapEl);
+
+    const storedView = localStorage.getItem(VIEW_STATE_KEY);
+    if (storedView) {
+      try {
+        const { offset, scale } = JSON.parse(storedView);
+        if (offset && typeof offset.x === 'number' && typeof offset.y === 'number') {
+          vc.offset = offset;
+        }
+        if (typeof scale === 'number') vc.scale = scale;
+        vc.draw();
+      } catch (_) {}
+    }
+
     setCanvas(vc);
     registerHotkeys();
 
@@ -108,8 +123,29 @@
       document.getElementById('visual-canvas').style.display = 'none';
       document.getElementById('visual-minimap').style.display = 'none';
       document.getElementById('editor').style.height = '90vh';
-      scrollToMeta(id);
+      if (id) {
+        scrollToMeta(id);
+      } else {
+        const raw = localStorage.getItem(TEXT_CURSOR_KEY);
+        if (raw) {
+          try {
+            const { pos } = JSON.parse(raw);
+            if (typeof pos === 'number') {
+              view.dispatch({ selection: { anchor: pos }, scrollIntoView: true });
+            }
+          } catch (_) {}
+        }
+      }
       view.focus();
+    };
+
+    window.openVisualMode = () => {
+      const sel = view.state.selection.main;
+      localStorage.setItem(TEXT_CURSOR_KEY, JSON.stringify({ pos: sel.anchor }));
+      document.getElementById('visual-canvas').style.display = 'block';
+      document.getElementById('visual-minimap').style.display = 'block';
+      document.getElementById('editor').style.height = '40vh';
+      vc.draw();
     };
 
     async function save() {

--- a/frontend/src/visual/canvas.js
+++ b/frontend/src/visual/canvas.js
@@ -4,6 +4,8 @@ import { registerHoverHighlight, drawHoverHighlight } from './hover.ts';
 import { Minimap } from './minimap.ts';
 import settings from '../../settings.json' assert { type: 'json' };
 
+export const VIEW_STATE_KEY = 'visual-view-state';
+
 const cfg = settings.visual || {};
 const GRID_SIZE = cfg.gridSize || 20;
 const MIN_SCALE = 0.5;
@@ -274,6 +276,18 @@ export class VisualCanvas {
     this.analyze();
   }
 
+  saveViewState() {
+    if (typeof localStorage === 'undefined') return;
+    try {
+      localStorage.setItem(
+        VIEW_STATE_KEY,
+        JSON.stringify({ offset: this.offset, scale: this.scale })
+      );
+    } catch (_err) {
+      // ignore storage errors
+    }
+  }
+
   connect(a, b) {
     this.connections.push([a, b]);
     this.analyze();
@@ -350,6 +364,7 @@ export class VisualCanvas {
       const pos = this.toWorld(e.offsetX, e.offsetY);
       const block = this.blocks.find(b => b.contains(pos.x, pos.y));
       if (block && typeof window.openInTextEditor === 'function') {
+        this.saveViewState();
         window.openInTextEditor(block.id);
       }
     });


### PR DESCRIPTION
## Summary
- Save visual canvas offset/scale to localStorage before switching to text view
- Restore saved canvas view on initialization
- Preserve text editor cursor when toggling between visual and text modes

## Testing
- `npm test`
- `npm --prefix frontend run lint` *(fails: Need to install eslint@9.33.0)*

------
https://chatgpt.com/codex/tasks/task_e_689cb564a96c8323be9071aa0daf40b4