### PR TITLE
feat: add struct block with editable fields

### DIFF
--- a/backend/meta.schema.json
+++ b/backend/meta.schema.json
@@ -237,6 +237,31 @@
       },
       "additionalProperties": false
     },
+    "StructNode": {
+      "type": "object",
+      "required": ["kind", "ports", "data"],
+      "properties": {
+        "kind": { "const": "Struct" },
+        "ports": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/VizPort" },
+          "minItems": 3,
+          "maxItems": 3
+        },
+        "data": {
+          "type": "object",
+          "required": ["fields"],
+          "properties": {
+            "fields": {
+              "type": "array",
+              "items": { "type": "string" }
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
     "VizNode": {
       "oneOf": [
         { "$ref": "#/definitions/ArrayNewNode" },
@@ -244,7 +269,8 @@
         { "$ref": "#/definitions/ArraySetNode" },
         { "$ref": "#/definitions/MapNewNode" },
         { "$ref": "#/definitions/MapGetNode" },
-        { "$ref": "#/definitions/MapSetNode" }
+        { "$ref": "#/definitions/MapSetNode" },
+        { "$ref": "#/definitions/StructNode" }
       ]
     }
   }

--- a/frontend/src/editor/meta.schema.json
+++ b/frontend/src/editor/meta.schema.json
@@ -237,6 +237,31 @@
       },
       "additionalProperties": false
     },
+    "StructNode": {
+      "type": "object",
+      "required": ["kind", "ports", "data"],
+      "properties": {
+        "kind": { "const": "Struct" },
+        "ports": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/VizPort" },
+          "minItems": 3,
+          "maxItems": 3
+        },
+        "data": {
+          "type": "object",
+          "required": ["fields"],
+          "properties": {
+            "fields": {
+              "type": "array",
+              "items": { "type": "string" }
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
     "VizNode": {
       "oneOf": [
         { "$ref": "#/definitions/ArrayNewNode" },
@@ -244,7 +269,8 @@
         { "$ref": "#/definitions/ArraySetNode" },
         { "$ref": "#/definitions/MapNewNode" },
         { "$ref": "#/definitions/MapGetNode" },
-        { "$ref": "#/definitions/MapSetNode" }
+        { "$ref": "#/definitions/MapSetNode" },
+        { "$ref": "#/definitions/StructNode" }
       ]
     }
   }

--- a/frontend/src/visual/block-editor.test.ts
+++ b/frontend/src/visual/block-editor.test.ts
@@ -37,5 +37,35 @@ describe('block editor', () => {
     expect(updateMetaComment).toHaveBeenCalled();
     expect(vc.upsertMeta).toHaveBeenCalledWith({ id: 'a' }, ['f1']);
   });
+
+  it('allows editing struct fields', () => {
+    const json = '{"id":"a","data":{"fields":["x"]}}';
+    const dispatch = vi.fn();
+    const metaView = {
+      state: { doc: { sliceString: () => json } },
+      dispatch
+    } as any;
+    const vc: any = {
+      canvas: { getBoundingClientRect: () => ({ left: 0, top: 0 }) } as any,
+      metaView,
+      blockDataMap: new Map([
+        ['a', { range: [0, json.length], kind: 'Struct' }]
+      ]),
+      upsertMeta: vi.fn(),
+      fileId: 'f1',
+      scale: 1,
+      offset: { x: 0, y: 0 }
+    };
+
+    openBlockEditor(vc, { id: 'a', x: 0, y: 0, w: 10, h: 10 });
+    const fieldInput = document.querySelector('input')! as HTMLInputElement;
+    fieldInput.value = 'y';
+    const btn = Array.from(document.querySelectorAll('button')).find(b => b.textContent === 'Save')!;
+    btn.dispatchEvent(new Event('click'));
+
+    expect(dispatch).toHaveBeenCalled();
+    const call = dispatch.mock.calls[0][0];
+    expect(call.changes.insert).toContain('"fields":["y"]');
+  });
 });
 

--- a/frontend/src/visual/blocks.js
+++ b/frontend/src/visual/blocks.js
@@ -326,6 +326,27 @@ export class MapSetBlock extends Block {
   }
 }
 
+export class StructBlock extends Block {
+  static defaultSize = { width: 120, height: 50 };
+  static ports = [
+    { id: 'execIn', kind: 'exec', dir: 'in' },
+    { id: 'execOut', kind: 'exec', dir: 'out' },
+    { id: 'out', kind: 'data', dir: 'out' }
+  ];
+  constructor(id, x, y) {
+    super(
+      id,
+      x,
+      y,
+      StructBlock.defaultSize.width,
+      StructBlock.defaultSize.height,
+      'Struct',
+      getTheme().blockKinds.Struct
+    );
+    this.ports = StructBlock.ports;
+  }
+}
+
 registerBlock('Literal/Number', NumberLiteralBlock);
 registerBlock('Literal/String', StringLiteralBlock);
 registerBlock('Literal/Boolean', BooleanLiteralBlock);
@@ -340,3 +361,4 @@ registerBlock('Array/Set', ArraySetBlock);
 registerBlock('Map/New', MapNewBlock);
 registerBlock('Map/Get', MapGetBlock);
 registerBlock('Map/Set', MapSetBlock);
+registerBlock('Struct', StructBlock);

--- a/frontend/src/visual/blocks.test.js
+++ b/frontend/src/visual/blocks.test.js
@@ -13,7 +13,8 @@ import {
   ArraySetBlock,
   MapNewBlock,
   MapGetBlock,
-  MapSetBlock
+  MapSetBlock,
+  StructBlock
 } from './blocks.js';
 import { getTheme } from './theme.ts';
 
@@ -89,5 +90,13 @@ describe('block utilities', () => {
       expect(b.ports).toEqual(ports);
       expect(b.color).toBe(theme.blockKinds.Map);
     }
+  });
+
+  it('provides struct block', () => {
+    const theme = getTheme();
+    const b = createBlock('Struct', 's', 0, 0, '');
+    expect(b).toBeInstanceOf(StructBlock);
+    expect(b.ports).toEqual(StructBlock.ports);
+    expect(b.color).toBe(theme.blockKinds.Struct || theme.blockFill);
   });
 });


### PR DESCRIPTION
## Summary
- add `StructBlock` and register it in block registry
- allow editing `data.fields` for Struct blocks in block editor
- extend meta schema with `StructNode` supporting `data.fields`

## Testing
- `npm test`
- `cargo test` *(fails: glib-2.0 and gobject-2.0 development libraries missing)*

------
https://chatgpt.com/codex/tasks/task_e_689eb620453083238addb6a6ea446310