### PR TITLE
fix: register uint32 format in split view

### DIFF
--- a/frontend/src/layout/splitView.ts
+++ b/frontend/src/layout/splitView.ts
@@ -6,6 +6,10 @@ import schema from '../editor/meta.schema.json' with { type: 'json' };
 
 const ajv = new Ajv({ allErrors: true });
 addFormats(ajv);
+ajv.addFormat('uint32', {
+  type: 'number',
+  validate: (n: number) => Number.isInteger(n) && n >= 0 && n <= 0xffffffff
+});
 const validateMeta = ajv.compile(schema);
 
 interface Panel {


### PR DESCRIPTION
## Summary
- register custom `uint32` AJV format so split view metadata validates

## Testing
- `npm test`
- `npm --prefix frontend run lint` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_689dc90c8098832389163890ae0adfc0