### PR TITLE
Add loop control blocks and hotkey bindings

### DIFF
--- a/frontend/src/visual/blocks.js
+++ b/frontend/src/visual/blocks.js
@@ -338,6 +338,99 @@ export class LoopBlock extends Block {
   }
 }
 
+export class ForLoopBlock extends Block {
+  static defaultSize = { width: 120, height: 50 };
+  static ports = [
+    { id: 'execIn', kind: 'exec', dir: 'in' },
+    { id: 'execOut', kind: 'exec', dir: 'out' },
+    { id: 'init', kind: 'data', dir: 'in' },
+    { id: 'cond', kind: 'data', dir: 'in' },
+    { id: 'iter', kind: 'data', dir: 'in' }
+  ];
+  constructor(id, x, y) {
+    super(
+      id,
+      x,
+      y,
+      ForLoopBlock.defaultSize.width,
+      ForLoopBlock.defaultSize.height,
+      'For',
+      getTheme().blockKinds.Loop
+    );
+    this.ports = ForLoopBlock.ports;
+  }
+}
+
+export class WhileLoopBlock extends Block {
+  static defaultSize = { width: 120, height: 50 };
+  static ports = [
+    { id: 'execIn', kind: 'exec', dir: 'in' },
+    { id: 'execOut', kind: 'exec', dir: 'out' },
+    { id: 'init', kind: 'data', dir: 'in' },
+    { id: 'cond', kind: 'data', dir: 'in' },
+    { id: 'iter', kind: 'data', dir: 'in' }
+  ];
+  constructor(id, x, y) {
+    super(
+      id,
+      x,
+      y,
+      WhileLoopBlock.defaultSize.width,
+      WhileLoopBlock.defaultSize.height,
+      'While',
+      getTheme().blockKinds.Loop
+    );
+    this.ports = WhileLoopBlock.ports;
+  }
+}
+
+export class ForEachLoopBlock extends Block {
+  static defaultSize = { width: 120, height: 50 };
+  static ports = [
+    { id: 'execIn', kind: 'exec', dir: 'in' },
+    { id: 'execOut', kind: 'exec', dir: 'out' },
+    { id: 'init', kind: 'data', dir: 'in' },
+    { id: 'cond', kind: 'data', dir: 'in' },
+    { id: 'iter', kind: 'data', dir: 'in' }
+  ];
+  constructor(id, x, y) {
+    super(
+      id,
+      x,
+      y,
+      ForEachLoopBlock.defaultSize.width,
+      ForEachLoopBlock.defaultSize.height,
+      'For Each',
+      getTheme().blockKinds.Loop
+    );
+    this.ports = ForEachLoopBlock.ports;
+  }
+}
+
+export class BreakBlock extends Block {
+  static defaultSize = { width: 120, height: 50 };
+  static ports = [
+    { id: 'execIn', kind: 'exec', dir: 'in' },
+    { id: 'execOut', kind: 'exec', dir: 'out' }
+  ];
+  constructor(id, x, y) {
+    super(id, x, y, BreakBlock.defaultSize.width, BreakBlock.defaultSize.height, 'Break', getTheme().blockKinds.Loop);
+    this.ports = BreakBlock.ports;
+  }
+}
+
+export class ContinueBlock extends Block {
+  static defaultSize = { width: 120, height: 50 };
+  static ports = [
+    { id: 'execIn', kind: 'exec', dir: 'in' },
+    { id: 'execOut', kind: 'exec', dir: 'out' }
+  ];
+  constructor(id, x, y) {
+    super(id, x, y, ContinueBlock.defaultSize.width, ContinueBlock.defaultSize.height, 'Continue', getTheme().blockKinds.Loop);
+    this.ports = ContinueBlock.ports;
+  }
+}
+
 export class ArrayNewBlock extends Block {
   static defaultSize = { width: 120, height: 50 };
   static ports = [
@@ -510,6 +603,11 @@ registerBlock('Condition', ConditionBlock);
 registerBlock('If', IfBlock);
 registerBlock('Switch', SwitchBlock);
 registerBlock('Loop', LoopBlock);
+registerBlock('Loop/For', ForLoopBlock);
+registerBlock('Loop/While', WhileLoopBlock);
+registerBlock('Loop/ForEach', ForEachLoopBlock);
+registerBlock('Loop/Break', BreakBlock);
+registerBlock('Loop/Continue', ContinueBlock);
 registerBlock('Array/New', ArrayNewBlock);
 registerBlock('Array/Get', ArrayGetBlock);
 registerBlock('Array/Set', ArraySetBlock);

--- a/frontend/src/visual/blocks.test.js
+++ b/frontend/src/visual/blocks.test.js
@@ -20,7 +20,12 @@ import {
   SwitchBlock,
   FunctionDefineBlock,
   FunctionCallBlock,
-  ReturnBlock
+  ReturnBlock,
+  ForLoopBlock,
+  WhileLoopBlock,
+  ForEachLoopBlock,
+  BreakBlock,
+  ContinueBlock
 } from './blocks.js';
 import { getTheme } from './theme.ts';
 
@@ -124,6 +129,23 @@ describe('block utilities', () => {
       expect(b).toBeInstanceOf(Ctor);
       expect(b.ports).toEqual(ports);
       expect(b.color).toBe(theme.blockKinds.Variable);
+    }
+  });
+
+  it('provides loop blocks', () => {
+    const theme = getTheme();
+    const cases = [
+      ['Loop/For', ForLoopBlock, ForLoopBlock.ports],
+      ['Loop/While', WhileLoopBlock, WhileLoopBlock.ports],
+      ['Loop/ForEach', ForEachLoopBlock, ForEachLoopBlock.ports],
+      ['Loop/Break', BreakBlock, BreakBlock.ports],
+      ['Loop/Continue', ContinueBlock, ContinueBlock.ports]
+    ];
+    for (const [kind, Ctor, ports] of cases) {
+      const b = createBlock(kind, 'loop', 0, 0, '');
+      expect(b).toBeInstanceOf(Ctor);
+      expect(b.ports).toEqual(ports);
+      expect(b.color).toBe(theme.blockKinds.Loop || theme.blockFill);
     }
   });
 

--- a/frontend/src/visual/hotkeys.ts
+++ b/frontend/src/visual/hotkeys.ts
@@ -21,6 +21,9 @@ export interface HotkeyMap {
   gotoRelated: string;
   gotoLine: string;
   formatCurrentFile: string;
+  insertForLoop: string;
+  insertWhileLoop: string;
+  insertForEachLoop: string;
 }
 
 const cfg: { hotkeys?: Partial<HotkeyMap>; visual?: { gridSize?: number } } = settings as any;
@@ -37,7 +40,10 @@ export const hotkeys: HotkeyMap = {
   redo: cfg.hotkeys?.redo || 'Ctrl+Shift+Z',
   gotoRelated: cfg.hotkeys?.gotoRelated || 'Ctrl+Alt+O',
   gotoLine: cfg.hotkeys?.gotoLine || 'Ctrl+G',
-  formatCurrentFile: cfg.hotkeys?.formatCurrentFile || 'Shift+Alt+F'
+  formatCurrentFile: cfg.hotkeys?.formatCurrentFile || 'Shift+Alt+F',
+  insertForLoop: cfg.hotkeys?.insertForLoop || 'Ctrl+Alt+F',
+  insertWhileLoop: cfg.hotkeys?.insertWhileLoop || 'Ctrl+Alt+W',
+  insertForEachLoop: cfg.hotkeys?.insertForEachLoop || 'Ctrl+Alt+E'
 };
 
 function buildCombo(e: KeyboardEvent) {
@@ -107,6 +113,18 @@ function handleKey(e: KeyboardEvent) {
       e.preventDefault();
       formatCurrentFile();
       break;
+    case hotkeys.insertForLoop:
+      e.preventDefault();
+      insertKeywordBlock('for');
+      break;
+    case hotkeys.insertWhileLoop:
+      e.preventDefault();
+      insertKeywordBlock('while');
+      break;
+    case hotkeys.insertForEachLoop:
+      e.preventDefault();
+      insertKeywordBlock('foreach');
+      break;
     case 'F2':
       e.preventDefault();
       canvasRef?.renameSelectedBlock?.();
@@ -155,8 +173,16 @@ function handleKey(e: KeyboardEvent) {
       e.preventDefault();
       insertKeywordBlock('let');
       keywordBuffer = '';
-    } else if (keywordBuffer.length > 3) {
-      keywordBuffer = keywordBuffer.slice(-3);
+    } else if (keywordBuffer.endsWith('for')) {
+      e.preventDefault();
+      insertKeywordBlock('for');
+      keywordBuffer = '';
+    } else if (keywordBuffer.endsWith('while')) {
+      e.preventDefault();
+      insertKeywordBlock('while');
+      keywordBuffer = '';
+    } else if (keywordBuffer.length > 5) {
+      keywordBuffer = keywordBuffer.slice(-5);
     }
   }
 }
@@ -231,12 +257,41 @@ export function zoomToFit() {
   canvasRef?.zoomToFit();
 }
 
-function insertKeywordBlock(keyword: 'var' | 'let') {
+function insertKeywordBlock(keyword: 'var' | 'let' | 'for' | 'while' | 'foreach') {
   if (!canvasRef) return;
   const theme = getTheme();
-  const kind = keyword === 'var' ? 'Variable/Get' : 'Variable/Set';
-  const label = keyword === 'var' ? 'Variable Get' : 'Variable Set';
-  const color = theme.blockKinds.Variable || theme.blockFill;
+  let kind: string;
+  let label: string;
+  let color: string;
+  switch (keyword) {
+    case 'var':
+      kind = 'Variable/Get';
+      label = 'Variable Get';
+      color = theme.blockKinds.Variable || theme.blockFill;
+      break;
+    case 'let':
+      kind = 'Variable/Set';
+      label = 'Variable Set';
+      color = theme.blockKinds.Variable || theme.blockFill;
+      break;
+    case 'for':
+      kind = 'Loop/For';
+      label = 'For';
+      color = theme.blockKinds.Loop || theme.blockFill;
+      break;
+    case 'while':
+      kind = 'Loop/While';
+      label = 'While';
+      color = theme.blockKinds.Loop || theme.blockFill;
+      break;
+    case 'foreach':
+      kind = 'Loop/ForEach';
+      label = 'For Each';
+      color = theme.blockKinds.Loop || theme.blockFill;
+      break;
+    default:
+      return;
+  }
   const id =
     (globalThis.crypto && typeof globalThis.crypto.randomUUID === 'function')
       ? globalThis.crypto.randomUUID()


### PR DESCRIPTION
## Summary
- Add ForLoopBlock, WhileLoopBlock, ForEachLoopBlock and control flow Break/Continue blocks
- Support hotkeys and keyword triggers for for/while loops
- Test new loop block registrations

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f23840d188323bf2d7cf7c974ac8b