### PR TITLE
feat: add literal blocks

### DIFF
--- a/frontend/src/visual/blocks.js
+++ b/frontend/src/visual/blocks.js
@@ -98,6 +98,74 @@ export async function reloadPlugins(urls) {
 
 // ---- Built-in blocks -------------------------------------------------------
 
+export class NumberLiteralBlock extends Block {
+  static defaultSize = { width: 120, height: 50 };
+  static ports = [{ id: 'out', kind: 'data', dir: 'out' }];
+  constructor(id, x, y) {
+    super(
+      id,
+      x,
+      y,
+      NumberLiteralBlock.defaultSize.width,
+      NumberLiteralBlock.defaultSize.height,
+      'Number',
+      getTheme().blockKinds.Literal
+    );
+    this.ports = NumberLiteralBlock.ports;
+  }
+}
+
+export class StringLiteralBlock extends Block {
+  static defaultSize = { width: 120, height: 50 };
+  static ports = [{ id: 'out', kind: 'data', dir: 'out' }];
+  constructor(id, x, y) {
+    super(
+      id,
+      x,
+      y,
+      StringLiteralBlock.defaultSize.width,
+      StringLiteralBlock.defaultSize.height,
+      'String',
+      getTheme().blockKinds.Literal
+    );
+    this.ports = StringLiteralBlock.ports;
+  }
+}
+
+export class BooleanLiteralBlock extends Block {
+  static defaultSize = { width: 120, height: 50 };
+  static ports = [{ id: 'out', kind: 'data', dir: 'out' }];
+  constructor(id, x, y) {
+    super(
+      id,
+      x,
+      y,
+      BooleanLiteralBlock.defaultSize.width,
+      BooleanLiteralBlock.defaultSize.height,
+      'Boolean',
+      getTheme().blockKinds.Literal
+    );
+    this.ports = BooleanLiteralBlock.ports;
+  }
+}
+
+export class NullLiteralBlock extends Block {
+  static defaultSize = { width: 120, height: 50 };
+  static ports = [{ id: 'out', kind: 'data', dir: 'out' }];
+  constructor(id, x, y) {
+    super(
+      id,
+      x,
+      y,
+      NullLiteralBlock.defaultSize.width,
+      NullLiteralBlock.defaultSize.height,
+      'Null',
+      getTheme().blockKinds.Literal
+    );
+    this.ports = NullLiteralBlock.ports;
+  }
+}
+
 export class FunctionBlock extends Block {
   constructor(id, x, y) {
     super(id, x, y, 120, 50, 'Function', getTheme().blockKinds.Function);
@@ -122,6 +190,10 @@ export class LoopBlock extends Block {
   }
 }
 
+registerBlock('Literal/Number', NumberLiteralBlock);
+registerBlock('Literal/String', StringLiteralBlock);
+registerBlock('Literal/Boolean', BooleanLiteralBlock);
+registerBlock('Literal/Null', NullLiteralBlock);
 registerBlock('Function', FunctionBlock);
 registerBlock('Variable', VariableBlock);
 registerBlock('Condition', ConditionBlock);

--- a/frontend/src/visual/blocks.test.js
+++ b/frontend/src/visual/blocks.test.js
@@ -1,5 +1,15 @@
 import { describe, it, expect } from 'vitest';
-import { Block, registerBlock, unregisterBlock, createBlock } from './blocks.js';
+import {
+  Block,
+  registerBlock,
+  unregisterBlock,
+  createBlock,
+  NumberLiteralBlock,
+  StringLiteralBlock,
+  BooleanLiteralBlock,
+  NullLiteralBlock
+} from './blocks.js';
+import { getTheme } from './theme.ts';
 
 describe('block utilities', () => {
   it('checks point containment and center', () => {
@@ -25,5 +35,23 @@ describe('block utilities', () => {
     unregisterBlock('temp');
     const b = createBlock('temp', '3', 0, 0, 'c');
     expect(b).toBeInstanceOf(Block);
+  });
+
+  it('provides built-in literal blocks', () => {
+    const theme = getTheme();
+    const cases = [
+      ['Literal/Number', NumberLiteralBlock],
+      ['Literal/String', StringLiteralBlock],
+      ['Literal/Boolean', BooleanLiteralBlock],
+      ['Literal/Null', NullLiteralBlock]
+    ];
+    for (const [kind, Ctor] of cases) {
+      const b = createBlock(kind, 'lit', 0, 0, '');
+      expect(b).toBeInstanceOf(Ctor);
+      expect(b.w).toBe(120);
+      expect(b.h).toBe(50);
+      expect(b.ports).toEqual([{ id: 'out', kind: 'data', dir: 'out' }]);
+      expect(b.color).toBe(theme.blockKinds.Literal);
+    }
   });
 });

--- a/frontend/src/visual/theme.ts
+++ b/frontend/src/visual/theme.ts
@@ -17,6 +17,10 @@ export interface VisualTheme {
 export const defaultTheme: VisualTheme = defaultThemeJson as VisualTheme;
 export const darkTheme: VisualTheme = darkThemeJson as VisualTheme;
 
+// ensure color for literal blocks exists
+defaultTheme.blockKinds.Literal = defaultTheme.blockKinds.Literal || '#e1bee7';
+darkTheme.blockKinds.Literal = darkTheme.blockKinds.Literal || '#8e24aa';
+
 const themeMap: Record<string, VisualTheme> = {
   default: defaultTheme,
   dark: darkTheme


### PR DESCRIPTION
## Summary
- add built-in Number, String, Boolean and Null literal blocks with data output port
- register literal blocks and color them via new `blockKinds.Literal` theme key
- cover literal block registration with unit tests

## Testing
- `npm --prefix frontend test -- --run`
- `npm --prefix frontend exec --yes eslint .` *(fails: ESLint couldn't find an eslint.config)*

------
https://chatgpt.com/codex/tasks/task_e_689ea72c88fc83238298bc55b125ae2b