### PR TITLE
feat: add editor history snapshots

### DIFF
--- a/frontend/src/editor/history.js
+++ b/frontend/src/editor/history.js
@@ -1,0 +1,68 @@
+const MAX_SNAPSHOTS = 20;
+const snapshots = [];
+
+/**
+ * Add a snapshot of the current editor content.
+ * @param {import('@codemirror/view').EditorView} view
+ */
+export function addSnapshot(view) {
+  if (!view) return;
+  const content = view.state.doc.toString();
+  snapshots.push({ timestamp: new Date().toISOString(), content });
+  if (snapshots.length > MAX_SNAPSHOTS) snapshots.shift();
+}
+
+/**
+ * Show dialog to select and restore a previous snapshot.
+ * @param {import('@codemirror/view').EditorView} view
+ */
+export function showHistory(view) {
+  if (!view || snapshots.length === 0) {
+    if (typeof alert === 'function') alert('No history');
+    return;
+  }
+
+  const dialog = document.createElement('dialog');
+  const select = document.createElement('select');
+  select.size = 10;
+
+  snapshots.forEach((snap, idx) => {
+    const opt = document.createElement('option');
+    opt.value = String(idx);
+    opt.textContent = `${idx + 1}: ${snap.timestamp}`;
+    select.appendChild(opt);
+  });
+
+  const okBtn = document.createElement('button');
+  okBtn.textContent = 'Restore';
+  okBtn.addEventListener('click', () => {
+    const idx = parseInt(select.value, 10);
+    const snap = snapshots[idx];
+    if (snap) {
+      view.dispatch({
+        changes: { from: 0, to: view.state.doc.length, insert: snap.content },
+      });
+    }
+    dialog.close();
+    dialog.remove();
+  });
+
+  const cancelBtn = document.createElement('button');
+  cancelBtn.textContent = 'Cancel';
+  cancelBtn.addEventListener('click', () => {
+    dialog.close();
+    dialog.remove();
+  });
+
+  dialog.appendChild(select);
+  dialog.appendChild(okBtn);
+  dialog.appendChild(cancelBtn);
+  document.body.appendChild(dialog);
+  if (typeof dialog.showModal === 'function') {
+    dialog.showModal();
+  } else {
+    dialog.style.display = 'block';
+  }
+}
+
+export { snapshots };

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -45,6 +45,7 @@
     import { searchAll, highlightResults, gotoResult } from "./shared/search.js";
     import { emit } from "./shared/event-bus.js";
     import { attachMinimap } from "./editor/minimap.ts";
+    import { addSnapshot, showHistory } from "./editor/history.js";
 
     const TEXT_CURSOR_KEY = 'text-cursor-pos';
     let view;
@@ -182,6 +183,7 @@
 
     async function save() {
       await invoke('save_state', { content: view.state.doc.toString() });
+      addSnapshot(view);
     }
 
     async function load() {
@@ -283,6 +285,7 @@
     document.getElementById('layout-import').addEventListener('click', importLayout);
     document.getElementById('undo').addEventListener('click', () => vc.undo());
     document.getElementById('redo').addEventListener('click', () => vc.redo());
+    document.getElementById('history').addEventListener('click', () => showHistory(view));
     document.getElementById('insert-meta').addEventListener('click', () => {
       insertVisualMeta(view, currentLang);
       foldMetaBlock(view);
@@ -408,6 +411,7 @@
         <button id="layout-import">Import</button>
         <button id="undo">Undo</button>
         <button id="redo">Redo</button>
+        <button id="history">History</button>
         <button id="insert-meta">Insert Meta</button>
         <select id="theme"></select>
         <select id="locale">


### PR DESCRIPTION
## Summary
- track up to 20 editor snapshots and restore via dialog
- add History button and snapshot tracking on save

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e1317f48483239a44a104085219a9