### PR TITLE
feat: add block palette with search

### DIFF
--- a/frontend/src/visual/palette.test.ts
+++ b/frontend/src/visual/palette.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { setRegistry, filterBlocks, PaletteBlock } from './palette.ts';
+
+const blocks: PaletteBlock[] = [
+  { kind: 'Operator/Add', name: 'Add', synonyms: ['plus'], tags: ['math'] },
+  { kind: 'Log', name: 'Log', synonyms: ['print', 'debug'], tags: ['debug', 'console'] },
+  { kind: 'Variable/Get', name: 'Variable Get', tags: ['variable'] }
+];
+
+describe('palette search', () => {
+  beforeEach(() => setRegistry(blocks));
+
+  it('finds by name', () => {
+    const res = filterBlocks('add');
+    expect(res).toHaveLength(1);
+    expect(res[0].kind).toBe('Operator/Add');
+  });
+
+  it('finds by synonym', () => {
+    const res = filterBlocks('print');
+    expect(res).toHaveLength(1);
+    expect(res[0].kind).toBe('Log');
+  });
+
+  it('finds by tag', () => {
+    const res = filterBlocks('variable');
+    expect(res).toHaveLength(1);
+    expect(res[0].kind).toBe('Variable/Get');
+  });
+
+  it('returns all for empty query', () => {
+    const res = filterBlocks('');
+    expect(res).toHaveLength(blocks.length);
+  });
+});

--- a/frontend/src/visual/palette.ts
+++ b/frontend/src/visual/palette.ts
@@ -1,0 +1,70 @@
+export interface PaletteBlock {
+  kind: string;
+  name: string;
+  synonyms?: string[];
+  tags?: string[];
+}
+
+let registry: PaletteBlock[] = [];
+
+/**
+ * Replace current registry with provided blocks. Useful for tests.
+ */
+export function setRegistry(blocks: PaletteBlock[]): void {
+  registry = [...blocks];
+}
+
+/**
+ * Load block list from a backend registry. The registry endpoint must return
+ * an array of {@link PaletteBlock} objects.
+ */
+export async function loadRegistry(fetcher: typeof fetch = fetch): Promise<PaletteBlock[]> {
+  const res = await fetcher('/api/registry/blocks');
+  const blocks: PaletteBlock[] = await res.json();
+  registry = blocks;
+  return blocks;
+}
+
+/**
+ * Filter registered blocks by a free text query. The query is matched against
+ * block name, kind, provided synonyms and tags.
+ */
+export function filterBlocks(query: string): PaletteBlock[] {
+  const q = query.trim().toLowerCase();
+  if (!q) return [...registry];
+  return registry.filter(b => {
+    const haystack = [b.name, b.kind, ...(b.synonyms ?? []), ...(b.tags ?? [])]
+      .join(' ')
+      .toLowerCase();
+    return haystack.includes(q);
+  });
+}
+
+/**
+ * Create simple palette component inside given container element. It consists
+ * of a search input and a list of blocks filtered according to the input
+ * value. The list is populated from the loaded registry.
+ */
+export function createPalette(container: HTMLElement): void {
+  const search = document.createElement('input');
+  search.type = 'search';
+  const list = document.createElement('ul');
+
+  const render = () => {
+    list.innerHTML = '';
+    for (const block of filterBlocks(search.value)) {
+      const li = document.createElement('li');
+      li.textContent = block.name;
+      list.appendChild(li);
+    }
+  };
+
+  search.addEventListener('input', render);
+  container.appendChild(search);
+  container.appendChild(list);
+  render();
+}
+
+export function getRegistry(): PaletteBlock[] {
+  return [...registry];
+}


### PR DESCRIPTION
## Summary
- add palette component that loads blocks from registry and filters by name, synonym or tag
- test palette search across names, synonyms and tags

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f652fd1e883239ab448cdcde837cd