### PR TITLE
feat: add goto line hotkey

### DIFF
--- a/frontend/src/editor/goto-line.js
+++ b/frontend/src/editor/goto-line.js
@@ -1,0 +1,21 @@
+/**
+ * Prompt for a line number and move cursor to that line.
+ * Highlights the line and handles invalid input.
+ *
+ * @param {import('@codemirror/view').EditorView} view
+ */
+export function gotoLine(view) {
+  if (!view) return;
+  const input = prompt('Go to line:');
+  if (!input) return;
+  const lineNumber = Number(input);
+  if (!Number.isInteger(lineNumber) || lineNumber < 1 || lineNumber > view.state.doc.lines) {
+    alert('Invalid line number');
+    return;
+  }
+  const line = view.state.doc.line(lineNumber);
+  view.dispatch({
+    selection: { anchor: line.from, head: line.to },
+    scrollIntoView: true
+  });
+}

--- a/frontend/src/visual/hotkeys.ts
+++ b/frontend/src/visual/hotkeys.ts
@@ -4,6 +4,7 @@ import { getTheme } from './theme.ts';
 import { createHotkeyDialog } from './hotkey-dialog.ts';
 import type { VisualCanvas } from './canvas.js';
 import { gotoRelated } from '../editor/navigation.js';
+import { gotoLine } from '../editor/goto-line.js';
 import { formatCurrentFile } from '../../scripts/format.js';
 
 export interface HotkeyMap {
@@ -16,6 +17,7 @@ export interface HotkeyMap {
   undo: string;
   redo: string;
   gotoRelated: string;
+  gotoLine: string;
   formatCurrentFile: string;
 }
 
@@ -32,6 +34,7 @@ export const hotkeys: HotkeyMap = {
   undo: cfg.hotkeys?.undo || 'Ctrl+Z',
   redo: cfg.hotkeys?.redo || 'Ctrl+Shift+Z',
   gotoRelated: cfg.hotkeys?.gotoRelated || 'Ctrl+Alt+O',
+  gotoLine: cfg.hotkeys?.gotoLine || 'Ctrl+G',
   formatCurrentFile: cfg.hotkeys?.formatCurrentFile || 'Shift+Alt+F'
 };
 
@@ -91,6 +94,10 @@ function handleKey(e: KeyboardEvent) {
     case hotkeys.gotoRelated:
       e.preventDefault();
       gotoRelated((globalThis as any).view);
+      break;
+    case hotkeys.gotoLine:
+      e.preventDefault();
+      gotoLine((globalThis as any).view);
       break;
     case hotkeys.formatCurrentFile:
       e.preventDefault();


### PR DESCRIPTION
## Summary
- add Ctrl+G shortcut for jumping to a line
- implement gotoLine helper to prompt and navigate

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e38fc4514832386786e32bd2cb062