### PR TITLE
Add compare view and diff command

### DIFF
--- a/frontend/src/compare.html
+++ b/frontend/src/compare.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Compare</title>
+  <style>
+    body { margin: 0; display: flex; height: 100vh; }
+    .editor { flex: 1; }
+    .cm-editor { height: 100%; }
+    .diff-added { background: #e6ffe6; }
+    .diff-removed { background: #ffe6e6; }
+  </style>
+  <script type="module">
+    import { EditorState, StateEffect, StateField } from "@codemirror/state";
+    import { EditorView, Decoration } from "@codemirror/view";
+    import { basicSetup } from "https://cdn.jsdelivr.net/npm/@codemirror/basic-setup@0.20.0/dist/index.js";
+    import * as Diff from "https://cdn.jsdelivr.net/npm/diff@5.2.0/dist/diff.min.js";
+
+    const leftDoc = localStorage.getItem('compareA') || '';
+    const rightDoc = localStorage.getItem('compareB') || '';
+    localStorage.removeItem('compareA');
+    localStorage.removeItem('compareB');
+
+    const setDeco = StateEffect.define();
+    const decoField = StateField.define({
+      create() { return Decoration.none; },
+      update(value, tr) {
+        for (const e of tr.effects) {
+          if (e.is(setDeco)) return e.value;
+        }
+        return value;
+      },
+      provide: f => EditorView.decorations.from(f)
+    });
+
+    const viewA = new EditorView({
+      state: EditorState.create({
+        doc: leftDoc,
+        extensions: [basicSetup, EditorState.readOnly.of(true), decoField]
+      }),
+      parent: document.getElementById('left')
+    });
+
+    const viewB = new EditorView({
+      state: EditorState.create({
+        doc: rightDoc,
+        extensions: [basicSetup, EditorState.readOnly.of(true), decoField]
+      }),
+      parent: document.getElementById('right')
+    });
+
+    function highlightDiff() {
+      const parts = Diff.diffLines(leftDoc, rightDoc);
+      let lineA = 1, lineB = 1;
+      const decoA = [], decoB = [];
+      for (const part of parts) {
+        const count = part.count || part.value.split('\n').length - 1;
+        if (part.removed) {
+          for (let i = 0; i < count; i++) {
+            const line = viewA.state.doc.line(lineA + i);
+            decoA.push(Decoration.line({ class: 'diff-removed' }).range(line.from));
+          }
+          lineA += count;
+        } else if (part.added) {
+          for (let i = 0; i < count; i++) {
+            const line = viewB.state.doc.line(lineB + i);
+            decoB.push(Decoration.line({ class: 'diff-added' }).range(line.from));
+          }
+          lineB += count;
+        } else {
+          lineA += count;
+          lineB += count;
+        }
+      }
+      viewA.dispatch({ effects: setDeco.of(Decoration.set(decoA)) });
+      viewB.dispatch({ effects: setDeco.of(Decoration.set(decoB)) });
+    }
+
+    highlightDiff();
+  </script>
+</head>
+<body>
+  <div id="left" class="editor"></div>
+  <div id="right" class="editor"></div>
+</body>
+</html>

--- a/frontend/src/editor/history.js
+++ b/frontend/src/editor/history.js
@@ -49,6 +49,20 @@ export function showHistory(view) {
     dialog.remove();
   });
 
+  const compareBtn = document.createElement('button');
+  compareBtn.textContent = t('compare_with');
+  compareBtn.addEventListener('click', () => {
+    const idx = parseInt(select.value, 10);
+    const snap = snapshots[idx];
+    if (snap) {
+      localStorage.setItem('compareA', view.state.doc.toString());
+      localStorage.setItem('compareB', snap.content);
+      window.open('compare.html', '_blank');
+    }
+    dialog.close();
+    dialog.remove();
+  });
+
   const cancelBtn = document.createElement('button');
   cancelBtn.textContent = t('cancel');
   cancelBtn.addEventListener('click', () => {
@@ -58,6 +72,7 @@ export function showHistory(view) {
 
   dialog.appendChild(select);
   dialog.appendChild(okBtn);
+  dialog.appendChild(compareBtn);
   dialog.appendChild(cancelBtn);
   document.body.appendChild(dialog);
   if (typeof dialog.showModal === 'function') {

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -22,6 +22,7 @@
   "split_view": "Split View",
   "no_history": "No history",
   "restore": "Restore",
+  "compare_with": "Compare with…",
   "cancel": "Cancel",
   "goto_line_prompt": "Go to line:",
   "invalid_line_number": "Invalid line number",

--- a/frontend/src/locales/ru.json
+++ b/frontend/src/locales/ru.json
@@ -22,6 +22,7 @@
   "split_view": "Разделенный вид",
   "no_history": "Нет истории",
   "restore": "Восстановить",
+  "compare_with": "Сравнить с…",
   "cancel": "Отмена",
   "goto_line_prompt": "Перейти к строке:",
   "invalid_line_number": "Неверный номер строки",


### PR DESCRIPTION
## Summary
- add `compare.html` with side-by-side CodeMirror editors and diff highlighting
- enable comparing snapshots via new "Compare with…" action
- localize "Compare with…" button text for English and Russian

## Testing
- `npm test`
- `npm --prefix frontend run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_689ee8655dec8323ba1b6f13002439d3