### PR TITLE
fix: correct backend paths in Tauri config

### DIFF
--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -2,14 +2,14 @@
   "$schema": "https://schema.tauri.app/config/2",
   "identifier": "com.example.multicode",
   "build": {
-    "beforeDevCommand": "cargo run --manifest-path ../backend/Cargo.toml",
-    "beforeBuildCommand": "cargo build --release --manifest-path ../backend/Cargo.toml",
+    "beforeDevCommand": "cargo run --manifest-path ../../backend/Cargo.toml",
+    "beforeBuildCommand": "cargo build --release --manifest-path ../../backend/Cargo.toml",
     "devUrl": "http://localhost:1420",
     "frontendDist": "../dist"
   },
   "bundle": {
     "externalBin": [
-      "../backend/target/release/backend"
+      "../../backend/target/release/backend"
     ]
   },
   "app": {


### PR DESCRIPTION
## Summary
- fix Tauri config to reference backend one directory higher

## Testing
- `npm run dev` *(fails: tauri not found and missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_689eda629f388323ad4741b42ace2d84