### PR TITLE
refactor: remove fs-extra dependency from scripts

### DIFF
--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -1,7 +1,26 @@
-const fs = require('fs-extra');
+let fs;
+try {
+  fs = require('fs-extra');
+} catch {
+  fs = require('fs');
+  // polyfill ensureDirSync used below
+  fs.ensureDirSync = (dir) => fs.mkdirSync(dir, { recursive: true });
+}
 const path = require('path');
 const { spawn } = require('child_process');
-const ora = require('ora');
+
+let ora;
+try {
+  ora = require('ora');
+} catch {
+  ora = (text) => ({
+    start: () => console.log(text),
+    succeed: (msg) => console.log(msg || text),
+    fail: (msg) => console.log(msg || text),
+    stop: () => console.log(text),
+    isEnabled: false,
+  });
+}
 
 function createLogger(name) {
   const logsDir = path.join(__dirname, '..', 'logs');


### PR DESCRIPTION
## Summary
- fallback to native fs and a simple spinner when fs-extra or ora are missing
- refactor setup/clean scripts to use fs.promises instead of fs-extra
- add checks for required Node.js features

## Testing
- `npm run clean`
- `npm run setup` (skipped dependency install)


------
https://chatgpt.com/codex/tasks/task_e_689ecceaa4cc8323be0621b489660cd1