### PR TITLE
feat: add frontend formatter

### DIFF
--- a/frontend/scripts/format.js
+++ b/frontend/scripts/format.js
@@ -1,0 +1,40 @@
+import prettier from 'https://cdn.jsdelivr.net/npm/prettier@3.3.2/standalone.mjs';
+import parserBabel from 'https://cdn.jsdelivr.net/npm/prettier@3.3.2/parser-babel.mjs';
+import parserHtml from 'https://cdn.jsdelivr.net/npm/prettier@3.3.2/parser-html.mjs';
+import parserTypescript from 'https://cdn.jsdelivr.net/npm/prettier@3.3.2/parser-typescript.mjs';
+import settings from '../settings.json' assert { type: 'json' };
+
+export function formatCurrentFile() {
+  const view = globalThis.view;
+  if (!view) return;
+  const lang = globalThis.currentLang;
+  let parser;
+  switch (lang) {
+    case 'typescript':
+    case 'ts':
+      parser = 'typescript';
+      break;
+    case 'javascript':
+    case 'js':
+      parser = 'babel';
+      break;
+    case 'html':
+      parser = 'html';
+      break;
+    default:
+      return;
+  }
+  const doc = view.state.doc.toString();
+  try {
+    const formatted = prettier.format(doc, {
+      parser,
+      plugins: [parserBabel, parserHtml, parserTypescript],
+      ...(settings.format || {})
+    });
+    view.dispatch({
+      changes: { from: 0, to: doc.length, insert: formatted }
+    });
+  } catch (err) {
+    console.error('format error', err);
+  }
+}

--- a/frontend/settings.json
+++ b/frontend/settings.json
@@ -4,7 +4,8 @@
     "pasteBlock": "Ctrl+V",
     "selectConnections": "Ctrl+Shift+A",
     "focusSearch": "Ctrl+F",
-    "showHelp": "Ctrl+?"
+    "showHelp": "Ctrl+?",
+    "formatCurrentFile": "Shift+Alt+F"
   },
   "visual": {
     "theme": "default",
@@ -18,6 +19,11 @@
     "autoFoldMeta": true,
     "autoSync": false,
     "autoSyncInterval": 5
+  },
+  "format": {
+    "tabWidth": 2,
+    "singleQuote": true,
+    "semi": true
   },
   "plugins": {}
 }

--- a/frontend/src/visual/hotkeys.ts
+++ b/frontend/src/visual/hotkeys.ts
@@ -4,6 +4,7 @@ import { getTheme } from './theme.ts';
 import { createHotkeyDialog } from './hotkey-dialog.ts';
 import type { VisualCanvas } from './canvas.js';
 import { gotoRelated } from '../editor/navigation.js';
+import { formatCurrentFile } from '../../scripts/format.js';
 
 export interface HotkeyMap {
   copyBlock: string;
@@ -15,6 +16,7 @@ export interface HotkeyMap {
   undo: string;
   redo: string;
   gotoRelated: string;
+  formatCurrentFile: string;
 }
 
 const cfg: { hotkeys?: Partial<HotkeyMap>; visual?: { gridSize?: number } } = settings as any;
@@ -29,7 +31,8 @@ export const hotkeys: HotkeyMap = {
   zoomToFit: cfg.hotkeys?.zoomToFit || 'Ctrl+0',
   undo: cfg.hotkeys?.undo || 'Ctrl+Z',
   redo: cfg.hotkeys?.redo || 'Ctrl+Shift+Z',
-  gotoRelated: cfg.hotkeys?.gotoRelated || 'Ctrl+Alt+O'
+  gotoRelated: cfg.hotkeys?.gotoRelated || 'Ctrl+Alt+O',
+  formatCurrentFile: cfg.hotkeys?.formatCurrentFile || 'Shift+Alt+F'
 };
 
 function buildCombo(e: KeyboardEvent) {
@@ -88,6 +91,10 @@ function handleKey(e: KeyboardEvent) {
     case hotkeys.gotoRelated:
       e.preventDefault();
       gotoRelated((globalThis as any).view);
+      break;
+    case hotkeys.formatCurrentFile:
+      e.preventDefault();
+      formatCurrentFile();
       break;
     case 'F2':
       e.preventDefault();


### PR DESCRIPTION
## Summary
- add browser-based `formatCurrentFile` using Prettier
- bind Shift+Alt+F to format current file
- configure default formatting options in settings

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e0c71c7648323b2176d640d7f7518