### PR TITLE
feat: show git blame info

### DIFF
--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -163,6 +163,12 @@ fn git_log_cmd() -> Result<Vec<String>, String> {
 
 #[cfg_attr(not(test), tauri::command)]
 #[cfg(not(test))]
+fn git_blame_cmd(path: String) -> Result<Vec<git::BlameLine>, String> {
+    git::blame(&path).map_err(|e| e.to_string())
+}
+
+#[cfg_attr(not(test), tauri::command)]
+#[cfg(not(test))]
 async fn run_tests(commands: Vec<String>) -> Result<(), String> {
     let status = Command::new("node")
         .arg("scripts/run-tests.js")
@@ -173,7 +179,10 @@ async fn run_tests(commands: Vec<String>) -> Result<(), String> {
     if status.success() {
         Ok(())
     } else {
-        Err(format!("tests failed with code {}", status.code().unwrap_or(-1)))
+        Err(format!(
+            "tests failed with code {}",
+            status.code().unwrap_or(-1)
+        ))
     }
 }
 
@@ -289,6 +298,7 @@ fn main() {
             git_diff_cmd,
             git_branches_cmd,
             git_log_cmd,
+            git_blame_cmd,
             run_tests,
             debug_run,
             debug_step,

--- a/frontend/src/editor/git-blame.js
+++ b/frontend/src/editor/git-blame.js
@@ -1,0 +1,82 @@
+import { invoke } from "https://cdn.jsdelivr.net/npm/@tauri-apps/api@1.5.0/tauri.js";
+
+const cache = new Map();
+
+/**
+ * Attach git blame tooltips to the editor line numbers.
+ * @param {import('@codemirror/view').EditorView} view
+ * @param {string} path File path relative to repo root
+ * @returns {() => void} cleanup function
+ */
+export function attachGitBlame(view, path) {
+  if (!view || !path) return () => {};
+  const gutter = view.dom.querySelector('.cm-gutters');
+  if (!gutter) return () => {};
+
+  const tooltip = document.createElement('div');
+  tooltip.style.position = 'fixed';
+  tooltip.style.pointerEvents = 'none';
+  tooltip.style.background = '#333';
+  tooltip.style.color = '#fff';
+  tooltip.style.padding = '2px 6px';
+  tooltip.style.borderRadius = '4px';
+  tooltip.style.fontSize = '12px';
+  tooltip.style.display = 'none';
+  document.body.appendChild(tooltip);
+
+  async function loadBlame() {
+    if (cache.has(path)) return cache.get(path);
+    try {
+      const data = await invoke('git_blame_cmd', { path });
+      cache.set(path, data);
+      return data;
+    } catch (e) {
+      console.error('git blame failed', e);
+      cache.set(path, null);
+      return null;
+    }
+  }
+
+  let current;
+
+  async function show(e) {
+    const lineEl = e.target.closest('.cm-gutterElement');
+    if (!lineEl) return;
+    const line = Number(lineEl.textContent);
+    if (!Number.isFinite(line)) return;
+    const blame = await loadBlame();
+    if (!blame) return;
+    const info = blame.find(b => b.line === line);
+    if (!info) return;
+    const date = new Date(info.time * 1000).toLocaleDateString();
+    tooltip.textContent = `${info.author} \u2013 ${date}`;
+    tooltip.style.left = e.clientX + 10 + 'px';
+    tooltip.style.top = e.clientY + 10 + 'px';
+    tooltip.style.display = 'block';
+    current = lineEl;
+  }
+
+  function move(e) {
+    if (tooltip.style.display !== 'none') {
+      tooltip.style.left = e.clientX + 10 + 'px';
+      tooltip.style.top = e.clientY + 10 + 'px';
+    }
+  }
+
+  function hide() {
+    tooltip.style.display = 'none';
+    current = null;
+  }
+
+  gutter.addEventListener('mouseover', show);
+  gutter.addEventListener('mousemove', move);
+  gutter.addEventListener('mouseout', hide);
+
+  return () => {
+    gutter.removeEventListener('mouseover', show);
+    gutter.removeEventListener('mousemove', move);
+    gutter.removeEventListener('mouseout', hide);
+    tooltip.remove();
+  };
+}
+

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -58,6 +58,7 @@
     import { spellcheck } from "./editor/spellcheck.js";
     import { activeBlock } from "./editor/active-block.js";
     import { todoHighlight, updateTodoPanel } from "./editor/todo-highlight.js";
+    import { attachGitBlame } from "./editor/git-blame.js";
     import { setLanguage, getLanguage, availableLanguages, getLanguageName } from "./shared/i18n.ts";
     import { startTutorial } from "./tutorial/index.ts";
     import { enablePreview, disablePreview, updatePreview } from "./editor/preview.js";
@@ -78,6 +79,7 @@
     let view;
     let removeMinimap;
     let removeOutline;
+    let removeBlame;
 
     await loadBlockPlugins(window.blockPlugins || []);
 
@@ -295,6 +297,8 @@
       parseAndRender();
       foldMetaBlock(view);
       setBlockIds(listMetaIds(view.state.doc.toString()));
+      if (removeBlame) removeBlame();
+      removeBlame = attachGitBlame(view, name);
     }
 
     window.openFile = openFile;


### PR DESCRIPTION
## Summary
- add backend git blame command and data type
- show blame author/date when hovering line numbers

## Testing
- `cargo test`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ef985fb288323bbe4000a9e0a320a