### PR TITLE
Add reroute block and auto reroute insertion

### DIFF
--- a/frontend/src/visual/blocks.js
+++ b/frontend/src/visual/blocks.js
@@ -117,6 +117,28 @@ export class GroupBlock extends Block {
   }
 }
 
+export class RerouteBlock extends Block {
+  static defaultSize = { width: 20, height: 20 };
+  static ports = [
+    { id: 'in', kind: 'data', dir: 'in' },
+    { id: 'out', kind: 'data', dir: 'out' }
+  ];
+  constructor(id, x, y) {
+    super(id, x, y, RerouteBlock.defaultSize.width, RerouteBlock.defaultSize.height, '', getTheme().blockFill);
+    this.ports = RerouteBlock.ports;
+  }
+  draw(ctx) {
+    const theme = getTheme();
+    ctx.fillStyle = this.color;
+    ctx.strokeStyle = theme.blockStroke;
+    ctx.lineWidth = 2;
+    ctx.beginPath();
+    ctx.arc(this.x + this.w / 2, this.y + this.h / 2, this.w / 2, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.stroke();
+  }
+}
+
 export class NumberLiteralBlock extends Block {
   static defaultSize = { width: 120, height: 50 };
   static ports = [{ id: 'out', kind: 'data', dir: 'out' }];
@@ -963,4 +985,5 @@ registerBlock('Map/New', MapNewBlock);
 registerBlock('Map/Get', MapGetBlock);
 registerBlock('Map/Set', MapSetBlock);
 registerBlock('Struct', StructBlock);
+registerBlock('Reroute', RerouteBlock);
 registerBlock('Group', GroupBlock);

--- a/frontend/tests/reroute.test.ts
+++ b/frontend/tests/reroute.test.ts
@@ -1,0 +1,72 @@
+/** @vitest-environment jsdom */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('@codemirror/state', () => ({
+  StateField: { define: vi.fn() },
+  RangeSetBuilder: class {}
+}));
+
+vi.mock('@codemirror/view', () => ({
+  Decoration: { mark: () => ({}) },
+  EditorView: { decorations: { from: vi.fn() }, updateListener: { of: vi.fn() } }
+}));
+
+vi.mock('@codemirror/language', () => ({
+  hoverTooltip: () => ({})
+}));
+
+import { VisualCanvas } from '../src/visual/canvas.js';
+import { Block } from '../src/visual/blocks.js';
+
+function createCanvas() {
+  const canvas = document.createElement('canvas');
+  const ctx = {
+    canvas,
+    save() {},
+    restore() {},
+    setTransform() {},
+    clearRect() {},
+    beginPath() {},
+    moveTo() {},
+    lineTo() {},
+    stroke() {},
+    fillRect() {},
+    strokeRect() {},
+    fillText() {},
+    arc() {},
+    fill() {},
+    setLineDash() {},
+    translate() {},
+    scale() {},
+  } as any;
+  canvas.getContext = () => ctx;
+  return canvas;
+}
+
+describe('reroute insertion', () => {
+  beforeEach(() => {
+    (global as any).requestAnimationFrame = () => 0;
+  });
+
+  it('inserts reroute block on double click', () => {
+    const canvasEl = createCanvas();
+    const vc = new VisualCanvas(canvasEl);
+    const a = new Block('a', 0, 0, 120, 50, 'A');
+    const b = new Block('b', 200, 0, 120, 50, 'B');
+    vc.addBlock(a);
+    vc.addBlock(b);
+    vc.connections.push([a, b]);
+
+    const evt = new MouseEvent('dblclick', { bubbles: true });
+    Object.defineProperty(evt, 'offsetX', { value: 160 });
+    Object.defineProperty(evt, 'offsetY', { value: 25 });
+    canvasEl.dispatchEvent(evt);
+
+    expect(vc.blocks.length).toBe(3);
+    const reroute = vc.blocks.find(bl => bl.id !== 'a' && bl.id !== 'b');
+    expect(reroute).toBeTruthy();
+    expect(vc.connections).toHaveLength(2);
+    expect(vc.connections[0][0]).toBe(a);
+    expect(vc.connections[1][1]).toBe(b);
+  });
+});


### PR DESCRIPTION
## Summary
- define `RerouteBlock` with data in/out ports
- insert reroute blocks when double-clicking a connection line
- test reroute insertion logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f6085015883238cbcc2daf088d9b5