### PR TITLE
feat: add array blocks

### DIFF
--- a/backend/meta.schema.json
+++ b/backend/meta.schema.json
@@ -82,17 +82,35 @@
       "description": "Optional AI-generated note.",
       "default": null,
       "anyOf": [
-        {
-          "$ref": "#/definitions/AiNote"
-        },
-        {
-          "type": "null"
-        }
+        { "$ref": "#/definitions/AiNote" },
+        { "type": "null" }
       ]
     },
     "extras": {
       "description": "Optional plugin-specific metadata.",
       "default": null
+    },
+    "history": {
+      "description": "Previous states of this metadata.",
+      "default": [],
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "timestamp": { "type": "string", "format": "date-time" },
+          "snapshot": { "type": "object" }
+        },
+        "required": ["timestamp", "snapshot"],
+        "additionalProperties": false
+      }
+    },
+    "node": {
+      "description": "Optional serialized visual node.",
+      "default": null,
+      "anyOf": [
+        { "$ref": "#/definitions/VizNode" },
+        { "type": "null" }
+      ]
     },
     "updated_at": {
       "description": "Timestamp of last update in UTC.",
@@ -124,6 +142,65 @@
         }
       },
       "additionalProperties": false
+    },
+    "VizPort": {
+      "type": "object",
+      "required": ["id", "kind", "dir"],
+      "properties": {
+        "id": { "type": "string" },
+        "kind": { "type": "string", "enum": ["exec", "data"] },
+        "dir": { "type": "string", "enum": ["in", "out"] }
+      },
+      "additionalProperties": false
+    },
+    "ArrayNewNode": {
+      "type": "object",
+      "required": ["kind", "ports"],
+      "properties": {
+        "kind": { "const": "Array/New" },
+        "ports": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/VizPort" },
+          "minItems": 3,
+          "maxItems": 3
+        }
+      },
+      "additionalProperties": false
+    },
+    "ArrayGetNode": {
+      "type": "object",
+      "required": ["kind", "ports"],
+      "properties": {
+        "kind": { "const": "Array/Get" },
+        "ports": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/VizPort" },
+          "minItems": 5,
+          "maxItems": 5
+        }
+      },
+      "additionalProperties": false
+    },
+    "ArraySetNode": {
+      "type": "object",
+      "required": ["kind", "ports"],
+      "properties": {
+        "kind": { "const": "Array/Set" },
+        "ports": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/VizPort" },
+          "minItems": 6,
+          "maxItems": 6
+        }
+      },
+      "additionalProperties": false
+    },
+    "VizNode": {
+      "oneOf": [
+        { "$ref": "#/definitions/ArrayNewNode" },
+        { "$ref": "#/definitions/ArrayGetNode" },
+        { "$ref": "#/definitions/ArraySetNode" }
+      ]
     }
   }
 }

--- a/frontend/src/editor/meta.schema.json
+++ b/frontend/src/editor/meta.schema.json
@@ -82,23 +82,13 @@
       "description": "Optional AI-generated note.",
       "default": null,
       "anyOf": [
-        {
-          "$ref": "#/definitions/AiNote"
-        },
-        {
-          "type": "null"
-        }
+        { "$ref": "#/definitions/AiNote" },
+        { "type": "null" }
       ]
     },
     "extras": {
       "description": "Optional plugin-specific metadata.",
       "default": null
-    },
-    "updated_at": {
-      "description": "Timestamp of last update in UTC.",
-      "default": "1970-01-01T00:00:00Z",
-      "type": "string",
-      "format": "date-time"
     },
     "history": {
       "description": "Previous states of this metadata.",
@@ -113,6 +103,20 @@
         "required": ["timestamp", "snapshot"],
         "additionalProperties": false
       }
+    },
+    "node": {
+      "description": "Optional serialized visual node.",
+      "default": null,
+      "anyOf": [
+        { "$ref": "#/definitions/VizNode" },
+        { "type": "null" }
+      ]
+    },
+    "updated_at": {
+      "description": "Timestamp of last update in UTC.",
+      "default": "1970-01-01T00:00:00Z",
+      "type": "string",
+      "format": "date-time"
     }
   },
   "additionalProperties": false,
@@ -138,6 +142,65 @@
         }
       },
       "additionalProperties": false
+    },
+    "VizPort": {
+      "type": "object",
+      "required": ["id", "kind", "dir"],
+      "properties": {
+        "id": { "type": "string" },
+        "kind": { "type": "string", "enum": ["exec", "data"] },
+        "dir": { "type": "string", "enum": ["in", "out"] }
+      },
+      "additionalProperties": false
+    },
+    "ArrayNewNode": {
+      "type": "object",
+      "required": ["kind", "ports"],
+      "properties": {
+        "kind": { "const": "Array/New" },
+        "ports": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/VizPort" },
+          "minItems": 3,
+          "maxItems": 3
+        }
+      },
+      "additionalProperties": false
+    },
+    "ArrayGetNode": {
+      "type": "object",
+      "required": ["kind", "ports"],
+      "properties": {
+        "kind": { "const": "Array/Get" },
+        "ports": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/VizPort" },
+          "minItems": 5,
+          "maxItems": 5
+        }
+      },
+      "additionalProperties": false
+    },
+    "ArraySetNode": {
+      "type": "object",
+      "required": ["kind", "ports"],
+      "properties": {
+        "kind": { "const": "Array/Set" },
+        "ports": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/VizPort" },
+          "minItems": 6,
+          "maxItems": 6
+        }
+      },
+      "additionalProperties": false
+    },
+    "VizNode": {
+      "oneOf": [
+        { "$ref": "#/definitions/ArrayNewNode" },
+        { "$ref": "#/definitions/ArrayGetNode" },
+        { "$ref": "#/definitions/ArraySetNode" }
+      ]
     }
   }
 }

--- a/frontend/src/visual/blocks.js
+++ b/frontend/src/visual/blocks.js
@@ -190,6 +190,74 @@ export class LoopBlock extends Block {
   }
 }
 
+export class ArrayNewBlock extends Block {
+  static defaultSize = { width: 120, height: 50 };
+  static ports = [
+    { id: 'execIn', kind: 'exec', dir: 'in' },
+    { id: 'execOut', kind: 'exec', dir: 'out' },
+    { id: 'out', kind: 'data', dir: 'out' }
+  ];
+  constructor(id, x, y) {
+    super(
+      id,
+      x,
+      y,
+      ArrayNewBlock.defaultSize.width,
+      ArrayNewBlock.defaultSize.height,
+      'Array New',
+      getTheme().blockKinds.Array
+    );
+    this.ports = ArrayNewBlock.ports;
+  }
+}
+
+export class ArrayGetBlock extends Block {
+  static defaultSize = { width: 120, height: 50 };
+  static ports = [
+    { id: 'execIn', kind: 'exec', dir: 'in' },
+    { id: 'execOut', kind: 'exec', dir: 'out' },
+    { id: 'array', kind: 'data', dir: 'in' },
+    { id: 'index', kind: 'data', dir: 'in' },
+    { id: 'value', kind: 'data', dir: 'out' }
+  ];
+  constructor(id, x, y) {
+    super(
+      id,
+      x,
+      y,
+      ArrayGetBlock.defaultSize.width,
+      ArrayGetBlock.defaultSize.height,
+      'Array Get',
+      getTheme().blockKinds.Array
+    );
+    this.ports = ArrayGetBlock.ports;
+  }
+}
+
+export class ArraySetBlock extends Block {
+  static defaultSize = { width: 120, height: 50 };
+  static ports = [
+    { id: 'execIn', kind: 'exec', dir: 'in' },
+    { id: 'execOut', kind: 'exec', dir: 'out' },
+    { id: 'array', kind: 'data', dir: 'in' },
+    { id: 'index', kind: 'data', dir: 'in' },
+    { id: 'value', kind: 'data', dir: 'in' },
+    { id: 'result', kind: 'data', dir: 'out' }
+  ];
+  constructor(id, x, y) {
+    super(
+      id,
+      x,
+      y,
+      ArraySetBlock.defaultSize.width,
+      ArraySetBlock.defaultSize.height,
+      'Array Set',
+      getTheme().blockKinds.Array
+    );
+    this.ports = ArraySetBlock.ports;
+  }
+}
+
 registerBlock('Literal/Number', NumberLiteralBlock);
 registerBlock('Literal/String', StringLiteralBlock);
 registerBlock('Literal/Boolean', BooleanLiteralBlock);
@@ -198,3 +266,6 @@ registerBlock('Function', FunctionBlock);
 registerBlock('Variable', VariableBlock);
 registerBlock('Condition', ConditionBlock);
 registerBlock('Loop', LoopBlock);
+registerBlock('Array/New', ArrayNewBlock);
+registerBlock('Array/Get', ArrayGetBlock);
+registerBlock('Array/Set', ArraySetBlock);

--- a/frontend/src/visual/blocks.test.js
+++ b/frontend/src/visual/blocks.test.js
@@ -7,7 +7,10 @@ import {
   NumberLiteralBlock,
   StringLiteralBlock,
   BooleanLiteralBlock,
-  NullLiteralBlock
+  NullLiteralBlock,
+  ArrayNewBlock,
+  ArrayGetBlock,
+  ArraySetBlock
 } from './blocks.js';
 import { getTheme } from './theme.ts';
 
@@ -52,6 +55,21 @@ describe('block utilities', () => {
       expect(b.h).toBe(50);
       expect(b.ports).toEqual([{ id: 'out', kind: 'data', dir: 'out' }]);
       expect(b.color).toBe(theme.blockKinds.Literal);
+    }
+  });
+
+  it('provides array blocks', () => {
+    const theme = getTheme();
+    const cases = [
+      ['Array/New', ArrayNewBlock, ArrayNewBlock.ports],
+      ['Array/Get', ArrayGetBlock, ArrayGetBlock.ports],
+      ['Array/Set', ArraySetBlock, ArraySetBlock.ports]
+    ];
+    for (const [kind, Ctor, ports] of cases) {
+      const b = createBlock(kind, 'arr', 0, 0, '');
+      expect(b).toBeInstanceOf(Ctor);
+      expect(b.ports).toEqual(ports);
+      expect(b.color).toBe(theme.blockKinds.Array);
     }
   });
 });

--- a/frontend/src/visual/theme.ts
+++ b/frontend/src/visual/theme.ts
@@ -20,6 +20,9 @@ export const darkTheme: VisualTheme = darkThemeJson as VisualTheme;
 // ensure color for literal blocks exists
 defaultTheme.blockKinds.Literal = defaultTheme.blockKinds.Literal || '#e1bee7';
 darkTheme.blockKinds.Literal = darkTheme.blockKinds.Literal || '#8e24aa';
+// ensure color for array blocks exists
+defaultTheme.blockKinds.Array = defaultTheme.blockKinds.Array || '#bbdefb';
+darkTheme.blockKinds.Array = darkTheme.blockKinds.Array || '#1976d2';
 
 const themeMap: Record<string, VisualTheme> = {
   default: defaultTheme,

--- a/frontend/src/visual/themes/dark.json
+++ b/frontend/src/visual/themes/dark.json
@@ -11,6 +11,7 @@
     "Function": "#455a64",
     "Variable": "#558b2f",
     "Condition": "#827717",
-    "Loop": "#6d4c41"
+    "Loop": "#6d4c41",
+    "Array": "#1976d2"
   }
 }

--- a/frontend/src/visual/themes/default.json
+++ b/frontend/src/visual/themes/default.json
@@ -11,6 +11,7 @@
     "Function": "#e0f7fa",
     "Variable": "#f1f8e9",
     "Condition": "#fff9c4",
-    "Loop": "#fce4ec"
+    "Loop": "#fce4ec",
+    "Array": "#bbdefb"
   }
 }


### PR DESCRIPTION
## Summary
- add ArrayNew, ArrayGet and ArraySet block classes with exec and data ports
- support array block kind in theme
- extend meta schema to serialize Array viz nodes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689eac2190708323bb9424f5350dc71d