### PR TITLE
feat: support function blocks and templates

### DIFF
--- a/backend/src/blocks/enrich.rs
+++ b/backend/src/blocks/enrich.rs
@@ -41,16 +41,22 @@ pub fn enrich_blocks(blocks: Vec<Block>, content: &str) -> Vec<BlockInfo> {
 }
 
 fn normalize_kind(kind: &str) -> String {
-    let k = kind.to_lowercase();
-    if k.contains("function") {
+    let lower = kind.to_lowercase();
+    if lower == "function/define" {
+        "Function/Define".into()
+    } else if lower == "function/call" {
+        "Function/Call".into()
+    } else if lower == "return" {
+        "Return".into()
+    } else if lower.contains("function") {
         "Function".into()
-    } else if k.contains("if") {
+    } else if lower.contains("if") {
         "Condition".into()
-    } else if k.contains("for") || k.contains("while") || k.contains("loop") {
+    } else if lower.contains("for") || lower.contains("while") || lower.contains("loop") {
         "Loop".into()
-    } else if k.contains("identifier") || k.contains("variable") {
+    } else if lower.contains("identifier") || lower.contains("variable") {
         "Variable".into()
-    } else if k.contains("map") {
+    } else if lower.contains("map") {
         "Map".into()
     } else {
         kind.to_string()

--- a/backend/src/parser/mod.rs
+++ b/backend/src/parser/mod.rs
@@ -67,11 +67,24 @@ pub fn parse_to_blocks(tree: &Tree) -> Vec<Block> {
     let mut blocks = Vec::new();
     let mut counter: u64 = 0;
 
+    fn map_kind(kind: &str) -> String {
+        let k = kind.to_lowercase();
+        if k.contains("call") && !k.contains("function") {
+            "Function/Call".into()
+        } else if k.contains("return") {
+            "Return".into()
+        } else if k.contains("function") || k.contains("method") {
+            "Function/Define".into()
+        } else {
+            kind.to_string()
+        }
+    }
+
     fn walk(node: Node, blocks: &mut Vec<Block>, counter: &mut u64) {
         blocks.push(Block {
             visual_id: counter.to_string(),
             node_id: node.id() as u32,
-            kind: node.kind().to_string(),
+            kind: map_kind(node.kind()),
             range: node.byte_range(),
         });
         *counter += 1;

--- a/frontend/src/visual/blocks.js
+++ b/frontend/src/visual/blocks.js
@@ -172,6 +172,69 @@ export class FunctionBlock extends Block {
   }
 }
 
+export class FunctionDefineBlock extends Block {
+  static defaultSize = { width: 120, height: 50 };
+  static ports = [
+    { id: 'exec', kind: 'exec', dir: 'in' },
+    { id: 'params', kind: 'data', dir: 'in' },
+    { id: 'out', kind: 'exec', dir: 'out' }
+  ];
+  constructor(id, x, y) {
+    super(
+      id,
+      x,
+      y,
+      FunctionDefineBlock.defaultSize.width,
+      FunctionDefineBlock.defaultSize.height,
+      'Function Define',
+      getTheme().blockKinds.Function
+    );
+    this.ports = FunctionDefineBlock.ports;
+  }
+}
+
+export class FunctionCallBlock extends Block {
+  static defaultSize = { width: 120, height: 50 };
+  static ports = [
+    { id: 'exec', kind: 'exec', dir: 'in' },
+    { id: 'params', kind: 'data', dir: 'in' },
+    { id: 'out', kind: 'exec', dir: 'out' }
+  ];
+  constructor(id, x, y) {
+    super(
+      id,
+      x,
+      y,
+      FunctionCallBlock.defaultSize.width,
+      FunctionCallBlock.defaultSize.height,
+      'Function Call',
+      getTheme().blockKinds.Function
+    );
+    this.ports = FunctionCallBlock.ports;
+  }
+}
+
+export class ReturnBlock extends Block {
+  static defaultSize = { width: 120, height: 50 };
+  static ports = [
+    { id: 'exec', kind: 'exec', dir: 'in' },
+    { id: 'params', kind: 'data', dir: 'in' },
+    { id: 'out', kind: 'exec', dir: 'out' }
+  ];
+  constructor(id, x, y) {
+    super(
+      id,
+      x,
+      y,
+      ReturnBlock.defaultSize.width,
+      ReturnBlock.defaultSize.height,
+      'Return',
+      getTheme().blockKinds.Function
+    );
+    this.ports = ReturnBlock.ports;
+  }
+}
+
 export class VariableBlock extends Block {
   constructor(id, x, y) {
     super(id, x, y, 120, 50, 'Variable', getTheme().blockKinds.Variable);
@@ -389,6 +452,9 @@ registerBlock('Literal/String', StringLiteralBlock);
 registerBlock('Literal/Boolean', BooleanLiteralBlock);
 registerBlock('Literal/Null', NullLiteralBlock);
 registerBlock('Function', FunctionBlock);
+registerBlock('Function/Define', FunctionDefineBlock);
+registerBlock('Function/Call', FunctionCallBlock);
+registerBlock('Return', ReturnBlock);
 registerBlock('Variable', VariableBlock);
 registerBlock('Variable/Get', VariableGetBlock);
 registerBlock('Variable/Set', VariableSetBlock);

--- a/frontend/src/visual/blocks.test.js
+++ b/frontend/src/visual/blocks.test.js
@@ -16,7 +16,10 @@ import {
   MapSetBlock,
   VariableGetBlock,
   VariableSetBlock,
-  StructBlock
+  StructBlock,
+  FunctionDefineBlock,
+  FunctionCallBlock,
+  ReturnBlock
 } from './blocks.js';
 import { getTheme } from './theme.ts';
 
@@ -91,6 +94,21 @@ describe('block utilities', () => {
       expect(b).toBeInstanceOf(Ctor);
       expect(b.ports).toEqual(ports);
       expect(b.color).toBe(theme.blockKinds.Map);
+    }
+  });
+
+  it('provides function blocks', () => {
+    const theme = getTheme();
+    const cases = [
+      ['Function/Define', FunctionDefineBlock],
+      ['Function/Call', FunctionCallBlock],
+      ['Return', ReturnBlock]
+    ];
+    for (const [kind, Ctor] of cases) {
+      const b = createBlock(kind, 'fn', 0, 0, '');
+      expect(b).toBeInstanceOf(Ctor);
+      expect(b.ports).toEqual(Ctor.ports);
+      expect(b.color).toBe(theme.blockKinds.Function);
     }
   });
 

--- a/frontend/src/visual/menu.ts
+++ b/frontend/src/visual/menu.ts
@@ -1,5 +1,6 @@
 import { hotkeys, showHotkeyHelp, zoomToFit, focusSearch } from './hotkeys';
 import { exportPNG } from './canvas.js';
+import { emit } from '../shared/event-bus.js';
 
 export function createSearchInput(canvas: any) {
   const input = document.createElement('input');
@@ -21,6 +22,14 @@ export interface MenuItem {
   action?: () => void;
   shortcut?: string;
   submenu?: MenuItem[];
+}
+
+function insertFunctionTemplate(kind: 'Function/Define' | 'Function/Call' | 'Return') {
+  const id =
+    (globalThis.crypto && typeof globalThis.crypto.randomUUID === 'function')
+      ? globalThis.crypto.randomUUID()
+      : Math.random().toString(36).slice(2);
+  emit('blockCreated', { id, kind });
 }
 
 export const mainMenu: MenuItem[] = [
@@ -47,6 +56,14 @@ export const mainMenu: MenuItem[] = [
     label: 'View',
     submenu: [
       { label: 'Zoom to Fit', action: zoomToFit, shortcut: hotkeys.zoomToFit }
+    ]
+  },
+  {
+    label: 'Templates',
+    submenu: [
+      { label: 'Function Define', action: () => insertFunctionTemplate('Function/Define') },
+      { label: 'Function Call', action: () => insertFunctionTemplate('Function/Call') },
+      { label: 'Return', action: () => insertFunctionTemplate('Return') }
     ]
   },
   {


### PR DESCRIPTION
## Summary
- add FunctionDefine, FunctionCall and Return blocks with exec/param/out ports
- map function sidecar nodes in parser and preserve SourceAnchor
- expose menu items to insert function templates

## Testing
- `npm test`
- `cargo test` *(fails: javascriptcoregtk-4.1 system library missing)*

------
https://chatgpt.com/codex/tasks/task_e_689f063753e48323a9b0ade796bcdc9f