### PR TITLE
fix depcheck false positive for CDN imports

### DIFF
--- a/frontend/.depcheckrc
+++ b/frontend/.depcheckrc
@@ -1,0 +1,2 @@
+ignores:
+  - "https:"


### PR DESCRIPTION
## Summary
- ignore https URL imports in depcheck

## Testing
- `npx depcheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689df80fbe34832397ad39526a88f4d2