### PR TITLE
feat: add preview for visual meta updates

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,7 +16,8 @@
     "@tauri-apps/api": "^2.0.0",
     "ajv": "^8.17.1",
     "ajv-formats": "^2.1.1",
-    "xterm": "^5.3.0"
+    "xterm": "^5.3.0",
+    "diff": "^5.2.0"
   },
   "devDependencies": {
     "jsdom": "^23.0.0",

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -32,7 +32,7 @@
     import { save as saveDialog } from "https://cdn.jsdelivr.net/npm/@tauri-apps/api@1.5.0/dialog.js";
     import { VisualCanvas, VIEW_STATE_KEY } from "./visual/canvas.js";
     import { loadBlockPlugins } from "./visual/blocks.js";
-    import { insertVisualMeta, updateMetaComment, visualMetaHighlighter, visualMetaTooltip, foldMetaBlock, visualMetaMessenger, scrollToMeta } from "./editor/visual-meta.js";
+    import { insertVisualMeta, visualMetaHighlighter, visualMetaTooltip, foldMetaBlock, visualMetaMessenger, scrollToMeta } from "./editor/visual-meta.js";
     import { registerHotkeys, setCanvas } from "./visual/hotkeys.ts";
     import settings from "../settings.json" assert { type: 'json' };
     import { availableThemes, applyTheme, getThemeName } from "./visual/theme.ts";
@@ -88,13 +88,7 @@
       }
     });
 
-    vc.onBlockMove(async block => {
-      if (updateMetaComment(view, { id: block.id, x: block.x, y: block.y })) {
-        await invoke('save_state', { content: view.state.doc.toString() });
-      }
-    });
-
-    const currentLang = 'rust';
+      const currentLang = 'rust';
     let currentLocale = 'en';
     vc.setLocale(currentLocale);
 
@@ -109,21 +103,26 @@
       }
     }
 
-    const view = new EditorView({
-      state: EditorState.create({
-        doc: '',
-        extensions: [
-          basicSetup, javascript(), python(), rust(), html(), css(), visualMetaHighlighter, visualMetaTooltip, visualMetaMessenger,
-          foldGutter(), keymap.of(foldKeymap),
-          EditorView.updateListener.of(update => {
-            if (update.docChanged) parseAndRender();
-          })
-        ]
-      }),
-      parent: document.getElementById('editor')
-    });
+      const view = new EditorView({
+        state: EditorState.create({
+          doc: '',
+          extensions: [
+            basicSetup, javascript(), python(), rust(), html(), css(), visualMetaHighlighter, visualMetaTooltip, visualMetaMessenger,
+            foldGutter(), keymap.of(foldKeymap),
+            EditorView.updateListener.of(update => {
+              if (update.docChanged) parseAndRender();
+            })
+          ]
+        }),
+        parent: document.getElementById('editor')
+      });
 
-    window.openInTextEditor = id => {
+      vc.setMetaView(view);
+      vc.onBlockMove(async () => {
+        await invoke('save_state', { content: view.state.doc.toString() });
+      });
+
+      window.openInTextEditor = id => {
       document.getElementById('visual-canvas').style.display = 'none';
       document.getElementById('visual-minimap').style.display = 'none';
       document.getElementById('editor').style.height = '90vh';

--- a/frontend/src/visual/canvas.test.js
+++ b/frontend/src/visual/canvas.test.js
@@ -1,5 +1,9 @@
 // @vitest-environment jsdom
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
+vi.mock('../editor/visual-meta.js', () => ({
+  updateMetaComment: vi.fn(),
+  previewDiff: vi.fn().mockResolvedValue(true)
+}));
 import { analyzeConnections, VisualCanvas } from './canvas.js';
 
 describe('analyzeConnections', () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@tauri-apps/api": "^2.0.0",
         "ajv": "^8.17.1",
         "ajv-formats": "^2.1.1",
+        "diff": "^5.2.0",
         "xterm": "^5.3.0"
       },
       "devDependencies": {
@@ -1508,6 +1509,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/diff": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
+      "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/dunder-proto": {


### PR DESCRIPTION
## Summary
- add diff preview modal before updating visual meta
- generate patches from canvas and apply on confirm
- save state after confirmed block moves

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689cdbf8e2388323b6a64d4686ed73d3