### PR TITLE
Handle unsupported languages in metadata update

### DIFF
--- a/backend/tests/server_error_format.rs
+++ b/backend/tests/server_error_format.rs
@@ -80,6 +80,7 @@ async fn metadata_endpoint_unauthorized() {
             updated_at: Utc::now(),
         },
         lang: "rust".into(),
+        files: vec![],
     };
     let (status, Json(err)) = metadata_upsert_endpoint(State(test_state()), headers, Json(req))
         .await


### PR DESCRIPTION
## Summary
- gracefully handle unsupported languages when upserting metadata
- fix test setup to include empty file list in metadata request

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_689d537d262883238e6dd6318504f153