### PR TITLE
feat: add concat operator block

### DIFF
--- a/backend/meta.schema.json
+++ b/backend/meta.schema.json
@@ -161,6 +161,20 @@
       },
       "additionalProperties": false
     },
+    "OperatorConcatNode": {
+      "type": "object",
+      "required": ["kind", "ports"],
+      "properties": {
+        "kind": { "const": "Operator/Concat" },
+        "ports": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/VizPort" },
+          "minItems": 3,
+          "maxItems": 3
+        }
+      },
+      "additionalProperties": false
+    },
     "ArrayNewNode": {
       "type": "object",
       "required": ["kind", "ports"],
@@ -321,6 +335,7 @@
     },
     "VizNode": {
       "oneOf": [
+        { "$ref": "#/definitions/OperatorConcatNode" },
         { "$ref": "#/definitions/ArrayNewNode" },
         { "$ref": "#/definitions/ArrayGetNode" },
         { "$ref": "#/definitions/ArraySetNode" },

--- a/frontend/src/editor/meta.schema.json
+++ b/frontend/src/editor/meta.schema.json
@@ -161,6 +161,20 @@
       },
       "additionalProperties": false
     },
+    "OperatorConcatNode": {
+      "type": "object",
+      "required": ["kind", "ports"],
+      "properties": {
+        "kind": { "const": "Operator/Concat" },
+        "ports": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/VizPort" },
+          "minItems": 3,
+          "maxItems": 3
+        }
+      },
+      "additionalProperties": false
+    },
     "ArrayNewNode": {
       "type": "object",
       "required": ["kind", "ports"],
@@ -297,6 +311,7 @@
     },
     "VizNode": {
       "oneOf": [
+        { "$ref": "#/definitions/OperatorConcatNode" },
         { "$ref": "#/definitions/ArrayNewNode" },
         { "$ref": "#/definitions/ArrayGetNode" },
         { "$ref": "#/definitions/ArraySetNode" },

--- a/frontend/src/visual/blocks.js
+++ b/frontend/src/visual/blocks.js
@@ -217,6 +217,12 @@ export class ModuloBlock extends OperatorBlockBase {
   }
 }
 
+export class OpConcatBlock extends OperatorBlockBase {
+  constructor(id, x, y) {
+    super(id, x, y, '++');
+  }
+}
+
 class LogicOperatorBlockBase extends Block {
   static defaultSize = { width: 120, height: 50 };
   static ports = [
@@ -870,6 +876,7 @@ registerBlock('Operator/Subtract', SubtractBlock);
 registerBlock('Operator/Multiply', MultiplyBlock);
 registerBlock('Operator/Divide', DivideBlock);
 registerBlock('Operator/Modulo', ModuloBlock);
+registerBlock('Operator/Concat', OpConcatBlock);
 registerBlock('OpComparison/Equal', OpEqualBlock);
 registerBlock('OpComparison/NotEqual', OpNotEqualBlock);
 registerBlock('OpComparison/Greater', OpGreaterBlock);

--- a/frontend/src/visual/blocks.test.js
+++ b/frontend/src/visual/blocks.test.js
@@ -33,6 +33,7 @@ import {
   MultiplyBlock,
   DivideBlock,
   ModuloBlock,
+  OpConcatBlock,
   OpAndBlock,
   OpOrBlock,
   OpNotBlock,
@@ -126,7 +127,8 @@ describe('block utilities', () => {
       ['Operator/Subtract', SubtractBlock, '-'],
       ['Operator/Multiply', MultiplyBlock, '*'],
       ['Operator/Divide', DivideBlock, '/'],
-      ['Operator/Modulo', ModuloBlock, '%']
+      ['Operator/Modulo', ModuloBlock, '%'],
+      ['Operator/Concat', OpConcatBlock, '++']
     ];
     for (const [kind, Ctor, label] of cases) {
       const b = createBlock(kind, 'op', 0, 0, '');

--- a/frontend/src/visual/hotkeys.ts
+++ b/frontend/src/visual/hotkeys.ts
@@ -164,7 +164,17 @@ function handleKey(e: KeyboardEvent) {
   }
 
   if (!e.ctrlKey && !e.altKey && !e.metaKey && e.key.length === 1) {
-    if ('+-*/%'.includes(e.key)) {
+    if (e.key === '+') {
+      if (pendingSymbol === '+') {
+        e.preventDefault();
+        insertOperatorBlock('++');
+        pendingSymbol = '';
+      } else {
+        pendingSymbol = '+';
+      }
+      keywordBuffer = '';
+      symbolBuffer = '';
+    } else if ('-*/%'.includes(e.key)) {
       e.preventDefault();
       insertOperatorBlock(e.key as OperatorSymbol);
       keywordBuffer = '';
@@ -233,6 +243,9 @@ function handleKey(e: KeyboardEvent) {
       } else if (pendingSymbol === '<') {
         e.preventDefault();
         insertComparisonOperatorBlock('<');
+      } else if (pendingSymbol === '+') {
+        e.preventDefault();
+        insertOperatorBlock('+');
       }
       pendingSymbol = '';
       symbolBuffer = '';
@@ -265,8 +278,12 @@ function handleKey(e: KeyboardEvent) {
         e.preventDefault();
         insertKeywordBlock('on');
         keywordBuffer = '';
-      } else if (keywordBuffer.length > 5) {
-        keywordBuffer = keywordBuffer.slice(-5);
+      } else if (keywordBuffer.endsWith('concat')) {
+        e.preventDefault();
+        insertOperatorBlock('++');
+        keywordBuffer = '';
+      } else if (keywordBuffer.length > 6) {
+        keywordBuffer = keywordBuffer.slice(-6);
       }
     }
   }
@@ -408,7 +425,7 @@ function insertKeywordBlock(keyword: 'var' | 'let' | 'for' | 'while' | 'foreach'
   canvasRef.draw?.();
 }
 
-type OperatorSymbol = '+' | '-' | '*' | '/' | '%';
+type OperatorSymbol = '+' | '-' | '*' | '/' | '%' | '++';
 
 function insertOperatorBlock(op: OperatorSymbol) {
   if (!canvasRef) return;
@@ -418,7 +435,8 @@ function insertOperatorBlock(op: OperatorSymbol) {
     '-': { kind: 'Operator/Subtract', label: '-' },
     '*': { kind: 'Operator/Multiply', label: '*' },
     '/': { kind: 'Operator/Divide', label: '/' },
-    '%': { kind: 'Operator/Modulo', label: '%' }
+    '%': { kind: 'Operator/Modulo', label: '%' },
+    '++': { kind: 'Operator/Concat', label: '++' }
   };
   const conf = mapping[op];
   const id =


### PR DESCRIPTION
## Summary
- add `OpConcatBlock` for string concatenation with lhs/rhs inputs
- register hotkey aliases `concat` and `++`
- extend serialization schema and tests for new block

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f517f2c08832392b31e3204bea46f