### PR TITLE
Add CodeMirror minimap and scroll margins

### DIFF
--- a/frontend/src/editor/minimap.ts
+++ b/frontend/src/editor/minimap.ts
@@ -1,11 +1,13 @@
 import { EditorView } from "@codemirror/view";
+import { StateEffect } from "@codemirror/state";
 
 /**
- * Attach a simple minimap to a CodeMirror editor.
- * The minimap renders a tiny representation of the document and highlights
- * the current viewport of the editor.
+ * Attach a minimap to a CodeMirror editor.
+ * Renders a tiny overview and keeps scroll position in sync
+ * between the minimap and the main editor.
  */
 export function attachMinimap(view: EditorView, container: HTMLElement) {
+  container.innerHTML = "";
   const canvas = document.createElement("canvas");
   canvas.style.width = "100%";
   canvas.style.height = "100%";
@@ -13,31 +15,66 @@ export function attachMinimap(view: EditorView, container: HTMLElement) {
   container.appendChild(canvas);
 
   function draw() {
-    const lineHeight = 2;
-    const lines = view.state.doc.lines;
     canvas.width = container.clientWidth;
-    canvas.height = lines * lineHeight;
+    canvas.height = container.clientHeight;
     const ctx = canvas.getContext("2d");
     if (!ctx) return;
     ctx.clearRect(0, 0, canvas.width, canvas.height);
 
+    // Render a simple representation of lines
+    const lineHeight = canvas.height / view.state.doc.lines;
     ctx.fillStyle = "#bbb";
-    for (let i = 0; i < lines; i++) {
+    for (let i = 0; i < view.state.doc.lines; i++) {
       ctx.fillRect(0, i * lineHeight, canvas.width, 1);
     }
 
     const totalHeight = view.scrollDOM.scrollHeight;
     const visible = view.scrollDOM.clientHeight;
     const scrollTop = view.scrollDOM.scrollTop;
-    const ratio = visible / totalHeight;
-    const top = (scrollTop / totalHeight) * canvas.height;
-    const height = ratio * canvas.height;
+    const scale = canvas.height / totalHeight;
+    const top = scrollTop * scale;
+    const height = visible * scale;
 
     ctx.fillStyle = "rgba(0,0,0,0.2)";
     ctx.fillRect(0, top, canvas.width, height);
   }
 
-  view.scrollDOM.addEventListener("scroll", draw);
   draw();
-}
+  view.scrollDOM.addEventListener("scroll", draw);
 
+  view.dispatch({
+    effects: StateEffect.appendConfig.of(
+      EditorView.updateListener.of(update => {
+        if (update.docChanged || update.viewportChanged) draw();
+      })
+    )
+  });
+
+  let dragging = false;
+  function setScroll(e: MouseEvent) {
+    const rect = canvas.getBoundingClientRect();
+    const y = e.clientY - rect.top;
+    const ratio = y / rect.height;
+    view.scrollDOM.scrollTop =
+      ratio * view.scrollDOM.scrollHeight - view.scrollDOM.clientHeight / 2;
+  }
+
+  canvas.addEventListener("mousedown", e => {
+    dragging = true;
+    setScroll(e);
+  });
+  const moveHandler = (e: MouseEvent) => {
+    if (dragging) setScroll(e);
+  };
+  const upHandler = () => {
+    dragging = false;
+  };
+  window.addEventListener("mousemove", moveHandler);
+  window.addEventListener("mouseup", upHandler);
+
+  return () => {
+    view.scrollDOM.removeEventListener("scroll", draw);
+    window.removeEventListener("mousemove", moveHandler);
+    window.removeEventListener("mouseup", upHandler);
+  };
+}

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -9,7 +9,9 @@
     body { margin: 0; font-family: sans-serif; }
     #visual-canvas { width: 100%; height: 50vh; border: 1px solid #ccc; display: block; }
     #visual-minimap { position: fixed; bottom: 10px; right: 10px; width: 200px; height: 150px; border: 1px solid #ccc; background: #fff; opacity: 0.8; }
-    #editor { height: 40vh; border: 1px solid #ccc; }
+    #editor-wrapper { display: flex; height: 40vh; }
+    #editor { flex: 1; border: 1px solid #ccc; }
+    #text-minimap { width: 60px; height: 100%; border: 1px solid #ccc; border-left: none; }
     #controls { padding: 0.5rem; }
     #git-panel { padding: 0.5rem; border-top: 1px solid #ccc; }
     #git-log { white-space: pre-wrap; background: #f5f5f5; max-height: 20vh; overflow: auto; padding: 0.5rem; }
@@ -40,15 +42,18 @@
     import { writeTextFile, BaseDirectory } from "https://cdn.jsdelivr.net/npm/@tauri-apps/api@1.5.0/fs.js";
     import { searchAll, highlightResults, gotoResult } from "./shared/search.js";
     import { emit } from "./shared/event-bus.js";
+    import { attachMinimap } from "./editor/minimap.ts";
 
     const TEXT_CURSOR_KEY = 'text-cursor-pos';
     let view;
+    let removeMinimap;
 
     await loadBlockPlugins(window.blockPlugins || []);
 
     const canvasEl = document.getElementById('visual-canvas');
     const minimapEl = document.getElementById('visual-minimap');
     const vc = new VisualCanvas(canvasEl, minimapEl);
+    const textMinimapEl = document.getElementById('text-minimap');
 
     const storedView = localStorage.getItem(VIEW_STATE_KEY);
     if (storedView) {
@@ -111,6 +116,7 @@
       currentLang = lang;
       vc.lang = lang;
       if (view) view.destroy();
+      if (removeMinimap) removeMinimap();
       const langSupport = await loadLanguage(lang);
       view = new EditorView({
         state: EditorState.create({
@@ -122,6 +128,7 @@
             visualMetaTooltip,
             visualMetaMessenger,
             foldGutter(),
+            EditorView.scrollMargins.of(() => ({ top: 20, bottom: 20 })),
             keymap.of(foldKeymap),
             EditorView.updateListener.of(update => {
               if (update.docChanged) parseAndRender();
@@ -130,6 +137,7 @@
         }),
         parent: document.getElementById('editor')
       });
+      removeMinimap = attachMinimap(view, textMinimapEl);
       vc.setMetaView(view);
       addBlockToolbar(view, vc, currentLang);
       vc.onBlockMove(async () => {
@@ -142,7 +150,7 @@
       window.openInTextEditor = id => {
       document.getElementById('visual-canvas').style.display = 'none';
       document.getElementById('visual-minimap').style.display = 'none';
-      document.getElementById('editor').style.height = '90vh';
+      document.getElementById('editor-wrapper').style.height = '90vh';
       if (id) {
         scrollToMeta(id);
       } else {
@@ -164,7 +172,7 @@
       localStorage.setItem(TEXT_CURSOR_KEY, JSON.stringify({ pos: sel.anchor }));
       document.getElementById('visual-canvas').style.display = 'block';
       document.getElementById('visual-minimap').style.display = 'block';
-      document.getElementById('editor').style.height = '40vh';
+      document.getElementById('editor-wrapper').style.height = '40vh';
       vc.draw();
     };
 
@@ -382,7 +390,10 @@
       <canvas id="visual-minimap" width="200" height="150"></canvas>
     </div>
     <div id="textPane">
-      <div id="editor" data-file-id="current"></div>
+      <div id="editor-wrapper">
+        <div id="editor" data-file-id="current"></div>
+        <div id="text-minimap"></div>
+      </div>
       <div id="controls">
         <button id="save">Save</button>
         <button id="load">Load</button>


### PR DESCRIPTION
## Summary
- add `attachMinimap` helper rendering a synchronized CodeMirror minimap
- wire minimap into editor and enable `EditorView.scrollMargins`
- style editor layout to include a canvas minimap next to the main view

## Testing
- `npm test`
- `npx -y eslint .` *(fails: ESLint couldn't find an eslint.config.)*

------
https://chatgpt.com/codex/tasks/task_e_689dff51886083239484dfed4cbbb233