### PR TITLE
feat: add async blocks and hotkeys

### DIFF
--- a/frontend/src/visual/blocks.js
+++ b/frontend/src/visual/blocks.js
@@ -379,6 +379,71 @@ export class TryBlock extends Block {
   }
 }
 
+export class AwaitBlock extends Block {
+  static defaultSize = { width: 120, height: 50 };
+  static ports = [
+    { id: 'execIn', kind: 'exec', dir: 'in' },
+    { id: 'value', kind: 'data', dir: 'in' },
+    { id: 'execOut', kind: 'exec', dir: 'out' },
+    { id: 'result', kind: 'data', dir: 'out' }
+  ];
+  constructor(id, x, y) {
+    super(
+      id,
+      x,
+      y,
+      AwaitBlock.defaultSize.width,
+      AwaitBlock.defaultSize.height,
+      'Await',
+      getTheme().blockKinds.Async
+    );
+    this.ports = AwaitBlock.ports;
+  }
+}
+
+export class DelayBlock extends Block {
+  static defaultSize = { width: 120, height: 50 };
+  static ports = [
+    { id: 'execIn', kind: 'exec', dir: 'in' },
+    { id: 'time', kind: 'data', dir: 'in' },
+    { id: 'execOut', kind: 'exec', dir: 'out' }
+  ];
+  constructor(id, x, y) {
+    super(
+      id,
+      x,
+      y,
+      DelayBlock.defaultSize.width,
+      DelayBlock.defaultSize.height,
+      'Delay',
+      getTheme().blockKinds.Async
+    );
+    this.ports = DelayBlock.ports;
+  }
+}
+
+export class EventOnBlock extends Block {
+  static defaultSize = { width: 120, height: 50 };
+  static ports = [
+    { id: 'target', kind: 'data', dir: 'in' },
+    { id: 'event', kind: 'data', dir: 'in' },
+    { id: 'exec', kind: 'exec', dir: 'out' },
+    { id: 'data', kind: 'data', dir: 'out' }
+  ];
+  constructor(id, x, y) {
+    super(
+      id,
+      x,
+      y,
+      EventOnBlock.defaultSize.width,
+      EventOnBlock.defaultSize.height,
+      'Event On',
+      getTheme().blockKinds.Async
+    );
+    this.ports = EventOnBlock.ports;
+  }
+}
+
 export class LoopBlock extends Block {
   constructor(id, x, y) {
     super(id, x, y, 120, 50, 'Loop', getTheme().blockKinds.Loop);
@@ -651,6 +716,9 @@ registerBlock('Sequence', SequenceBlock);
 registerBlock('If', IfBlock);
 registerBlock('Switch', SwitchBlock);
 registerBlock('Try', TryBlock);
+registerBlock('Async/Await', AwaitBlock);
+registerBlock('Async/Delay', DelayBlock);
+registerBlock('Async/EventOn', EventOnBlock);
 registerBlock('Loop', LoopBlock);
 registerBlock('Loop/For', ForLoopBlock);
 registerBlock('Loop/While', WhileLoopBlock);

--- a/frontend/src/visual/hotkeys.ts
+++ b/frontend/src/visual/hotkeys.ts
@@ -181,6 +181,18 @@ function handleKey(e: KeyboardEvent) {
       e.preventDefault();
       insertKeywordBlock('while');
       keywordBuffer = '';
+    } else if (keywordBuffer.endsWith('await')) {
+      e.preventDefault();
+      insertKeywordBlock('await');
+      keywordBuffer = '';
+    } else if (keywordBuffer.endsWith('delay')) {
+      e.preventDefault();
+      insertKeywordBlock('delay');
+      keywordBuffer = '';
+    } else if (keywordBuffer === 'on') {
+      e.preventDefault();
+      insertKeywordBlock('on');
+      keywordBuffer = '';
     } else if (keywordBuffer.length > 5) {
       keywordBuffer = keywordBuffer.slice(-5);
     }
@@ -257,7 +269,7 @@ export function zoomToFit() {
   canvasRef?.zoomToFit();
 }
 
-function insertKeywordBlock(keyword: 'var' | 'let' | 'for' | 'while' | 'foreach') {
+function insertKeywordBlock(keyword: 'var' | 'let' | 'for' | 'while' | 'foreach' | 'await' | 'delay' | 'on') {
   if (!canvasRef) return;
   const theme = getTheme();
   let kind: string;
@@ -288,6 +300,21 @@ function insertKeywordBlock(keyword: 'var' | 'let' | 'for' | 'while' | 'foreach'
       kind = 'Loop/ForEach';
       label = 'For Each';
       color = theme.blockKinds.Loop || theme.blockFill;
+      break;
+    case 'await':
+      kind = 'Async/Await';
+      label = 'Await';
+      color = theme.blockKinds.Async || theme.blockFill;
+      break;
+    case 'delay':
+      kind = 'Async/Delay';
+      label = 'Delay';
+      color = theme.blockKinds.Async || theme.blockFill;
+      break;
+    case 'on':
+      kind = 'Async/EventOn';
+      label = 'Event On';
+      color = theme.blockKinds.Async || theme.blockFill;
       break;
     default:
       return;

--- a/frontend/src/visual/theme.ts
+++ b/frontend/src/visual/theme.ts
@@ -26,6 +26,9 @@ darkTheme.blockKinds.Array = darkTheme.blockKinds.Array || '#1976d2';
 // ensure color for map blocks exists
 defaultTheme.blockKinds.Map = defaultTheme.blockKinds.Map || '#c8e6c9';
 darkTheme.blockKinds.Map = darkTheme.blockKinds.Map || '#388e3c';
+// ensure color for async blocks exists
+defaultTheme.blockKinds.Async = defaultTheme.blockKinds.Async || '#b2dfdb';
+darkTheme.blockKinds.Async = darkTheme.blockKinds.Async || '#00897b';
 
 const themeMap: Record<string, VisualTheme> = {
   default: defaultTheme,


### PR DESCRIPTION
## Summary
- implement Await, Delay and Event On blocks with exec/data ports
- enable hotkey keyword insertion for `await`, `delay`, and `on`
- add Async block theme colors

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f3add37748323a498b76b0ac0fb0c