### PR TITLE
feat: unify text and block search

### DIFF
--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -14,6 +14,8 @@
     #git-panel { padding: 0.5rem; border-top: 1px solid #ccc; }
     #git-log { white-space: pre-wrap; background: #f5f5f5; max-height: 20vh; overflow: auto; padding: 0.5rem; }
     .cm-invalid-meta { text-decoration: wavy underline red; }
+    #search-panel { padding: 0.5rem; border-top: 1px solid #ccc; }
+    #search-results { width: 100%; }
   </style>
   <script type="module">
     import { EditorState } from "@codemirror/state";
@@ -35,6 +37,7 @@
     import settings from "../settings.json" assert { type: 'json' };
     import { availableThemes, applyTheme, getThemeName } from "./visual/theme.ts";
     import { writeTextFile, BaseDirectory } from "https://cdn.jsdelivr.net/npm/@tauri-apps/api@1.5.0/fs.js";
+    import { searchAll, highlightResults, gotoResult } from "./shared/search.js";
 
     const TEXT_CURSOR_KEY = 'text-cursor-pos';
 
@@ -100,6 +103,7 @@
       try {
         const blocks = await invoke('parse_blocks', { content, lang: currentLang });
         vc.setBlocks(blocks);
+        updateSearch();
       } catch (e) {
         console.error(e);
       }
@@ -222,6 +226,27 @@
       vc.setLocale(currentLocale);
     });
 
+    const searchInput = document.getElementById('search-input');
+    const searchResultsEl = document.getElementById('search-results');
+    let searchResults = [];
+    function updateSearch() {
+      searchResults = searchAll(searchInput.value, view, vc.blocksData, currentLocale);
+      searchResultsEl.innerHTML = '';
+      searchResults.forEach((r, i) => {
+        const opt = document.createElement('option');
+        opt.value = String(i);
+        opt.textContent = r.type === 'block' ? `Block: ${r.label}` : `Line ${r.line}: ${r.label}`;
+        searchResultsEl.appendChild(opt);
+      });
+      highlightResults(searchResults, view, vc);
+    }
+    searchInput.addEventListener('input', updateSearch);
+    searchResultsEl.addEventListener('change', () => {
+      const idx = parseInt(searchResultsEl.value, 10);
+      const res = searchResults[idx];
+      if (res) gotoResult(res, view, vc);
+    });
+
     async function gitCommit() {
       const message = document.getElementById('git-message').value;
       await invoke('git_commit_cmd', { message });
@@ -294,6 +319,10 @@
       <option value="ru">Русский</option>
       <option value="es">Español</option>
     </select>
+  </div>
+  <div id="search-panel">
+    <input id="search-input" placeholder="Search..." />
+    <select id="search-results" size="5"></select>
   </div>
   <div id="git-panel">
     <input id="git-message" placeholder="Commit message" />

--- a/frontend/src/shared/search.js
+++ b/frontend/src/shared/search.js
@@ -1,0 +1,73 @@
+import { scrollToMeta } from '../editor/visual-meta.js';
+
+/**
+ * Search across plain text content and blocks data.
+ * @param {string} query
+ * @param {import('@codemirror/view').EditorView} view
+ * @param {Array} blocksData
+ * @param {string} locale
+ * @returns {Array}
+ */
+export function searchAll(query, view, blocksData, locale = 'en') {
+  const results = [];
+  if (!query) return results;
+  const lower = query.toLowerCase();
+  const fullText = view.state.doc.toString();
+  const lowerText = fullText.toLowerCase();
+  let idx = lowerText.indexOf(lower);
+  while (idx !== -1) {
+    const lineInfo = view.state.doc.lineAt(idx);
+    results.push({
+      type: 'text',
+      from: idx,
+      to: idx + query.length,
+      line: lineInfo.number,
+      label: lineInfo.text.trim()
+    });
+    idx = lowerText.indexOf(lower, idx + query.length);
+  }
+  if (Array.isArray(blocksData)) {
+    blocksData.forEach(b => {
+      const label = (b.translations && b.translations[locale]) || b.kind || '';
+      if (label.toLowerCase().includes(lower)) {
+        results.push({ type: 'block', id: b.visual_id, label });
+      }
+    });
+  }
+  return results;
+}
+
+/**
+ * Highlight search results in editor and canvas.
+ * @param {Array} results
+ * @param {import('@codemirror/view').EditorView} view
+ * @param {any} canvas
+ */
+export function highlightResults(results, view, canvas) {
+  const blockIds = results.filter(r => r.type === 'block').map(r => r.id);
+  if (canvas && typeof canvas.highlightBlocks === 'function') {
+    canvas.highlightBlocks(blockIds);
+  }
+  const textRes = results.find(r => r.type === 'text');
+  if (textRes) {
+    view.dispatch({ selection: { anchor: textRes.from, head: textRes.to }, scrollIntoView: true });
+  }
+}
+
+/**
+ * Navigate to selected search result.
+ * @param {object} result
+ * @param {import('@codemirror/view').EditorView} view
+ * @param {any} canvas
+ */
+export function gotoResult(result, view, canvas) {
+  if (!result) return;
+  if (result.type === 'text') {
+    view.dispatch({ selection: { anchor: result.from, head: result.to }, scrollIntoView: true });
+  } else if (result.type === 'block') {
+    if (canvas && typeof canvas.selectBlock === 'function') {
+      canvas.selectBlock(result.id);
+    }
+    scrollToMeta(result.id);
+  }
+}


### PR DESCRIPTION
## Summary
- add shared search module combining text and block queries
- wire search panel into editor UI
- allow jumping to blocks or meta comments from search results

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689cd765b58c832386d19cfa8d3414d7