### PR TITLE
Add operator blocks and hotkey insertion

### DIFF
--- a/frontend/src/visual/blocks.js
+++ b/frontend/src/visual/blocks.js
@@ -166,6 +166,57 @@ export class NullLiteralBlock extends Block {
   }
 }
 
+class OperatorBlockBase extends Block {
+  static defaultSize = { width: 120, height: 50 };
+  static ports = [
+    { id: 'lhs', kind: 'data', dir: 'in' },
+    { id: 'rhs', kind: 'data', dir: 'in' },
+    { id: 'out', kind: 'data', dir: 'out' }
+  ];
+  constructor(id, x, y, label) {
+    super(
+      id,
+      x,
+      y,
+      OperatorBlockBase.defaultSize.width,
+      OperatorBlockBase.defaultSize.height,
+      label,
+      getTheme().blockKinds.Operator || getTheme().blockFill
+    );
+    this.ports = OperatorBlockBase.ports;
+  }
+}
+
+export class AddBlock extends OperatorBlockBase {
+  constructor(id, x, y) {
+    super(id, x, y, '+');
+  }
+}
+
+export class SubtractBlock extends OperatorBlockBase {
+  constructor(id, x, y) {
+    super(id, x, y, '-');
+  }
+}
+
+export class MultiplyBlock extends OperatorBlockBase {
+  constructor(id, x, y) {
+    super(id, x, y, '*');
+  }
+}
+
+export class DivideBlock extends OperatorBlockBase {
+  constructor(id, x, y) {
+    super(id, x, y, '/');
+  }
+}
+
+export class ModuloBlock extends OperatorBlockBase {
+  constructor(id, x, y) {
+    super(id, x, y, '%');
+  }
+}
+
 export class FunctionBlock extends Block {
   constructor(id, x, y) {
     super(id, x, y, 120, 50, 'Function', getTheme().blockKinds.Function);
@@ -704,6 +755,11 @@ registerBlock('Literal/Number', NumberLiteralBlock);
 registerBlock('Literal/String', StringLiteralBlock);
 registerBlock('Literal/Boolean', BooleanLiteralBlock);
 registerBlock('Literal/Null', NullLiteralBlock);
+registerBlock('Operator/Add', AddBlock);
+registerBlock('Operator/Subtract', SubtractBlock);
+registerBlock('Operator/Multiply', MultiplyBlock);
+registerBlock('Operator/Divide', DivideBlock);
+registerBlock('Operator/Modulo', ModuloBlock);
 registerBlock('Function', FunctionBlock);
 registerBlock('Function/Define', FunctionDefineBlock);
 registerBlock('Function/Call', FunctionCallBlock);

--- a/frontend/src/visual/blocks.test.js
+++ b/frontend/src/visual/blocks.test.js
@@ -27,7 +27,12 @@ import {
   WhileLoopBlock,
   ForEachLoopBlock,
   BreakBlock,
-  ContinueBlock
+  ContinueBlock,
+  AddBlock,
+  SubtractBlock,
+  MultiplyBlock,
+  DivideBlock,
+  ModuloBlock
 } from './blocks.js';
 import { getTheme } from './theme.ts';
 
@@ -102,6 +107,24 @@ describe('block utilities', () => {
       expect(b).toBeInstanceOf(Ctor);
       expect(b.ports).toEqual(ports);
       expect(b.color).toBe(theme.blockKinds.Map);
+    }
+  });
+
+  it('provides operator blocks', () => {
+    const theme = getTheme();
+    const cases = [
+      ['Operator/Add', AddBlock, '+'],
+      ['Operator/Subtract', SubtractBlock, '-'],
+      ['Operator/Multiply', MultiplyBlock, '*'],
+      ['Operator/Divide', DivideBlock, '/'],
+      ['Operator/Modulo', ModuloBlock, '%']
+    ];
+    for (const [kind, Ctor, label] of cases) {
+      const b = createBlock(kind, 'op', 0, 0, '');
+      expect(b).toBeInstanceOf(Ctor);
+      expect(b.ports).toEqual(Ctor.ports);
+      expect(b.label).toBe(label);
+      expect(b.color).toBe(theme.blockKinds.Operator || theme.blockFill);
     }
   });
 

--- a/frontend/src/visual/hotkeys.ts
+++ b/frontend/src/visual/hotkeys.ts
@@ -164,37 +164,43 @@ function handleKey(e: KeyboardEvent) {
   }
 
   if (!e.ctrlKey && !e.altKey && !e.metaKey && e.key.length === 1) {
-    keywordBuffer += e.key.toLowerCase();
-    if (keywordBuffer.endsWith('var')) {
+    if ('+-*/%'.includes(e.key)) {
       e.preventDefault();
-      insertKeywordBlock('var');
+      insertOperatorBlock(e.key as OperatorSymbol);
       keywordBuffer = '';
-    } else if (keywordBuffer.endsWith('let')) {
-      e.preventDefault();
-      insertKeywordBlock('let');
-      keywordBuffer = '';
-    } else if (keywordBuffer.endsWith('for')) {
-      e.preventDefault();
-      insertKeywordBlock('for');
-      keywordBuffer = '';
-    } else if (keywordBuffer.endsWith('while')) {
-      e.preventDefault();
-      insertKeywordBlock('while');
-      keywordBuffer = '';
-    } else if (keywordBuffer.endsWith('await')) {
-      e.preventDefault();
-      insertKeywordBlock('await');
-      keywordBuffer = '';
-    } else if (keywordBuffer.endsWith('delay')) {
-      e.preventDefault();
-      insertKeywordBlock('delay');
-      keywordBuffer = '';
-    } else if (keywordBuffer === 'on') {
-      e.preventDefault();
-      insertKeywordBlock('on');
-      keywordBuffer = '';
-    } else if (keywordBuffer.length > 5) {
-      keywordBuffer = keywordBuffer.slice(-5);
+    } else {
+      keywordBuffer += e.key.toLowerCase();
+      if (keywordBuffer.endsWith('var')) {
+        e.preventDefault();
+        insertKeywordBlock('var');
+        keywordBuffer = '';
+      } else if (keywordBuffer.endsWith('let')) {
+        e.preventDefault();
+        insertKeywordBlock('let');
+        keywordBuffer = '';
+      } else if (keywordBuffer.endsWith('for')) {
+        e.preventDefault();
+        insertKeywordBlock('for');
+        keywordBuffer = '';
+      } else if (keywordBuffer.endsWith('while')) {
+        e.preventDefault();
+        insertKeywordBlock('while');
+        keywordBuffer = '';
+      } else if (keywordBuffer.endsWith('await')) {
+        e.preventDefault();
+        insertKeywordBlock('await');
+        keywordBuffer = '';
+      } else if (keywordBuffer.endsWith('delay')) {
+        e.preventDefault();
+        insertKeywordBlock('delay');
+        keywordBuffer = '';
+      } else if (keywordBuffer === 'on') {
+        e.preventDefault();
+        insertKeywordBlock('on');
+        keywordBuffer = '';
+      } else if (keywordBuffer.length > 5) {
+        keywordBuffer = keywordBuffer.slice(-5);
+      }
     }
   }
 }
@@ -326,6 +332,40 @@ function insertKeywordBlock(keyword: 'var' | 'let' | 'for' | 'while' | 'foreach'
   const block = createBlock(kind, id, 0, 0, label, color);
   canvasRef.blocks.push(block);
   const data: any = { kind, visual_id: id, x: 0, y: 0, translations: { en: label } };
+  canvasRef.blocksData.push(data);
+  canvasRef.blockDataMap.set(id, data);
+  canvasRef.selected = new Set([block]);
+  canvasRef.moveCallback?.(block);
+  canvasRef.draw?.();
+}
+
+type OperatorSymbol = '+' | '-' | '*' | '/' | '%';
+
+function insertOperatorBlock(op: OperatorSymbol) {
+  if (!canvasRef) return;
+  const theme = getTheme();
+  const mapping: Record<OperatorSymbol, { kind: string; label: string }> = {
+    '+': { kind: 'Operator/Add', label: '+' },
+    '-': { kind: 'Operator/Subtract', label: '-' },
+    '*': { kind: 'Operator/Multiply', label: '*' },
+    '/': { kind: 'Operator/Divide', label: '/' },
+    '%': { kind: 'Operator/Modulo', label: '%' }
+  };
+  const conf = mapping[op];
+  const id =
+    (globalThis.crypto && typeof globalThis.crypto.randomUUID === 'function')
+      ? globalThis.crypto.randomUUID()
+      : Math.random().toString(36).slice(2);
+  const color = theme.blockKinds.Operator || theme.blockFill;
+  const block = createBlock(conf.kind, id, 0, 0, conf.label, color);
+  canvasRef.blocks.push(block);
+  const data: any = {
+    kind: conf.kind,
+    visual_id: id,
+    x: 0,
+    y: 0,
+    translations: { en: conf.label }
+  };
   canvasRef.blocksData.push(data);
   canvasRef.blockDataMap.set(id, data);
   canvasRef.selected = new Set([block]);


### PR DESCRIPTION
## Summary
- support binary operator blocks (+, -, *, /, %) with lhs/rhs inputs and out port
- allow typing +, -, *, / or % to instantly insert the matching operator block
- test coverage for new operator block types

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f41e27bf08323876911c5a086854f