### PR TITLE
feat: enable visual block rename

### DIFF
--- a/frontend/src/visual/hotkeys.ts
+++ b/frontend/src/visual/hotkeys.ts
@@ -82,6 +82,10 @@ function handleKey(e: KeyboardEvent) {
       e.preventDefault();
       canvasRef?.redo?.();
       break;
+    case 'F2':
+      e.preventDefault();
+      canvasRef?.renameSelectedBlock?.();
+      break;
     case 'ArrowUp':
     case 'ArrowDown':
     case 'ArrowLeft':


### PR DESCRIPTION
## Summary
- add F2 action to rename selected block
- search & replace block id across meta and code with confirmation dialog
- cover block renaming with tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689dae41efa4832393e958529b8006c8