### PR TITLE
feat: add log block and hotkey

### DIFF
--- a/frontend/src/visual/blocks.js
+++ b/frontend/src/visual/blocks.js
@@ -166,6 +166,35 @@ export class NullLiteralBlock extends Block {
   }
 }
 
+export class LogBlock extends Block {
+  static defaultSize = { width: 120, height: 50 };
+  constructor(id, x, y, _w, _h, label, color, data) {
+    super(
+      id,
+      x,
+      y,
+      LogBlock.defaultSize.width,
+      LogBlock.defaultSize.height,
+      label || 'Log',
+      color ?? getTheme().blockKinds.Log
+    );
+    this.exec = !!data?.exec;
+    this.updatePorts();
+  }
+
+  updatePorts() {
+    this.ports = [
+      { id: 'data', kind: 'data', dir: 'in' },
+      ...(this.exec
+        ? [
+            { id: 'exec', kind: 'exec', dir: 'in' },
+            { id: 'out', kind: 'exec', dir: 'out' }
+          ]
+        : [])
+    ];
+  }
+}
+
 class OperatorBlockBase extends Block {
   static defaultSize = { width: 120, height: 50 };
   static ports = [
@@ -890,6 +919,7 @@ registerBlock('Function', FunctionBlock);
 registerBlock('Function/Define', FunctionDefineBlock);
 registerBlock('Function/Call', FunctionCallBlock);
 registerBlock('Return', ReturnBlock);
+registerBlock('Log', LogBlock);
 registerBlock('Variable', VariableBlock);
 registerBlock('Variable/Get', VariableGetBlock);
 registerBlock('Variable/Set', VariableSetBlock);

--- a/frontend/src/visual/blocks.test.js
+++ b/frontend/src/visual/blocks.test.js
@@ -23,6 +23,7 @@ import {
   FunctionDefineBlock,
   FunctionCallBlock,
   ReturnBlock,
+  LogBlock,
   ForLoopBlock,
   WhileLoopBlock,
   ForEachLoopBlock,
@@ -187,6 +188,20 @@ describe('block utilities', () => {
       expect(b.ports).toEqual(Ctor.ports);
       expect(b.color).toBe(theme.blockKinds.Function);
     }
+  });
+
+  it('provides log block with optional exec', () => {
+    const theme = getTheme();
+    const b = createBlock('Log', 'l1', 0, 0, '');
+    expect(b).toBeInstanceOf(LogBlock);
+    expect(b.ports).toEqual([{ id: 'data', kind: 'data', dir: 'in' }]);
+    expect(b.color).toBe(theme.blockKinds.Log || theme.blockFill);
+    const bExec = createBlock('Log', 'l2', 0, 0, '', undefined, { exec: true });
+    expect(bExec.ports).toEqual([
+      { id: 'data', kind: 'data', dir: 'in' },
+      { id: 'exec', kind: 'exec', dir: 'in' },
+      { id: 'out', kind: 'exec', dir: 'out' }
+    ]);
   });
 
   it('provides variable get/set blocks', () => {

--- a/frontend/src/visual/hotkeys.ts
+++ b/frontend/src/visual/hotkeys.ts
@@ -24,6 +24,7 @@ export interface HotkeyMap {
   insertForLoop: string;
   insertWhileLoop: string;
   insertForEachLoop: string;
+  insertLogBlock: string;
 }
 
 const cfg: { hotkeys?: Partial<HotkeyMap>; visual?: { gridSize?: number } } = settings as any;
@@ -43,12 +44,13 @@ export const hotkeys: HotkeyMap = {
   formatCurrentFile: cfg.hotkeys?.formatCurrentFile || 'Shift+Alt+F',
   insertForLoop: cfg.hotkeys?.insertForLoop || 'Ctrl+Alt+F',
   insertWhileLoop: cfg.hotkeys?.insertWhileLoop || 'Ctrl+Alt+W',
-  insertForEachLoop: cfg.hotkeys?.insertForEachLoop || 'Ctrl+Alt+E'
+  insertForEachLoop: cfg.hotkeys?.insertForEachLoop || 'Ctrl+Alt+E',
+  insertLogBlock: cfg.hotkeys?.insertLogBlock || 'Ctrl+L'
 };
 
 function buildCombo(e: KeyboardEvent) {
   const parts: string[] = [];
-  if (e.ctrlKey) parts.push('Ctrl');
+  if (e.ctrlKey || e.metaKey) parts.push('Ctrl');
   if (e.altKey) parts.push('Alt');
   if (e.shiftKey) parts.push('Shift');
   const key = e.key.length === 1 ? e.key.toUpperCase() : e.key;
@@ -124,6 +126,10 @@ function handleKey(e: KeyboardEvent) {
     case hotkeys.insertForEachLoop:
       e.preventDefault();
       insertKeywordBlock('foreach');
+      break;
+    case hotkeys.insertLogBlock:
+      e.preventDefault();
+      insertLogBlock();
       break;
     case 'F2':
       e.preventDefault();
@@ -519,6 +525,33 @@ function insertComparisonOperatorBlock(op: ComparisonOperatorSymbol) {
     x: 0,
     y: 0,
     translations: { en: conf.label }
+  };
+  canvasRef.blocksData.push(data);
+  canvasRef.blockDataMap.set(id, data);
+  canvasRef.selected = new Set([block]);
+  canvasRef.moveCallback?.(block);
+  canvasRef.draw?.();
+}
+
+function insertLogBlock() {
+  if (!canvasRef) return;
+  const theme = getTheme();
+  const kind = 'Log';
+  const label = 'Log';
+  const id =
+    (globalThis.crypto && typeof globalThis.crypto.randomUUID === 'function')
+      ? globalThis.crypto.randomUUID()
+      : Math.random().toString(36).slice(2);
+  const color = theme.blockKinds.Log || theme.blockFill;
+  const block = createBlock(kind, id, 0, 0, label, color, { exec: true });
+  canvasRef.blocks.push(block);
+  const data: any = {
+    kind,
+    visual_id: id,
+    x: 0,
+    y: 0,
+    translations: { en: label },
+    exec: true
   };
   canvasRef.blocksData.push(data);
   canvasRef.blockDataMap.set(id, data);

--- a/frontend/src/visual/theme.ts
+++ b/frontend/src/visual/theme.ts
@@ -35,6 +35,9 @@ darkTheme.blockKinds.OpLogic = darkTheme.blockKinds.OpLogic || '#7e57c2';
 // ensure color for comparison operator blocks exists
 defaultTheme.blockKinds.OpComparison = defaultTheme.blockKinds.OpComparison || '#cfd8dc';
 darkTheme.blockKinds.OpComparison = darkTheme.blockKinds.OpComparison || '#607d8b';
+// ensure color for log blocks exists
+defaultTheme.blockKinds.Log = defaultTheme.blockKinds.Log || '#ffe082';
+darkTheme.blockKinds.Log = darkTheme.blockKinds.Log || '#ffb300';
 
 const themeMap: Record<string, VisualTheme> = {
   default: defaultTheme,


### PR DESCRIPTION
## Summary
- implement LogBlock with optional exec ports
- add Ctrl/Cmd+L hotkey to insert Log block and support meta key detection
- theme support for Log block color and tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f5704dc088323a585319fd8567c5c