### PR TITLE
feat: add sequence block

### DIFF
--- a/frontend/src/visual/blocks.js
+++ b/frontend/src/visual/blocks.js
@@ -284,6 +284,30 @@ export class ConditionBlock extends Block {
   }
 }
 
+export class SequenceBlock extends Block {
+  static defaultSize = { width: 120, height: 50 };
+  constructor(id, x, y, _w, _h, label, color, data) {
+    super(
+      id,
+      x,
+      y,
+      SequenceBlock.defaultSize.width,
+      SequenceBlock.defaultSize.height,
+      label || 'Sequence',
+      color ?? getTheme().blockKinds.Sequence
+    );
+    this.steps = Array.isArray(data?.steps) ? data.steps : [];
+    this.updatePorts();
+  }
+
+  updatePorts() {
+    this.ports = [
+      ...this.steps.map(s => ({ id: `exec[${s}]`, kind: 'exec', dir: 'in' })),
+      { id: 'out', kind: 'exec', dir: 'out' }
+    ];
+  }
+}
+
 export class IfBlock extends Block {
   static defaultSize = { width: 120, height: 50 };
   static ports = [
@@ -600,6 +624,7 @@ registerBlock('Variable', VariableBlock);
 registerBlock('Variable/Get', VariableGetBlock);
 registerBlock('Variable/Set', VariableSetBlock);
 registerBlock('Condition', ConditionBlock);
+registerBlock('Sequence', SequenceBlock);
 registerBlock('If', IfBlock);
 registerBlock('Switch', SwitchBlock);
 registerBlock('Loop', LoopBlock);

--- a/frontend/src/visual/blocks.test.js
+++ b/frontend/src/visual/blocks.test.js
@@ -17,6 +17,7 @@ import {
   VariableGetBlock,
   VariableSetBlock,
   StructBlock,
+  SequenceBlock,
   SwitchBlock,
   FunctionDefineBlock,
   FunctionCallBlock,
@@ -169,5 +170,18 @@ describe('block utilities', () => {
       { id: 'default', kind: 'exec', dir: 'out' }
     ]);
     expect(b.color).toBe(theme.blockKinds.Switch || theme.blockFill);
+  });
+
+  it('preserves order of sequence block steps', () => {
+    const theme = getTheme();
+    const b = createBlock('Sequence', 'seq', 0, 0, '', undefined, { steps: ['a', 'b'] });
+    expect(b).toBeInstanceOf(SequenceBlock);
+    expect(b.ports).toEqual([
+      { id: 'exec[a]', kind: 'exec', dir: 'in' },
+      { id: 'exec[b]', kind: 'exec', dir: 'in' },
+      { id: 'out', kind: 'exec', dir: 'out' }
+    ]);
+    expect(b.color).toBe(theme.blockKinds.Sequence || theme.blockFill);
+    expect(b.steps).toEqual(['a', 'b']);
   });
 });

--- a/frontend/src/visual/menu.ts
+++ b/frontend/src/visual/menu.ts
@@ -32,6 +32,14 @@ function insertFunctionTemplate(kind: 'Function/Define' | 'Function/Call' | 'Ret
   emit('blockCreated', { id, kind });
 }
 
+function insertSequenceTemplate() {
+  const id =
+    (globalThis.crypto && typeof globalThis.crypto.randomUUID === 'function')
+      ? globalThis.crypto.randomUUID()
+      : Math.random().toString(36).slice(2);
+  emit('blockCreated', { id, kind: 'Sequence' });
+}
+
 export const mainMenu: MenuItem[] = [
   {
     label: 'File',
@@ -63,8 +71,9 @@ export const mainMenu: MenuItem[] = [
     submenu: [
       { label: 'Function Define', action: () => insertFunctionTemplate('Function/Define') },
       { label: 'Function Call', action: () => insertFunctionTemplate('Function/Call') },
-      { label: 'Return', action: () => insertFunctionTemplate('Return') }
-    ]
+      { label: 'Return', action: () => insertFunctionTemplate('Return') },
+      { label: 'Sequence', action: insertSequenceTemplate }
+    ].sort((a, b) => a.label.localeCompare(b.label))
   },
   {
     label: 'Help',


### PR DESCRIPTION
## Summary
- add SequenceBlock with multiple exec inputs and single output
- allow inserting Sequence blocks via menu
- test that sequence step order is preserved

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f2816455c8323b0b4e21850e76ecb