### PR TITLE
feat: add inline block editor for visual canvas blocks

### DIFF
--- a/frontend/src/visual/block-editor.test.ts
+++ b/frontend/src/visual/block-editor.test.ts
@@ -1,0 +1,41 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+vi.mock('../editor/visual-meta.js', () => ({
+  updateMetaComment: vi.fn()
+}));
+import { openBlockEditor } from './block-editor.ts';
+import { updateMetaComment } from '../editor/visual-meta.js';
+
+describe('block editor', () => {
+  it('saves changes and updates meta', () => {
+    const dispatch = vi.fn();
+    const text = 'old';
+    const metaView = {
+      state: { doc: { sliceString: (f: number, t: number) => text.slice(f, t) } },
+      dispatch
+    } as any;
+
+    const vc: any = {
+      canvas: { getBoundingClientRect: () => ({ left: 0, top: 0 }) } as any,
+      metaView,
+      blockDataMap: new Map([
+        ['a', { range: [0, text.length] }]
+      ]),
+      upsertMeta: vi.fn(),
+      fileId: 'f1',
+      scale: 1,
+      offset: { x: 0, y: 0 }
+    };
+
+    openBlockEditor(vc, { id: 'a', x: 0, y: 0, w: 10, h: 10 });
+    const textarea = document.querySelector('textarea')!;
+    textarea.value = 'new';
+    const btn = Array.from(document.querySelectorAll('button')).find(b => b.textContent === 'Save')!;
+    btn.dispatchEvent(new Event('click'));
+
+    expect(dispatch).toHaveBeenCalledWith({ changes: { from: 0, to: text.length, insert: 'new' } });
+    expect(updateMetaComment).toHaveBeenCalled();
+    expect(vc.upsertMeta).toHaveBeenCalledWith({ id: 'a' }, ['f1']);
+  });
+});
+

--- a/frontend/src/visual/block-editor.ts
+++ b/frontend/src/visual/block-editor.ts
@@ -1,0 +1,71 @@
+import { updateMetaComment } from '../editor/visual-meta.js';
+import type { EditorView } from '@codemirror/view';
+
+export interface VisualCanvasLike {
+  canvas: HTMLCanvasElement;
+  metaView: EditorView | null;
+  blockDataMap: Map<string, any>;
+  upsertMeta(meta: any, fileIds: string[]): Promise<void> | void;
+  fileId: string;
+  scale: number;
+  offset: { x: number; y: number };
+}
+
+export function openBlockEditor(vc: VisualCanvasLike, block: { id: string; x: number; y: number; w: number; h: number }) {
+  if (!vc.metaView) return;
+  const data = vc.blockDataMap.get(block.id);
+  if (!data || !Array.isArray(data.range)) return;
+
+  const rect = vc.canvas.getBoundingClientRect();
+  const left = block.x * vc.scale + vc.offset.x + rect.left;
+  const top = block.y * vc.scale + vc.offset.y + rect.top;
+  const width = block.w * vc.scale;
+  const height = block.h * vc.scale;
+
+  const overlay = document.createElement('div');
+  overlay.style.position = 'fixed';
+  overlay.style.left = left + 'px';
+  overlay.style.top = top + 'px';
+  overlay.style.zIndex = '1000';
+  overlay.style.background = '#fff';
+  overlay.style.border = '1px solid #ccc';
+  overlay.style.padding = '4px';
+
+  const textarea = document.createElement('textarea');
+  textarea.style.width = width + 'px';
+  textarea.style.height = height + 'px';
+  textarea.value = vc.metaView.state.doc.sliceString(data.range[0], data.range[1]);
+  overlay.appendChild(textarea);
+
+  const btnBar = document.createElement('div');
+  btnBar.style.textAlign = 'right';
+  btnBar.style.marginTop = '4px';
+
+  const saveBtn = document.createElement('button');
+  saveBtn.textContent = 'Save';
+  const cancelBtn = document.createElement('button');
+  cancelBtn.textContent = 'Cancel';
+
+  btnBar.appendChild(saveBtn);
+  btnBar.appendChild(cancelBtn);
+  overlay.appendChild(btnBar);
+
+  function close() {
+    overlay.remove();
+  }
+
+  cancelBtn.addEventListener('click', close);
+  saveBtn.addEventListener('click', () => {
+    const newText = textarea.value;
+    vc.metaView?.dispatch({ changes: { from: data.range[0], to: data.range[1], insert: newText } });
+    updateMetaComment(vc.metaView!, { id: block.id });
+    try {
+      vc.upsertMeta({ id: block.id }, [vc.fileId]);
+    } catch (_) {}
+    close();
+  });
+
+  document.body.appendChild(overlay);
+  textarea.focus();
+}
+

--- a/frontend/src/visual/canvas.js
+++ b/frontend/src/visual/canvas.js
@@ -5,6 +5,7 @@ import { Minimap } from './minimap.ts';
 import settings from '../../settings.json' assert { type: 'json' };
 import { createTwoFilesPatch } from 'diff';
 import { updateMetaComment, previewDiff } from '../editor/visual-meta.js';
+import { openBlockEditor } from './block-editor.ts';
 
 export const VIEW_STATE_KEY = 'visual-view-state';
 
@@ -450,9 +451,9 @@ export class VisualCanvas {
     this.canvas.addEventListener('dblclick', e => {
       const pos = this.toWorld(e.offsetX, e.offsetY);
       const block = this.blocks.find(b => b.contains(pos.x, pos.y));
-      if (block && typeof window.openInTextEditor === 'function') {
+      if (block) {
         this.saveViewState();
-        window.openInTextEditor(block.id);
+        openBlockEditor(this, block);
       }
     });
 


### PR DESCRIPTION
## Summary
- add block-editor component overlay for editing blocks in place
- open mini editor on block double click instead of switching to text mode
- update meta comment and document via visual-meta when saving

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689da86a7a248323afd84876c9a415f3