### PR TITLE
feat: add map blocks

### DIFF
--- a/backend/meta.schema.json
+++ b/backend/meta.schema.json
@@ -195,11 +195,56 @@
       },
       "additionalProperties": false
     },
+    "MapNewNode": {
+      "type": "object",
+      "required": ["kind", "ports"],
+      "properties": {
+        "kind": { "const": "Map/New" },
+        "ports": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/VizPort" },
+          "minItems": 3,
+          "maxItems": 3
+        }
+      },
+      "additionalProperties": false
+    },
+    "MapGetNode": {
+      "type": "object",
+      "required": ["kind", "ports"],
+      "properties": {
+        "kind": { "const": "Map/Get" },
+        "ports": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/VizPort" },
+          "minItems": 5,
+          "maxItems": 5
+        }
+      },
+      "additionalProperties": false
+    },
+    "MapSetNode": {
+      "type": "object",
+      "required": ["kind", "ports"],
+      "properties": {
+        "kind": { "const": "Map/Set" },
+        "ports": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/VizPort" },
+          "minItems": 6,
+          "maxItems": 6
+        }
+      },
+      "additionalProperties": false
+    },
     "VizNode": {
       "oneOf": [
         { "$ref": "#/definitions/ArrayNewNode" },
         { "$ref": "#/definitions/ArrayGetNode" },
-        { "$ref": "#/definitions/ArraySetNode" }
+        { "$ref": "#/definitions/ArraySetNode" },
+        { "$ref": "#/definitions/MapNewNode" },
+        { "$ref": "#/definitions/MapGetNode" },
+        { "$ref": "#/definitions/MapSetNode" }
       ]
     }
   }

--- a/backend/src/blocks/enrich.rs
+++ b/backend/src/blocks/enrich.rs
@@ -50,6 +50,8 @@ fn normalize_kind(kind: &str) -> String {
         "Loop".into()
     } else if k.contains("identifier") || k.contains("variable") {
         "Variable".into()
+    } else if k.contains("map") {
+        "Map".into()
     } else {
         kind.to_string()
     }

--- a/frontend/src/editor/meta.schema.json
+++ b/frontend/src/editor/meta.schema.json
@@ -195,11 +195,56 @@
       },
       "additionalProperties": false
     },
+    "MapNewNode": {
+      "type": "object",
+      "required": ["kind", "ports"],
+      "properties": {
+        "kind": { "const": "Map/New" },
+        "ports": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/VizPort" },
+          "minItems": 3,
+          "maxItems": 3
+        }
+      },
+      "additionalProperties": false
+    },
+    "MapGetNode": {
+      "type": "object",
+      "required": ["kind", "ports"],
+      "properties": {
+        "kind": { "const": "Map/Get" },
+        "ports": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/VizPort" },
+          "minItems": 5,
+          "maxItems": 5
+        }
+      },
+      "additionalProperties": false
+    },
+    "MapSetNode": {
+      "type": "object",
+      "required": ["kind", "ports"],
+      "properties": {
+        "kind": { "const": "Map/Set" },
+        "ports": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/VizPort" },
+          "minItems": 6,
+          "maxItems": 6
+        }
+      },
+      "additionalProperties": false
+    },
     "VizNode": {
       "oneOf": [
         { "$ref": "#/definitions/ArrayNewNode" },
         { "$ref": "#/definitions/ArrayGetNode" },
-        { "$ref": "#/definitions/ArraySetNode" }
+        { "$ref": "#/definitions/ArraySetNode" },
+        { "$ref": "#/definitions/MapNewNode" },
+        { "$ref": "#/definitions/MapGetNode" },
+        { "$ref": "#/definitions/MapSetNode" }
       ]
     }
   }

--- a/frontend/src/visual/blocks.js
+++ b/frontend/src/visual/blocks.js
@@ -258,6 +258,74 @@ export class ArraySetBlock extends Block {
   }
 }
 
+export class MapNewBlock extends Block {
+  static defaultSize = { width: 120, height: 50 };
+  static ports = [
+    { id: 'execIn', kind: 'exec', dir: 'in' },
+    { id: 'execOut', kind: 'exec', dir: 'out' },
+    { id: 'out', kind: 'data', dir: 'out' }
+  ];
+  constructor(id, x, y) {
+    super(
+      id,
+      x,
+      y,
+      MapNewBlock.defaultSize.width,
+      MapNewBlock.defaultSize.height,
+      'Map New',
+      getTheme().blockKinds.Map
+    );
+    this.ports = MapNewBlock.ports;
+  }
+}
+
+export class MapGetBlock extends Block {
+  static defaultSize = { width: 120, height: 50 };
+  static ports = [
+    { id: 'execIn', kind: 'exec', dir: 'in' },
+    { id: 'execOut', kind: 'exec', dir: 'out' },
+    { id: 'map', kind: 'data', dir: 'in' },
+    { id: 'key', kind: 'data', dir: 'in' },
+    { id: 'value', kind: 'data', dir: 'out' }
+  ];
+  constructor(id, x, y) {
+    super(
+      id,
+      x,
+      y,
+      MapGetBlock.defaultSize.width,
+      MapGetBlock.defaultSize.height,
+      'Map Get',
+      getTheme().blockKinds.Map
+    );
+    this.ports = MapGetBlock.ports;
+  }
+}
+
+export class MapSetBlock extends Block {
+  static defaultSize = { width: 120, height: 50 };
+  static ports = [
+    { id: 'execIn', kind: 'exec', dir: 'in' },
+    { id: 'execOut', kind: 'exec', dir: 'out' },
+    { id: 'map', kind: 'data', dir: 'in' },
+    { id: 'key', kind: 'data', dir: 'in' },
+    { id: 'value', kind: 'data', dir: 'in' },
+    { id: 'result', kind: 'data', dir: 'out' }
+  ];
+  constructor(id, x, y) {
+    super(
+      id,
+      x,
+      y,
+      MapSetBlock.defaultSize.width,
+      MapSetBlock.defaultSize.height,
+      'Map Set',
+      getTheme().blockKinds.Map
+    );
+    this.ports = MapSetBlock.ports;
+  }
+}
+
 registerBlock('Literal/Number', NumberLiteralBlock);
 registerBlock('Literal/String', StringLiteralBlock);
 registerBlock('Literal/Boolean', BooleanLiteralBlock);
@@ -269,3 +337,6 @@ registerBlock('Loop', LoopBlock);
 registerBlock('Array/New', ArrayNewBlock);
 registerBlock('Array/Get', ArrayGetBlock);
 registerBlock('Array/Set', ArraySetBlock);
+registerBlock('Map/New', MapNewBlock);
+registerBlock('Map/Get', MapGetBlock);
+registerBlock('Map/Set', MapSetBlock);

--- a/frontend/src/visual/blocks.test.js
+++ b/frontend/src/visual/blocks.test.js
@@ -10,7 +10,10 @@ import {
   NullLiteralBlock,
   ArrayNewBlock,
   ArrayGetBlock,
-  ArraySetBlock
+  ArraySetBlock,
+  MapNewBlock,
+  MapGetBlock,
+  MapSetBlock
 } from './blocks.js';
 import { getTheme } from './theme.ts';
 
@@ -70,6 +73,21 @@ describe('block utilities', () => {
       expect(b).toBeInstanceOf(Ctor);
       expect(b.ports).toEqual(ports);
       expect(b.color).toBe(theme.blockKinds.Array);
+    }
+  });
+
+  it('provides map blocks', () => {
+    const theme = getTheme();
+    const cases = [
+      ['Map/New', MapNewBlock, MapNewBlock.ports],
+      ['Map/Get', MapGetBlock, MapGetBlock.ports],
+      ['Map/Set', MapSetBlock, MapSetBlock.ports]
+    ];
+    for (const [kind, Ctor, ports] of cases) {
+      const b = createBlock(kind, 'map', 0, 0, '');
+      expect(b).toBeInstanceOf(Ctor);
+      expect(b.ports).toEqual(ports);
+      expect(b.color).toBe(theme.blockKinds.Map);
     }
   });
 });

--- a/frontend/src/visual/theme.ts
+++ b/frontend/src/visual/theme.ts
@@ -23,6 +23,9 @@ darkTheme.blockKinds.Literal = darkTheme.blockKinds.Literal || '#8e24aa';
 // ensure color for array blocks exists
 defaultTheme.blockKinds.Array = defaultTheme.blockKinds.Array || '#bbdefb';
 darkTheme.blockKinds.Array = darkTheme.blockKinds.Array || '#1976d2';
+// ensure color for map blocks exists
+defaultTheme.blockKinds.Map = defaultTheme.blockKinds.Map || '#c8e6c9';
+darkTheme.blockKinds.Map = darkTheme.blockKinds.Map || '#388e3c';
 
 const themeMap: Record<string, VisualTheme> = {
   default: defaultTheme,

--- a/frontend/src/visual/themes/dark.json
+++ b/frontend/src/visual/themes/dark.json
@@ -12,6 +12,7 @@
     "Variable": "#558b2f",
     "Condition": "#827717",
     "Loop": "#6d4c41",
-    "Array": "#1976d2"
+    "Array": "#1976d2",
+    "Map": "#388e3c"
   }
 }

--- a/frontend/src/visual/themes/default.json
+++ b/frontend/src/visual/themes/default.json
@@ -12,6 +12,7 @@
     "Variable": "#f1f8e9",
     "Condition": "#fff9c4",
     "Loop": "#fce4ec",
-    "Array": "#bbdefb"
+    "Array": "#bbdefb",
+    "Map": "#c8e6c9"
   }
 }


### PR DESCRIPTION
## Summary
- implement Map blocks (new, get, set) with ports and registration
- theme support and colors for Map block kind
- add Map kind handling in backend and schemas

## Testing
- `npm test`
- `cargo test` *(fails: system library `glib-2.0` missing)*

------
https://chatgpt.com/codex/tasks/task_e_689eb0f67a8c83238889d365b532ca5a