### PR TITLE
Handle updated block kinds in tests

### DIFF
--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -25,6 +25,7 @@ pub use backend::BlockInfo;
 use clap::{Parser, Subcommand};
 #[cfg(not(test))]
 use tauri::State;
+#[cfg(not(test))]
 use tokio::process::Command;
 
 #[cfg(not(test))]
@@ -326,7 +327,7 @@ mod tests {
         let src = "fn main() {}".to_string();
         let blocks = parse_blocks(src, "rust".into()).expect("parse");
         assert!(!blocks.is_empty());
-        assert!(blocks.iter().any(|b| b.kind == "Function"));
+        assert!(blocks.iter().any(|b| b.kind.starts_with("Function")));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- update backend test to accept specific function block names
- gate `tokio::process::Command` import to non-test builds

## Testing
- `cargo test --tests`

------
https://chatgpt.com/codex/tasks/task_e_689f10c8e9c08323a4abc0fd3f03dc5f