### PR TITLE
feat: introduce event bus for visual modules

### DIFF
--- a/docs/event-bus-plugin-example.md
+++ b/docs/event-bus-plugin-example.md
@@ -1,0 +1,17 @@
+# Plugin reacting to events
+
+Plugins can subscribe to the shared event bus (`frontend/src/shared/event-bus.js`) to react to editor actions.
+
+```js
+import { on } from '../src/shared/event-bus.js';
+
+export default function activate() {
+  on('blockSelected', ({ id }) => {
+    console.log('Selected block:', id);
+  });
+
+  on('metaUpdated', meta => {
+    console.log('Meta updated:', meta);
+  });
+}
+```

--- a/frontend/src/shared/event-bus.js
+++ b/frontend/src/shared/event-bus.js
@@ -1,0 +1,46 @@
+// Simple shared event bus for frontend modules.
+// Events:
+// - blockSelected { id: string }
+// - blockInfoRequest { id: string }
+// - blockInfo { id: string, kind: string, color: string, thumbnail?: string }
+// - metaUpdated { id: string, x?: number, y?: number }
+// - edgeNotFound { from: string, to: string }
+// - blockCreated { id: string, kind: string }
+// - blockRemoved { id: string }
+// - lintReported { errors: Record<string,string> }
+// - testResult { id: string, success: boolean }
+// - edgeSelected { from: string, to: string }
+// - blocksReordered { ids: string[] }
+// - refreshText { updates: Record<string,string> }
+const listeners = new Map();
+
+/**
+ * Subscribe to event.
+ * @param {string} event
+ * @param {(data:any)=>void} handler
+ * @returns {() => void}
+ */
+export function on(event, handler) {
+  if (!listeners.has(event)) listeners.set(event, new Set());
+  listeners.get(event).add(handler);
+  return () => listeners.get(event)?.delete(handler);
+}
+
+/**
+ * Emit event to subscribers.
+ * @param {string} event
+ * @param {any} data
+ */
+export function emit(event, data) {
+  const handlers = listeners.get(event);
+  if (handlers) {
+    handlers.forEach(fn => {
+      try {
+        fn(data);
+      } catch (e) {
+        console.error('event handler error', e);
+      }
+    });
+  }
+}
+


### PR DESCRIPTION
## Summary
- add shared event bus with emit/on utilities
- route canvas and visual-meta communication through event bus
- document plugin example responding to events

## Testing
- `npm test`
- `npm --prefix frontend run lint` *(fails: ESLint couldn't find eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_689ddc51837c8323b51a8c25c630d8ae