### PR TITLE
feat: navigate to related files

### DIFF
--- a/frontend/src/editor/navigation.js
+++ b/frontend/src/editor/navigation.js
@@ -1,0 +1,46 @@
+export const RELATED_EXTS = ['js', 'ts', 'jsx', 'tsx', 'json', 'html', 'css', 'md'];
+
+/**
+ * Attempt to open a file related to the current editor file.
+ * Tries files with the same basename but different extensions in the
+ * same directory.  If a related file is found it is opened using the
+ * global `openFile` function.  Displays an alert if no related file
+ * exists.
+ *
+ * @param {import('@codemirror/view').EditorView} view
+ */
+export async function gotoRelated(view) {
+  const el = view?.dom;
+  const current = el?.dataset?.fileId;
+  if (!current) {
+    alert('Related file not found');
+    return;
+  }
+
+  const slash = current.lastIndexOf('/');
+  const dir = slash === -1 ? '' : current.slice(0, slash + 1);
+  const file = slash === -1 ? current : current.slice(slash + 1);
+  const dot = file.lastIndexOf('.');
+  const name = dot === -1 ? file : file.slice(0, dot);
+  const ext = dot === -1 ? '' : file.slice(dot + 1);
+
+  for (const candidateExt of RELATED_EXTS) {
+    if (candidateExt === ext) continue;
+    const candidatePath = `${dir}${name}.${candidateExt}`;
+    try {
+      const res = await fetch(candidatePath);
+      if (res.ok) {
+        const text = await res.text();
+        if (typeof window !== 'undefined' && typeof window.openFile === 'function') {
+          await window.openFile(candidatePath, text);
+          el.dataset.fileId = candidatePath;
+        }
+        return;
+      }
+    } catch (_) {
+      // ignore errors and try next extension
+    }
+  }
+
+  alert('Related file not found');
+}

--- a/frontend/src/visual/hotkeys.ts
+++ b/frontend/src/visual/hotkeys.ts
@@ -3,6 +3,7 @@ import { createBlock } from './blocks.js';
 import { getTheme } from './theme.ts';
 import { createHotkeyDialog } from './hotkey-dialog.ts';
 import type { VisualCanvas } from './canvas.js';
+import { gotoRelated } from '../editor/navigation.js';
 
 export interface HotkeyMap {
   copyBlock: string;
@@ -13,6 +14,7 @@ export interface HotkeyMap {
   zoomToFit: string;
   undo: string;
   redo: string;
+  gotoRelated: string;
 }
 
 const cfg: { hotkeys?: Partial<HotkeyMap>; visual?: { gridSize?: number } } = settings as any;
@@ -26,7 +28,8 @@ export const hotkeys: HotkeyMap = {
   showHelp: cfg.hotkeys?.showHelp || 'Ctrl+?',
   zoomToFit: cfg.hotkeys?.zoomToFit || 'Ctrl+0',
   undo: cfg.hotkeys?.undo || 'Ctrl+Z',
-  redo: cfg.hotkeys?.redo || 'Ctrl+Shift+Z'
+  redo: cfg.hotkeys?.redo || 'Ctrl+Shift+Z',
+  gotoRelated: cfg.hotkeys?.gotoRelated || 'Ctrl+Alt+O'
 };
 
 function buildCombo(e: KeyboardEvent) {
@@ -81,6 +84,10 @@ function handleKey(e: KeyboardEvent) {
     case hotkeys.redo:
       e.preventDefault();
       canvasRef?.redo?.();
+      break;
+    case hotkeys.gotoRelated:
+      e.preventDefault();
+      gotoRelated((globalThis as any).view);
       break;
     case 'F2':
       e.preventDefault();


### PR DESCRIPTION
## Summary
- add navigation helper to jump to related source files
- bind Ctrl+Alt+O hotkey to open related files and alert when missing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689df505f1108323a7102d1641fb4baf