### PR TITLE
feat: add tutorial with i18n support

### DIFF
--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -54,6 +54,7 @@
     import { activeBlock } from "./editor/active-block.js";
     import { todoHighlight, updateTodoPanel } from "./editor/todo-highlight.js";
     import { setLanguage, getLanguage, availableLanguages, getLanguageName } from "./shared/i18n.ts";
+    import { startTutorial } from "./tutorial/index.ts";
 
     const editorCfg = settings.editor || {};
     setLanguage(settings.language || 'en');
@@ -219,6 +220,10 @@
     }
 
     await initEditor(currentLang);
+
+    document.getElementById('tutorial-start')?.addEventListener('click', () => {
+      startTutorial();
+    });
 
       window.openInTextEditor = id => {
       document.getElementById('visual-canvas').style.display = 'none';
@@ -490,6 +495,7 @@
         <button id="redo" data-i18n="redo"></button>
         <button id="history" data-i18n="history"></button>
         <button id="insert-meta" data-i18n="insert_meta"></button>
+        <button id="tutorial-start" data-i18n="tutorial_button"></button>
         <select id="theme"></select>
         <select id="locale"></select>
         <label><span data-i18n="font_size"></span>: <input id="font-size" type="range" min="10" max="24" /></label>

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -27,5 +27,13 @@
   "invalid_line_number": "Invalid line number",
   "related_file_not_found": "Related file not found",
   "failed_load_plugins": "Failed to load plugins",
-  "failed_update_plugin": "Failed to update plugin"
+  "failed_update_plugin": "Failed to update plugin",
+  "tutorial_button": "Tutorial",
+  "tutorial_step_canvas": "This area displays visual blocks.",
+  "tutorial_step_controls": "Use these controls to save, load, and configure the editor.",
+  "tutorial_step_search": "Use the search panel to find text within your project.",
+  "tutorial_prev": "Back",
+  "tutorial_next": "Next",
+  "tutorial_done": "Finish",
+  "tutorial_progress": "Step"
 }

--- a/frontend/src/locales/ru.json
+++ b/frontend/src/locales/ru.json
@@ -27,5 +27,13 @@
   "invalid_line_number": "Неверный номер строки",
   "related_file_not_found": "Связанный файл не найден",
   "failed_load_plugins": "Не удалось загрузить плагины",
-  "failed_update_plugin": "Не удалось обновить плагин"
+  "failed_update_plugin": "Не удалось обновить плагин",
+  "tutorial_button": "Обучение",
+  "tutorial_step_canvas": "Здесь отображаются визуальные блоки.",
+  "tutorial_step_controls": "Используйте эти элементы управления для сохранения, загрузки и настройки редактора.",
+  "tutorial_step_search": "Панель поиска помогает находить текст в проекте.",
+  "tutorial_prev": "Назад",
+  "tutorial_next": "Далее",
+  "tutorial_done": "Готово",
+  "tutorial_progress": "Шаг"
 }

--- a/frontend/src/tutorial/index.ts
+++ b/frontend/src/tutorial/index.ts
@@ -1,0 +1,93 @@
+import { t } from "../shared/i18n.ts";
+
+interface Step {
+  element: string;
+  i18nKey: string;
+}
+
+const steps: Step[] = [
+  { element: '#visual-canvas', i18nKey: 'tutorial_step_canvas' },
+  { element: '#controls', i18nKey: 'tutorial_step_controls' },
+  { element: '#search-panel', i18nKey: 'tutorial_step_search' },
+];
+
+export function startTutorial(): void {
+  let current = 0;
+  const overlay = document.createElement('div');
+  overlay.id = 'tutorial-overlay';
+  overlay.style.position = 'fixed';
+  overlay.style.top = '0';
+  overlay.style.left = '0';
+  overlay.style.right = '0';
+  overlay.style.bottom = '0';
+  overlay.style.background = 'rgba(0,0,0,0.5)';
+  overlay.style.display = 'flex';
+  overlay.style.alignItems = 'center';
+  overlay.style.justifyContent = 'center';
+  overlay.style.zIndex = '1000';
+  document.body.appendChild(overlay);
+
+  const box = document.createElement('div');
+  box.style.background = '#fff';
+  box.style.padding = '1rem';
+  box.style.maxWidth = '300px';
+  box.style.textAlign = 'center';
+  overlay.appendChild(box);
+
+  const text = document.createElement('p');
+  box.appendChild(text);
+
+  const progress = document.createElement('p');
+  box.appendChild(progress);
+
+  const buttons = document.createElement('div');
+  buttons.style.display = 'flex';
+  buttons.style.justifyContent = 'space-between';
+  buttons.style.marginTop = '0.5rem';
+  box.appendChild(buttons);
+
+  const prev = document.createElement('button');
+  prev.textContent = t('tutorial_prev');
+  prev.addEventListener('click', () => {
+    if (current > 0) {
+      current--;
+      show();
+    }
+  });
+  buttons.appendChild(prev);
+
+  const next = document.createElement('button');
+  next.addEventListener('click', () => {
+    current++;
+    if (current >= steps.length) {
+      finish();
+    } else {
+      show();
+    }
+  });
+  buttons.appendChild(next);
+
+  const style = document.createElement('style');
+  style.textContent = '.tutorial-highlight{box-shadow:0 0 0 3px #ff0;}';
+  document.head.appendChild(style);
+
+  function show() {
+    const step = steps[current];
+    text.textContent = t(step.i18nKey);
+    progress.textContent = `${t('tutorial_progress')} ${current + 1}/${steps.length}`;
+    prev.style.display = current === 0 ? 'none' : 'inline-block';
+    next.textContent = current === steps.length - 1 ? t('tutorial_done') : t('tutorial_next');
+    document.querySelectorAll('.tutorial-highlight').forEach(el => el.classList.remove('tutorial-highlight'));
+    const el = document.querySelector(step.element) as HTMLElement | null;
+    if (el) {
+      el.classList.add('tutorial-highlight');
+    }
+  }
+
+  function finish() {
+    overlay.remove();
+    document.querySelectorAll('.tutorial-highlight').forEach(el => el.classList.remove('tutorial-highlight'));
+  }
+
+  show();
+}


### PR DESCRIPTION
## Summary
- add guided tutorial module with progress and restart
- wire UI button to start tutorial
- translate tutorial strings to English and Russian

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e9a23493883238f91647e54b696b8