### PR TITLE
feat: export canvas to PNG

### DIFF
--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -42,6 +42,7 @@
     import { loadBlockPlugins } from "./visual/blocks.js";
     import { insertVisualMeta, visualMetaHighlighter, visualMetaTooltip, foldMetaBlock, visualMetaMessenger, scrollToMeta, addBlockToolbar, refreshBlockCount, listMetaIds } from "./editor/visual-meta.js";
     import { registerHotkeys, setCanvas } from "./visual/hotkeys.ts";
+    import { setCanvas as setExportCanvas } from "./visual/export.ts";
     import { registerCommandPalette } from "./editor/command-palette.ts";
     import { gotoLine } from "./editor/goto-line.js";
     import { gotoRelated } from "./editor/navigation.js";
@@ -102,6 +103,7 @@
     }
 
     setCanvas(vc);
+    setExportCanvas(vc);
     registerHotkeys();
     registerCommandPalette([
       { id: 'gotoLine', title: 'Go to Line', run: () => gotoLine(view) },

--- a/frontend/src/visual/export.test.ts
+++ b/frontend/src/visual/export.test.ts
@@ -1,0 +1,47 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import { renderToCanvas, EXPORT_PADDING } from './export.ts';
+
+describe('export', () => {
+  it('calculates canvas size to include edge blocks', () => {
+    class StubOffscreen {
+      width: number;
+      height: number;
+      constructor(w: number, h: number) { this.width = w; this.height = h; }
+      getContext() { return {}; }
+    }
+    const old = (globalThis as any).OffscreenCanvas;
+    (globalThis as any).OffscreenCanvas = StubOffscreen as any;
+    let seenOffset: any;
+    const vc: any = {
+      blocks: [
+        { x: 0, y: 0, w: 10, h: 10 },
+        { x: 100, y: 100, w: 10, h: 10 }
+      ],
+      canvas: { width: 0, height: 0 },
+      ctx: {},
+      scale: 1,
+      offset: { x: 0, y: 0 },
+      draw() { seenOffset = { ...this.offset }; }
+    };
+    const off = renderToCanvas(vc) as any;
+    (globalThis as any).OffscreenCanvas = old;
+    expect(off.width).toBe(150);
+    expect(off.height).toBe(150);
+    const dx = seenOffset.x;
+    const dy = seenOffset.y;
+    for (const b of vc.blocks) {
+      const left = b.x + dx;
+      const right = left + b.w;
+      const top = b.y + dy;
+      const bottom = top + b.h;
+      expect(left).toBeGreaterThanOrEqual(0);
+      expect(top).toBeGreaterThanOrEqual(0);
+      expect(right).toBeLessThanOrEqual(off.width);
+      expect(bottom).toBeLessThanOrEqual(off.height);
+    }
+    expect(dx).toBe(EXPORT_PADDING);
+    expect(dy).toBe(EXPORT_PADDING);
+  });
+});
+

--- a/frontend/src/visual/export.ts
+++ b/frontend/src/visual/export.ts
@@ -1,0 +1,64 @@
+import type { VisualCanvas } from './canvas.js';
+
+export const EXPORT_PADDING = 20;
+
+let canvasRef: VisualCanvas | null = null;
+
+export function setCanvas(vc: VisualCanvas) {
+  canvasRef = vc;
+}
+
+export function renderToCanvas(vc: VisualCanvas): HTMLCanvasElement | OffscreenCanvas {
+  if (!vc.blocks.length) {
+    const empty = typeof OffscreenCanvas === 'function'
+      ? new OffscreenCanvas(1, 1)
+      : document.createElement('canvas');
+    empty.width = 1;
+    empty.height = 1;
+    return empty as any;
+  }
+  const minX = Math.min(...vc.blocks.map(b => b.x));
+  const minY = Math.min(...vc.blocks.map(b => b.y));
+  const maxX = Math.max(...vc.blocks.map(b => b.x + b.w));
+  const maxY = Math.max(...vc.blocks.map(b => b.y + b.h));
+  const width = maxX - minX + EXPORT_PADDING * 2;
+  const height = maxY - minY + EXPORT_PADDING * 2;
+  const off: any = typeof OffscreenCanvas === 'function'
+    ? new OffscreenCanvas(width, height)
+    : document.createElement('canvas');
+  off.width = width;
+  off.height = height;
+  const ctx = off.getContext('2d');
+  const prevCanvas = vc.canvas;
+  const prevCtx = vc.ctx;
+  const prevScale = vc.scale;
+  const prevOffset = { ...vc.offset };
+  vc.canvas = off as any;
+  vc.ctx = ctx as any;
+  vc.scale = 1;
+  vc.offset = { x: -minX + EXPORT_PADDING, y: -minY + EXPORT_PADDING };
+  vc.draw();
+  vc.canvas = prevCanvas;
+  vc.ctx = prevCtx;
+  vc.scale = prevScale;
+  vc.offset = prevOffset;
+  return off;
+}
+
+export async function exportPNG() {
+  if (!canvasRef) return;
+  const off = renderToCanvas(canvasRef);
+  let blob: Blob;
+  if (off instanceof OffscreenCanvas) {
+    blob = await off.convertToBlob({ type: 'image/png' });
+  } else {
+    blob = await new Promise<Blob>(resolve => (off as HTMLCanvasElement).toBlob(b => resolve(b!), 'image/png'));
+  }
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = 'canvas.png';
+  link.click();
+  setTimeout(() => URL.revokeObjectURL(url), 1000);
+}
+

--- a/frontend/src/visual/hotkeys.ts
+++ b/frontend/src/visual/hotkeys.ts
@@ -10,6 +10,7 @@ import { formatCurrentFile } from '../../scripts/format.js';
 import { EditorSelection } from '@codemirror/state';
 import * as commands from '@codemirror/commands';
 import { openCommandPalette } from '../editor/command-palette.ts';
+import { exportPNG } from './export.ts';
 
 export interface HotkeyMap {
   copyBlock: string;
@@ -30,6 +31,7 @@ export interface HotkeyMap {
   insertWhileLoop: string;
   insertForEachLoop: string;
   insertLogBlock: string;
+  exportPNG: string;
 }
 
 const cfg: { hotkeys?: Partial<HotkeyMap> } = settings as any;
@@ -53,7 +55,8 @@ export const hotkeys: HotkeyMap = {
   insertForLoop: cfg.hotkeys?.insertForLoop || 'Ctrl+Alt+F',
   insertWhileLoop: cfg.hotkeys?.insertWhileLoop || 'Ctrl+Alt+W',
   insertForEachLoop: cfg.hotkeys?.insertForEachLoop || 'Ctrl+Alt+E',
-  insertLogBlock: cfg.hotkeys?.insertLogBlock || 'Ctrl+L'
+  insertLogBlock: cfg.hotkeys?.insertLogBlock || 'Ctrl+L',
+  exportPNG: cfg.hotkeys?.exportPNG || 'Ctrl+Shift+E'
 };
 
 function buildCombo(e: KeyboardEvent) {
@@ -138,6 +141,10 @@ function handleKey(e: KeyboardEvent) {
     case hotkeys.formatCurrentFile:
       e.preventDefault();
       formatCurrentFile();
+      break;
+    case hotkeys.exportPNG:
+      e.preventDefault();
+      exportPNG();
       break;
     case hotkeys.insertForLoop:
       e.preventDefault();

--- a/frontend/src/visual/menu.ts
+++ b/frontend/src/visual/menu.ts
@@ -1,5 +1,5 @@
 import { hotkeys, showHotkeyHelp, zoomToFit, focusSearch } from './hotkeys';
-import { exportPNG } from './canvas.js';
+import { exportPNG } from './export.ts';
 import { emit } from '../shared/event-bus.js';
 
 export function createSearchInput(canvas: any) {
@@ -46,7 +46,7 @@ export const mainMenu: MenuItem[] = [
     submenu: [
       { label: 'New', action: () => console.log('new file') },
       { label: 'Open', action: () => console.log('open file') },
-      { label: 'Экспорт в PNG', action: exportPNG }
+      { label: 'Export PNG', action: exportPNG, shortcut: hotkeys.exportPNG }
     ]
   },
   {


### PR DESCRIPTION
## Summary
- export visual canvas to PNG via offscreen canvas
- add Export PNG menu item and Ctrl+Shift+E hotkey
- test that extreme blocks stay in frame when exporting

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a003778aec832396882d9fce45d0f9