### PR TITLE
Handle missing utils in scripts

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,9 +1,20 @@
 #!/usr/bin/env node
-const { createLogger, runCommand, createSpinner } = require('./utils');
-
 process.env.NODE_ENV = 'production';
 
 async function main() {
+  let createLogger, runCommand, createSpinner;
+  try {
+    ({ createLogger, runCommand, createSpinner } = require('./utils'));
+  } catch (err) {
+    if (err.code === 'MODULE_NOT_FOUND') {
+      console.error(
+        'Зависимости не установлены. Запустите `npm install` и затем `npm run setup`.'
+      );
+      process.exit(1);
+    }
+    throw err;
+  }
+
   const log = createLogger('build');
   log(`NODE_ENV=${process.env.NODE_ENV}`);
   const spinner = createSpinner('Building application');

--- a/scripts/clean.js
+++ b/scripts/clean.js
@@ -2,8 +2,6 @@
 const fs = require('fs');
 const fsp = fs.promises;
 const path = require('path');
-const { createLogger, createSpinner } = require('./utils');
-
 if (!fsp || !fsp.rm) {
   console.error('Node.js fs.promises.rm is required to run clean');
   process.exit(1);
@@ -29,6 +27,19 @@ async function emptyDir(dir) {
 }
 
 async function main() {
+  let createLogger, createSpinner;
+  try {
+    ({ createLogger, createSpinner } = require('./utils'));
+  } catch (err) {
+    if (err.code === 'MODULE_NOT_FOUND') {
+      console.error(
+        'Зависимости не установлены. Запустите `npm install` и затем `npm run setup`.'
+      );
+      process.exit(1);
+    }
+    throw err;
+  }
+
   const log = createLogger('clean');
   log(`NODE_ENV=${process.env.NODE_ENV}`);
   const spinner = createSpinner('Cleaning artifacts');

--- a/scripts/dev.js
+++ b/scripts/dev.js
@@ -1,9 +1,20 @@
 #!/usr/bin/env node
-const { createLogger, runCommand, createSpinner } = require('./utils');
-
 process.env.NODE_ENV = 'development';
 
 async function main() {
+  let createLogger, runCommand, createSpinner;
+  try {
+    ({ createLogger, runCommand, createSpinner } = require('./utils'));
+  } catch (err) {
+    if (err.code === 'MODULE_NOT_FOUND') {
+      console.error(
+        'Зависимости не установлены. Запустите `npm install` и затем `npm run setup`.'
+      );
+      process.exit(1);
+    }
+    throw err;
+  }
+
   const log = createLogger('dev');
   log(`NODE_ENV=${process.env.NODE_ENV}`);
   const spinner = createSpinner('Starting development server');

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -1,9 +1,20 @@
 #!/usr/bin/env node
-const { createLogger, runCommand, createSpinner } = require('./utils');
-
 process.env.NODE_ENV = 'test';
 
 async function main() {
+  let createLogger, runCommand, createSpinner;
+  try {
+    ({ createLogger, runCommand, createSpinner } = require('./utils'));
+  } catch (err) {
+    if (err.code === 'MODULE_NOT_FOUND') {
+      console.error(
+        'Зависимости не установлены. Запустите `npm install` и затем `npm run setup`.'
+      );
+      process.exit(1);
+    }
+    throw err;
+  }
+
   const log = createLogger('test');
   log(`NODE_ENV=${process.env.NODE_ENV}`);
   const spinner = createSpinner('Running tests');


### PR DESCRIPTION
## Summary
- load script utilities lazily inside main functions
- show installation hint when `./utils` is missing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ed36424548323bba9bbbf02889101