### PR TITLE
feat: add markdown/html preview panel

### DIFF
--- a/frontend/src/editor/preview.js
+++ b/frontend/src/editor/preview.js
@@ -1,0 +1,65 @@
+import { marked } from 'https://cdn.jsdelivr.net/npm/marked@9.1.2/lib/marked.esm.js';
+
+let active = false;
+let editorEl;
+let previewEl;
+let currentMime = '';
+let syncing = false;
+
+function syncScroll(src, dest) {
+  const ratio = src.scrollTop / Math.max(1, src.scrollHeight - src.clientHeight);
+  dest.scrollTop = ratio * (dest.scrollHeight - dest.clientHeight);
+}
+
+function onEditorScroll() {
+  if (syncing || !previewEl) return;
+  syncing = true;
+  syncScroll(editorEl, previewEl);
+  syncing = false;
+}
+
+function onPreviewScroll() {
+  if (syncing || !editorEl) return;
+  syncing = true;
+  syncScroll(previewEl, editorEl);
+  syncing = false;
+}
+
+function render(view) {
+  if (!active || !previewEl) return;
+  const text = view.state.doc.toString();
+  if (currentMime === 'text/markdown') {
+    previewEl.innerHTML = marked.parse(text);
+  } else {
+    previewEl.innerHTML = text;
+  }
+}
+
+export function enablePreview(view, mime) {
+  previewEl = document.getElementById('preview');
+  editorEl = view?.scrollDOM;
+  currentMime = mime;
+  if (!previewEl || !editorEl) return;
+  previewEl.style.display = 'block';
+  active = true;
+  render(view);
+  editorEl.addEventListener('scroll', onEditorScroll);
+  previewEl.addEventListener('scroll', onPreviewScroll);
+}
+
+export function disablePreview() {
+  if (editorEl) editorEl.removeEventListener('scroll', onEditorScroll);
+  if (previewEl) {
+    previewEl.removeEventListener('scroll', onPreviewScroll);
+    previewEl.style.display = 'none';
+    previewEl.innerHTML = '';
+  }
+  active = false;
+  editorEl = null;
+  previewEl = null;
+  currentMime = '';
+}
+
+export function updatePreview(view) {
+  if (active) render(view);
+}

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -11,6 +11,7 @@
     #visual-minimap { position: fixed; bottom: 10px; right: 10px; width: 200px; height: 150px; border: 1px solid #ccc; background: #fff; opacity: 0.8; }
     #editor-wrapper { display: flex; height: 40vh; }
     #editor { flex: 1; border: 1px solid #ccc; }
+    #preview { flex: 1; border: 1px solid #ccc; border-left: none; overflow: auto; display: none; padding: 0.5rem; }
     #text-minimap { width: 60px; height: 100%; border: 1px solid #ccc; border-left: none; }
     #outline { width: 200px; height: 100%; border: 1px solid #ccc; border-left: none; overflow: auto; }
     #controls { padding: 0.5rem; }
@@ -55,6 +56,7 @@
     import { todoHighlight, updateTodoPanel } from "./editor/todo-highlight.js";
     import { setLanguage, getLanguage, availableLanguages, getLanguageName } from "./shared/i18n.ts";
     import { startTutorial } from "./tutorial/index.ts";
+    import { enablePreview, disablePreview, updatePreview } from "./editor/preview.js";
 
     const editorCfg = settings.editor || {};
     setLanguage(settings.language || 'en');
@@ -177,6 +179,7 @@
     async function initEditor(lang, doc = '') {
       currentLang = lang;
       vc.lang = lang;
+      disablePreview();
       if (view) view.destroy();
       if (removeMinimap) removeMinimap();
       if (removeOutline) removeOutline();
@@ -201,7 +204,10 @@
             EditorView.scrollMargins.of(() => ({ top: 20, bottom: 20 })),
             keymap.of(foldKeymap),
             EditorView.updateListener.of(update => {
-              if (update.docChanged) parseAndRender();
+              if (update.docChanged) {
+                parseAndRender();
+                updatePreview(update.view);
+              }
             })
           ]
         }),
@@ -271,6 +277,12 @@
       const mime = mimeFromFilename(name);
       await initEditor(lang, content || '');
       document.getElementById('editor').dataset.mime = mime;
+      if (mime === 'text/markdown' || mime === 'text/html') {
+        enablePreview(view, mime);
+        updatePreview(view);
+      } else {
+        disablePreview();
+      }
       parseAndRender();
       foldMetaBlock(view);
       setBlockIds(listMetaIds(view.state.doc.toString()));
@@ -481,6 +493,7 @@
     <div id="textPane">
       <div id="editor-wrapper">
       <div id="editor" data-file-id="current"></div>
+      <div id="preview"></div>
       <div id="text-minimap"></div>
       <div id="outline"></div>
       </div>


### PR DESCRIPTION
## Summary
- show side preview panel for markdown or html files
- render markdown via marked.js and sync scroll with editor

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689eecc9248083239f33a52d0954998b