### PR TITLE
feat: report visual meta diagnostics

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,11 +9,14 @@
       "version": "0.1.0",
       "dependencies": {
         "@codemirror/language": "^6.10.1",
+        "@codemirror/lint": "^6.8.5",
         "@codemirror/state": "^6.4.0",
         "@codemirror/view": "^6.21.3",
         "@tauri-apps/api": "^2.0.0",
         "ajv": "^8.17.1",
         "ajv-formats": "^2.1.1",
+        "diff": "^5.2.0",
+        "typo-js": "^1.3.0",
         "xterm": "^5.3.0"
       },
       "devDependencies": {
@@ -59,6 +62,17 @@
         "@lezer/highlight": "^1.0.0",
         "@lezer/lr": "^1.0.0",
         "style-mod": "^4.0.0"
+      }
+    },
+    "node_modules/@codemirror/lint": {
+      "version": "6.8.5",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.8.5.tgz",
+      "integrity": "sha512-s3n3KisH7dx3vsoeGMxsbRAgKe4O1vbrnKBClm99PU0fWxmxsx5rR2PfqQgIt+2MMJBHbiJ5rfIdLYfB9NNvsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.35.0",
+        "crelt": "^1.0.5"
       }
     },
     "node_modules/@codemirror/state": {
@@ -1339,6 +1353,15 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/diff": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
+      "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -2201,6 +2224,12 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/typo-js": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/typo-js/-/typo-js-1.3.1.tgz",
+      "integrity": "sha512-elJkpCL6Z77Ghw0Lv0lGnhBAjSTOQ5FhiVOCfOuxhaoTT2xtLVbqikYItK5HHchzPbHEUFAcjOH669T2ZzeCbg==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/universalify": {
       "version": "0.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,14 +11,15 @@
   },
   "dependencies": {
     "@codemirror/language": "^6.10.1",
+    "@codemirror/lint": "^6.8.5",
     "@codemirror/state": "^6.4.0",
     "@codemirror/view": "^6.21.3",
     "@tauri-apps/api": "^2.0.0",
     "ajv": "^8.17.1",
     "ajv-formats": "^2.1.1",
-    "xterm": "^5.3.0",
     "diff": "^5.2.0",
-    "typo-js": "^1.3.0"
+    "typo-js": "^1.3.0",
+    "xterm": "^5.3.0"
   },
   "devDependencies": {
     "jsdom": "^23.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@codemirror/language": "^6.10.1",
+        "@codemirror/lint": "^6.8.5",
         "@codemirror/state": "^6.4.0",
         "@codemirror/view": "^6.21.3",
         "@tauri-apps/api": "^2.0.0",
@@ -70,6 +71,17 @@
         "@lezer/highlight": "^1.0.0",
         "@lezer/lr": "^1.0.0",
         "style-mod": "^4.0.0"
+      }
+    },
+    "node_modules/@codemirror/lint": {
+      "version": "6.8.5",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.8.5.tgz",
+      "integrity": "sha512-s3n3KisH7dx3vsoeGMxsbRAgKe4O1vbrnKBClm99PU0fWxmxsx5rR2PfqQgIt+2MMJBHbiJ5rfIdLYfB9NNvsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.35.0",
+        "crelt": "^1.0.5"
       }
     },
     "node_modules/@codemirror/state": {


### PR DESCRIPTION
## Summary
- forward linter and consistency errors to CodeMirror using setDiagnostics
- export `editorDiagnostics` helper for visual meta documents
- add `@codemirror/lint` dependency

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e33a3e8a0832383d8ac20b3128a32