### PR TITLE
feat: add auto-sync timer and watch endpoint

### DIFF
--- a/frontend/settings.json
+++ b/frontend/settings.json
@@ -10,10 +10,14 @@
     "theme": "default",
     "gridSize": 20,
     "showGrid": true,
-    "syncOrder": true
+    "syncOrder": true,
+    "autoSync": false,
+    "autoSyncInterval": 5
   },
   "editor": {
-    "autoFoldMeta": true
+    "autoFoldMeta": true,
+    "autoSync": false,
+    "autoSyncInterval": 5
   },
   "plugins": {}
 }

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -164,6 +164,32 @@
       foldMetaBlock(view);
     }
 
+    async function fetchWatch() {
+      try {
+        const res = await fetch('/watch');
+        const blocks = await res.json();
+        if (Array.isArray(blocks) && blocks.length) {
+          vc.setBlocks(blocks);
+          refreshBlockCount(view);
+        }
+      } catch (e) {
+        console.error('auto-sync failed', e);
+      }
+    }
+
+    function startAutoSync() {
+      const editorCfg = settings?.editor || {};
+      if (editorCfg.autoSync) {
+        const ms = Math.max(5, editorCfg.autoSyncInterval || 5) * 60000;
+        setInterval(fetchWatch, ms);
+      }
+      const visualCfg = settings?.visual || {};
+      if (visualCfg.autoSync) {
+        const ms = Math.max(5, visualCfg.autoSyncInterval || 5) * 60000;
+        setInterval(fetchWatch, ms);
+      }
+    }
+
     async function exportWithoutMeta() {
       exportProgress.style.display = 'inline';
       try {
@@ -296,6 +322,7 @@
     document.getElementById('git-diff').addEventListener('click', showDiff);
 
     refreshLog();
+    startAutoSync();
 
     parseAndRender();
   </script>


### PR DESCRIPTION
## Summary
- add configurable auto-sync settings with interval and toggle
- poll new backend watch endpoint to refresh blocks automatically

## Testing
- `npm test`
- `cargo test --manifest-path backend/Cargo.toml` *(fails: missing system library webkit2gtk-4.1)*

------
https://chatgpt.com/codex/tasks/task_e_689d5fb57eec8323b29a15932229fba7