### PR TITLE
feat: add regex search options

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@codemirror/language": "^6.10.1",
     "@codemirror/lint": "^6.8.5",
+    "@codemirror/search": "^6.5.11",
     "@codemirror/state": "^6.4.0",
     "@codemirror/view": "^6.21.3",
     "@tauri-apps/api": "^2.0.0",

--- a/frontend/src/editor/search.js
+++ b/frontend/src/editor/search.js
@@ -1,0 +1,33 @@
+import { SearchQuery } from '@codemirror/search';
+
+/**
+ * Search text inside the editor using CodeMirror's search API.
+ * @param {string} query
+ * @param {import('@codemirror/view').EditorView} view
+ * @param {{regex?: boolean, wholeWord?: boolean}} opts
+ * @returns {Array}
+ */
+export function searchText(query, view, opts = {}) {
+  const { regex = false, wholeWord = false } = opts;
+  const results = [];
+  if (!query || !view) return results;
+  try {
+    const searchQuery = new SearchQuery({ search: query, regexp: regex, wholeWord });
+    if (!searchQuery.valid) return results;
+    const cursor = searchQuery.getCursor(view.state, 0, view.state.doc.length);
+    while (!cursor.next().done) {
+      const { from, to } = cursor.value;
+      const lineInfo = view.state.doc.lineAt(from);
+      results.push({
+        type: 'text',
+        from,
+        to,
+        line: lineInfo.number,
+        label: lineInfo.text.trim()
+      });
+    }
+  } catch (e) {
+    console.error('Invalid search pattern', e);
+  }
+  return results;
+}

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -340,9 +340,19 @@
 
     const searchInput = document.getElementById('search-input');
     const searchResultsEl = document.getElementById('search-results');
+    const searchRegex = document.getElementById('search-regex');
+    const searchWhole = document.getElementById('search-whole');
     let searchResults = [];
     function updateSearch() {
-      searchResults = searchAll(searchInput.value, view, vc.blocksData, currentLocale);
+      try {
+        searchResults = searchAll(searchInput.value, view, vc.blocksData, currentLocale, {
+          regex: searchRegex.checked,
+          wholeWord: searchWhole.checked
+        });
+      } catch (e) {
+        console.error(e);
+        searchResults = [];
+      }
       searchResultsEl.innerHTML = '';
       searchResults.forEach((r, i) => {
         const opt = document.createElement('option');
@@ -353,6 +363,8 @@
       highlightResults(searchResults, view, vc);
     }
     searchInput.addEventListener('input', updateSearch);
+    searchRegex.addEventListener('change', updateSearch);
+    searchWhole.addEventListener('change', updateSearch);
     searchResultsEl.addEventListener('change', () => {
       const idx = parseInt(searchResultsEl.value, 10);
       const res = searchResults[idx];
@@ -468,6 +480,8 @@
       </div>
       <div id="search-panel">
         <input id="search-input" placeholder="Search..." />
+        <label><input type="checkbox" id="search-regex"> Regex</label>
+        <label><input type="checkbox" id="search-whole"> Whole word</label>
         <select id="search-results" size="5"></select>
       </div>
       <div id="git-panel">

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
       "dependencies": {
         "@codemirror/language": "^6.10.1",
         "@codemirror/lint": "^6.8.5",
+        "@codemirror/search": "^6.5.11",
         "@codemirror/state": "^6.4.0",
         "@codemirror/view": "^6.21.3",
         "@tauri-apps/api": "^2.0.0",
@@ -81,6 +82,17 @@
       "dependencies": {
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.35.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/search": {
+      "version": "6.5.11",
+      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.5.11.tgz",
+      "integrity": "sha512-KmWepDE6jUdL6n8cAAqIpRmLPBZ5ZKnicE8oGU/s3QrAVID+0VhLFrzUucVKHG5035/BSykhExDL/Xm7dHthiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
         "crelt": "^1.0.5"
       }
     },


### PR DESCRIPTION
## Summary
- enable regex and whole word searching via CodeMirror search
- add Regex and Whole word checkboxes to search panel
- handle invalid search patterns gracefully

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e4106df088323b6c695ddfac9fe4f