### PR TITLE
feat: add custom autocomplete

### DIFF
--- a/frontend/src/editor/autocomplete.js
+++ b/frontend/src/editor/autocomplete.js
@@ -1,0 +1,33 @@
+// Store current block identifiers for suggestions
+let blockIds = [];
+
+// Simple list of keywords offered in completion
+const keywords = [
+  "function",
+  "return",
+  "const",
+  "let",
+  "if",
+  "else",
+  "for",
+  "while"
+];
+
+export function setBlockIds(ids) {
+  blockIds = Array.isArray(ids) ? ids : [];
+}
+
+// Custom completion source combining block ids and keywords
+export const customSource = context => {
+  const word = context.matchBefore(/\w*/);
+  if (!word || (word.from === word.to && !context.explicit)) return null;
+  const options = [
+    ...blockIds.map(id => ({ label: id, type: "variable" })),
+    ...keywords.map(kw => ({ label: kw, type: "keyword" }))
+  ];
+  return {
+    from: word.from,
+    options,
+    validFor: /^\w*$/
+  };
+};

--- a/frontend/src/editor/visual-meta.js
+++ b/frontend/src/editor/visual-meta.js
@@ -84,6 +84,11 @@ function rebuildMetaPositions(text) {
   }
 }
 
+export function listMetaIds(text) {
+  rebuildMetaPositions(text);
+  return Array.from(metaPositions.keys());
+}
+
 function extractMetaCoords(text) {
   const map = new Map();
   const block = getMetaBlock(text);

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -30,13 +30,15 @@
     import { foldGutter } from "@codemirror/language";
     import { foldKeymap } from "https://cdn.jsdelivr.net/npm/@codemirror/commands@6.8.1/dist/index.js";
     import { basicSetup } from "https://cdn.jsdelivr.net/npm/@codemirror/basic-setup@0.20.0/dist/index.js";
+    import { autocompletion as autocomplete } from "https://cdn.jsdelivr.net/npm/@codemirror/autocomplete@6.18.6/dist/index.js";
     import { invoke } from "https://cdn.jsdelivr.net/npm/@tauri-apps/api@1.5.0/tauri.js";
     import { save as saveDialog } from "https://cdn.jsdelivr.net/npm/@tauri-apps/api@1.5.0/dialog.js";
     import { VisualCanvas, VIEW_STATE_KEY } from "./visual/canvas.js";
     import { languageFromFilename, loadLanguage, mimeFromFilename } from "./shared/mime-map.js";
     import { loadBlockPlugins } from "./visual/blocks.js";
-    import { insertVisualMeta, visualMetaHighlighter, visualMetaTooltip, foldMetaBlock, visualMetaMessenger, scrollToMeta, addBlockToolbar, refreshBlockCount } from "./editor/visual-meta.js";
+    import { insertVisualMeta, visualMetaHighlighter, visualMetaTooltip, foldMetaBlock, visualMetaMessenger, scrollToMeta, addBlockToolbar, refreshBlockCount, listMetaIds } from "./editor/visual-meta.js";
     import { registerHotkeys, setCanvas } from "./visual/hotkeys.ts";
+    import { customSource, setBlockIds } from "./editor/autocomplete.js";
     import settings from "../settings.json" assert { type: 'json' };
     import { availableThemes, applyTheme, getThemeName } from "./visual/theme.ts";
     import { writeTextFile, BaseDirectory } from "https://cdn.jsdelivr.net/npm/@tauri-apps/api@1.5.0/fs.js";
@@ -128,6 +130,7 @@
             visualMetaTooltip,
             visualMetaMessenger,
             foldGutter(),
+            autocomplete({ override: [customSource] }),
             EditorView.scrollMargins.of(() => ({ top: 20, bottom: 20 })),
             keymap.of(foldKeymap),
             EditorView.updateListener.of(update => {
@@ -137,6 +140,7 @@
         }),
         parent: document.getElementById('editor')
       });
+      setBlockIds(listMetaIds(view.state.doc.toString()));
       removeMinimap = attachMinimap(view, textMinimapEl);
       vc.setMetaView(view);
       addBlockToolbar(view, vc, currentLang);
@@ -194,6 +198,7 @@
       document.getElementById('editor').dataset.mime = mime;
       parseAndRender();
       foldMetaBlock(view);
+      setBlockIds(listMetaIds(view.state.doc.toString()));
     }
 
     window.openFile = openFile;


### PR DESCRIPTION
## Summary
- add custom autocomplete source for block IDs and keywords
- wire CodeMirror autocompletion into the editor
- expose helper to list all meta block ids

## Testing
- `npm test`
- `npm --prefix frontend run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_689e06f40960832394259b2b4cfde58e