### PR TITLE
Add micro op nodes with anchored parsing

### DIFF
--- a/backend/src/blocks/enrich.rs
+++ b/backend/src/blocks/enrich.rs
@@ -31,6 +31,7 @@ pub fn enrich_blocks(blocks: Vec<Block>, content: &str) -> Vec<BlockInfo> {
                 kind: label,
                 translations,
                 range: (b.range.start, b.range.end),
+                anchors: b.anchors.clone(),
                 x: pos.map(|m| m.x).unwrap_or(0.0),
                 y: pos.map(|m| m.y).unwrap_or(0.0),
                 ai: pos.and_then(|m| m.ai.clone()),
@@ -75,6 +76,7 @@ mod tests {
             node_id: 1,
             kind: "function".into(),
             range: 0..5,
+            anchors: vec![],
         };
         let res = enrich_blocks(vec![block], "");
         assert_eq!(res.len(), 1);
@@ -91,6 +93,7 @@ mod tests {
             node_id: 1,
             kind: "function".into(),
             range: 0..5,
+            anchors: vec![],
         };
         let content = "<!-- @VISUAL_META {\"id\":\"42\",\"x\":1.0,\"y\":2.0,\"translations\":{\"en\":\"Test\"}} -->";
         let res = enrich_blocks(vec![block], content);

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -38,6 +38,8 @@ pub struct BlockInfo {
     pub kind: String,
     pub translations: HashMap<String, String>,
     pub range: (usize, usize),
+    #[serde(default)]
+    pub anchors: Vec<(usize, usize)>,
     pub x: f64,
     pub y: f64,
     pub ai: Option<AiNote>,

--- a/frontend/src/visual/blocks.js
+++ b/frontend/src/visual/blocks.js
@@ -293,6 +293,39 @@ export class OpConcatBlock extends OperatorBlockBase {
   }
 }
 
+class MicroOpBlock extends Block {
+  static defaultSize = { width: 56, height: 28 };
+  static ports = [
+    { id: 'lhs', kind: 'data', dir: 'in' },
+    { id: 'rhs', kind: 'data', dir: 'in' },
+    { id: 'out', kind: 'data', dir: 'out' }
+  ];
+  constructor(id, x, y, label) {
+    super(
+      id,
+      x,
+      y,
+      MicroOpBlock.defaultSize.width,
+      MicroOpBlock.defaultSize.height,
+      label,
+      getTheme().blockKinds.Operator || getTheme().blockFill
+    );
+    this.ports = MicroOpBlock.ports;
+  }
+}
+
+export class OpPlusMicroBlock extends MicroOpBlock {
+  constructor(id, x, y) {
+    super(id, x, y, '+');
+  }
+}
+
+export class OpMultiplyMicroBlock extends MicroOpBlock {
+  constructor(id, x, y) {
+    super(id, x, y, '*');
+  }
+}
+
 class LogicOperatorBlockBase extends Block {
   static defaultSize = { width: 120, height: 50 };
   static ports = [
@@ -479,7 +512,7 @@ export class VariableBlock extends Block {
 }
 
 export class VariableGetBlock extends Block {
-  static defaultSize = { width: 120, height: 50 };
+  static defaultSize = { width: 56, height: 28 };
   static ports = [{ id: 'data', kind: 'data', dir: 'out' }];
   constructor(id, x, y) {
     super(
@@ -947,6 +980,8 @@ registerBlock('Operator/Multiply', MultiplyBlock);
 registerBlock('Operator/Divide', DivideBlock);
 registerBlock('Operator/Modulo', ModuloBlock);
 registerBlock('Operator/Concat', OpConcatBlock);
+registerBlock('Op/+', OpPlusMicroBlock);
+registerBlock('Op/*', OpMultiplyMicroBlock);
 registerBlock('OpComparison/Equal', OpEqualBlock);
 registerBlock('OpComparison/NotEqual', OpNotEqualBlock);
 registerBlock('OpComparison/Greater', OpGreaterBlock);

--- a/frontend/src/visual/blocks.test.js
+++ b/frontend/src/visual/blocks.test.js
@@ -35,6 +35,8 @@ import {
   DivideBlock,
   ModuloBlock,
   OpConcatBlock,
+  OpPlusMicroBlock,
+  OpMultiplyMicroBlock,
   OpAndBlock,
   OpOrBlock,
   OpNotBlock,
@@ -140,6 +142,23 @@ describe('block utilities', () => {
     }
   });
 
+  it('provides micro operator blocks', () => {
+    const theme = getTheme();
+    const cases = [
+      ['Op/+', OpPlusMicroBlock, '+'],
+      ['Op/*', OpMultiplyMicroBlock, '*']
+    ];
+    for (const [kind, Ctor, label] of cases) {
+      const b = createBlock(kind, 'mop', 0, 0, '');
+      expect(b).toBeInstanceOf(Ctor);
+      expect(b.w).toBe(56);
+      expect(b.h).toBe(28);
+      expect(b.ports).toEqual(Ctor.ports);
+      expect(b.label).toBe(label);
+      expect(b.color).toBe(theme.blockKinds.Operator || theme.blockFill);
+    }
+  });
+
   it('provides logic operator blocks', () => {
     const theme = getTheme();
     const cases = [
@@ -215,6 +234,10 @@ describe('block utilities', () => {
       expect(b).toBeInstanceOf(Ctor);
       expect(b.ports).toEqual(ports);
       expect(b.color).toBe(theme.blockKinds.Variable);
+      if (kind === 'Variable/Get') {
+        expect(b.w).toBe(56);
+        expect(b.h).toBe(28);
+      }
     }
   });
 


### PR DESCRIPTION
## Summary
- generate `Op/*` and `Variable/Get` blocks with source anchors during parsing
- add 56×28 micro node style and operator rendering on frontend
- cover expression DAG parsing and micro blocks with tests

## Testing
- `cargo test`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a00e29486c8323abfa3d53ad5ed158