### PR TITLE
feat: add comment spellcheck

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,7 +17,8 @@
     "ajv": "^8.17.1",
     "ajv-formats": "^2.1.1",
     "xterm": "^5.3.0",
-    "diff": "^5.2.0"
+    "diff": "^5.2.0",
+    "typo-js": "^1.3.0"
   },
   "devDependencies": {
     "jsdom": "^23.0.0",

--- a/frontend/settings.json
+++ b/frontend/settings.json
@@ -18,7 +18,8 @@
   "editor": {
     "autoFoldMeta": true,
     "autoSync": false,
-    "autoSyncInterval": 5
+    "autoSyncInterval": 5,
+    "spellcheck": false
   },
   "format": {
     "tabWidth": 2,

--- a/frontend/src/editor/spellcheck.js
+++ b/frontend/src/editor/spellcheck.js
@@ -1,0 +1,63 @@
+import Typo from "typo-js";
+import { syntaxTree } from "@codemirror/language";
+import { RangeSetBuilder } from "@codemirror/state";
+import { Decoration, EditorView, ViewPlugin } from "@codemirror/view";
+
+let dictPromise;
+
+async function loadDictionary() {
+  if (!dictPromise) {
+    dictPromise = Promise.all([
+      fetch("https://cdn.jsdelivr.net/npm/typo-js@1.3.0/dictionaries/en_US/en_US.aff").then(r => r.text()),
+      fetch("https://cdn.jsdelivr.net/npm/typo-js@1.3.0/dictionaries/en_US/en_US.dic").then(r => r.text())
+    ]).then(([aff, dic]) => new Typo("en_US", aff, dic));
+  }
+  return dictPromise;
+}
+
+export async function spellcheck() {
+  const dictionary = await loadDictionary();
+
+  const plugin = ViewPlugin.fromClass(class {
+    constructor(view) {
+      this.decorations = this.buildDeco(view);
+    }
+    update(update) {
+      if (update.docChanged || update.viewportChanged) {
+        this.decorations = this.buildDeco(update.view);
+      }
+    }
+    buildDeco(view) {
+      const builder = new RangeSetBuilder();
+      const { from, to } = view.viewport;
+      const tree = syntaxTree(view.state);
+      tree.iterate({
+        from,
+        to,
+        enter: node => {
+          if (!node.type.is("comment")) return;
+          const text = view.state.doc.sliceString(node.from, node.to);
+          const word = /\b[A-Za-z]+\b/g;
+          let m;
+          while ((m = word.exec(text)) !== null) {
+            const w = m[0];
+            if (!dictionary.check(w)) {
+              const start = node.from + m.index;
+              const end = start + w.length;
+              builder.add(start, end, Decoration.mark({ class: "cm-spell-error" }));
+            }
+          }
+        }
+      });
+      return builder.finish();
+    }
+  }, {
+    decorations: v => v.decorations
+  });
+
+  const theme = EditorView.baseTheme({
+    ".cm-spell-error": { textDecoration: "underline wavy red" }
+  });
+
+  return [plugin, theme];
+}

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -46,6 +46,7 @@
     import { emit } from "./shared/event-bus.js";
     import { attachMinimap } from "./editor/minimap.ts";
     import { addSnapshot, showHistory } from "./editor/history.js";
+    import { spellcheck } from "./editor/spellcheck.js";
 
     const TEXT_CURSOR_KEY = 'text-cursor-pos';
     let view;
@@ -121,12 +122,14 @@
       if (view) view.destroy();
       if (removeMinimap) removeMinimap();
       const langSupport = await loadLanguage(lang);
+      const spellExt = settings.editor?.spellcheck ? await spellcheck() : [];
       view = new EditorView({
         state: EditorState.create({
           doc,
           extensions: [
             basicSetup,
             langSupport || [],
+            ...spellExt,
             visualMetaHighlighter,
             visualMetaTooltip,
             visualMetaMessenger,

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "ajv": "^8.17.1",
         "ajv-formats": "^2.1.1",
         "diff": "^5.2.0",
+        "typo-js": "^1.3.0",
         "xterm": "^5.3.0"
       },
       "devDependencies": {
@@ -2633,6 +2634,12 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/typo-js": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/typo-js/-/typo-js-1.3.0.tgz",
+      "integrity": "sha512-ERVoYp5PG7jpj7+kzKmFZfp5+IYMOOQM3etNnlYu06Z2CL5UmC9ekT8Z/JVYpR7e7sXB4bOFq1fz/budv++Z0g==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/universalify": {
       "version": "2.0.1",


### PR DESCRIPTION
## Summary
- integrate typo.js spellcheck extension for CodeMirror
- only highlight spelling errors inside comment tokens
- add `editor.spellcheck` setting and wire into editor

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689e17dede1c8323a524fbd4a2919e65