### PR TITLE
Handle new hotkeys and improve zoom to fit

### DIFF
--- a/frontend/src/visual/canvas.js
+++ b/frontend/src/visual/canvas.js
@@ -1041,9 +1041,10 @@ export class VisualCanvas {
   }
 
   zoomToFit() {
-    if (this.blocks.length === 0) return;
+    const blocks = this.selected && this.selected.size ? Array.from(this.selected) : this.blocks;
+    if (blocks.length === 0) return;
     let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
-    for (const b of this.blocks) {
+    for (const b of blocks) {
       minX = Math.min(minX, b.x);
       minY = Math.min(minY, b.y);
       maxX = Math.max(maxX, b.x + b.w);

--- a/frontend/src/visual/canvas.test.js
+++ b/frontend/src/visual/canvas.test.js
@@ -72,6 +72,33 @@ describe('zoomToFit', () => {
     expect(bottomRight.x).toBeLessThanOrEqual(canvasEl.width);
     expect(bottomRight.y).toBeLessThanOrEqual(canvasEl.height);
   });
+
+  it('handles large graphs', () => {
+    const canvasEl = document.createElement('canvas');
+    Object.defineProperty(canvasEl, 'clientWidth', { value: 500 });
+    Object.defineProperty(canvasEl, 'clientHeight', { value: 500 });
+    canvasEl.getContext = () => ({ save(){}, setTransform(){}, clearRect(){}, beginPath(){}, stroke(){}, moveTo(){}, lineTo(){}, fillRect(){}, strokeRect(){}, fillText(){}, restore(){} });
+    globalThis.requestAnimationFrame = () => 0;
+    const vc = new VisualCanvas(canvasEl);
+    vc.blocks = [
+      { x: -5000, y: 0, w: 100, h: 100 },
+      { x: 10000, y: 5000, w: 100, h: 100 },
+      { x: 0, y: 10000, w: 100, h: 100 }
+    ];
+    vc.zoomToFit();
+    expect(vc.scale).toBeGreaterThan(0);
+    expect(vc.scale).toBeLessThanOrEqual(1);
+    const xs = vc.blocks.flatMap(b => [b.x, b.x + b.w]);
+    const ys = vc.blocks.flatMap(b => [b.y, b.y + b.h]);
+    const minX = Math.min(...xs); const minY = Math.min(...ys);
+    const maxX = Math.max(...xs); const maxY = Math.max(...ys);
+    const topLeft = { x: minX * vc.scale + vc.offset.x, y: minY * vc.scale + vc.offset.y };
+    const bottomRight = { x: maxX * vc.scale + vc.offset.x, y: maxY * vc.scale + vc.offset.y };
+    expect(topLeft.x).toBeLessThanOrEqual(canvasEl.width);
+    expect(bottomRight.x).toBeGreaterThanOrEqual(0);
+    expect(topLeft.y).toBeLessThanOrEqual(canvasEl.height);
+    expect(bottomRight.y).toBeGreaterThanOrEqual(0);
+  });
 });
 
 describe('selection box', () => {

--- a/frontend/src/visual/hotkeys.ts
+++ b/frontend/src/visual/hotkeys.ts
@@ -92,6 +92,7 @@ function handleKey(e: KeyboardEvent) {
       selectConnections();
       break;
     case hotkeys.focusSearch:
+    case 'F':
       e.preventDefault();
       focusSearch();
       break;
@@ -104,6 +105,7 @@ function handleKey(e: KeyboardEvent) {
       openCommandPalette();
       break;
     case hotkeys.zoomToFit:
+    case '0':
       e.preventDefault();
       zoomToFit();
       break;


### PR DESCRIPTION
## Summary
- Add plain `F` and `0` key handling for search and zoom
- Compute selection bounds for zoom-to-fit and test large graphs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f9faf693c8323b08666ea9f24f5f6