### PR TITLE
feat: add visual block generation toolbar

### DIFF
--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -32,7 +32,7 @@
     import { save as saveDialog } from "https://cdn.jsdelivr.net/npm/@tauri-apps/api@1.5.0/dialog.js";
     import { VisualCanvas, VIEW_STATE_KEY } from "./visual/canvas.js";
     import { loadBlockPlugins } from "./visual/blocks.js";
-    import { insertVisualMeta, visualMetaHighlighter, visualMetaTooltip, foldMetaBlock, visualMetaMessenger, scrollToMeta } from "./editor/visual-meta.js";
+    import { insertVisualMeta, visualMetaHighlighter, visualMetaTooltip, foldMetaBlock, visualMetaMessenger, scrollToMeta, addBlockToolbar, refreshBlockCount } from "./editor/visual-meta.js";
     import { registerHotkeys, setCanvas } from "./visual/hotkeys.ts";
     import settings from "../settings.json" assert { type: 'json' };
     import { availableThemes, applyTheme, getThemeName } from "./visual/theme.ts";
@@ -97,6 +97,7 @@
       try {
         const blocks = await invoke('parse_blocks', { content, lang: currentLang });
         vc.setBlocks(blocks);
+        refreshBlockCount(view);
         updateSearch();
       } catch (e) {
         console.error(e);
@@ -118,6 +119,7 @@
       });
 
       vc.setMetaView(view);
+      addBlockToolbar(view, vc, currentLang);
       vc.onBlockMove(async () => {
         await invoke('save_state', { content: view.state.doc.toString() });
       });


### PR DESCRIPTION
## Summary
- add editor toolbar button to generate visual blocks
- prevent duplicate visual-meta entries and show block count
- refresh block count after parsing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689d5b606c2c8323afe29f3f74cb3d53