### PR TITLE
feat: stable block ids and theme extensions

### DIFF
--- a/backend/src/blocks/cache.rs
+++ b/backend/src/blocks/cache.rs
@@ -1,7 +1,7 @@
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 
-use crate::{get_cached_blocks, update_block_cache, BlockInfo};
+use crate::{get_cached_blocks, parser::Block, update_block_cache, BlockInfo};
 
 /// Generate a stable cache key based on the file `content`.
 pub fn key(content: &str) -> String {
@@ -18,4 +18,26 @@ pub fn get(key: &str, content: &str) -> Option<Vec<BlockInfo>> {
 /// Store parsed block information in the cache under `key`.
 pub fn store(key: String, content: String, blocks: Vec<BlockInfo>) {
     update_block_cache(key, content, blocks);
+}
+
+/// Generate a stable identifier for a block based on its `range` and `content`.
+///
+/// The produced id is deterministic for the same snippet occupying the same
+/// position which allows us to preserve UI state (anchors, coordinates) between
+/// parse runs.
+pub fn stable_id(content: &str, range: (usize, usize)) -> String {
+    let mut hasher = DefaultHasher::new();
+    let start = range.0.min(content.len());
+    let end = range.1.min(content.len());
+    let snippet = content[start..end].trim();
+    snippet.hash(&mut hasher);
+    start.hash(&mut hasher);
+    hasher.finish().to_string()
+}
+
+/// Assign stable identifiers to all parsed `blocks` using the current `content`.
+pub fn assign_ids(content: &str, blocks: &mut [Block]) {
+    for b in blocks.iter_mut() {
+        b.visual_id = stable_id(content, (b.range.start, b.range.end));
+    }
 }

--- a/backend/src/blocks/mod.rs
+++ b/backend/src/blocks/mod.rs
@@ -29,7 +29,8 @@ pub fn parse_blocks(content: String, lang: String) -> Option<Vec<BlockInfo>> {
         return Some(blocks);
     }
 
-    let blocks = parsing::parse(&content, lang)?;
+    let mut blocks = parsing::parse(&content, lang)?;
+    cache::assign_ids(&content, &mut blocks);
     let result = enrich::enrich_blocks(blocks, &content);
     cache::store(key, content, result.clone());
     Some(result)

--- a/backend/tests/merge.rs
+++ b/backend/tests/merge.rs
@@ -1,0 +1,23 @@
+use backend::blocks::parse_blocks;
+
+#[test]
+fn stable_ids_preserved_when_appending() {
+    let src1 = "fn a() {}\nfn b() {}\n".to_string();
+    let blocks1 = parse_blocks(src1.clone(), "rust".into()).expect("first parse");
+    let fns1: Vec<_> = blocks1
+        .iter()
+        .filter(|b| b.kind == "Function/Define")
+        .collect();
+    assert!(fns1.len() >= 2);
+
+    let src2 = format!("{}fn c() {{}}\n", src1);
+    let blocks2 = parse_blocks(src2, "rust".into()).expect("second parse");
+    let fns2: Vec<_> = blocks2
+        .iter()
+        .filter(|b| b.kind == "Function/Define")
+        .collect();
+    assert!(fns2.len() >= 3);
+
+    assert_eq!(fns1[0].visual_id, fns2[0].visual_id);
+    assert_eq!(fns1[1].visual_id, fns2[1].visual_id);
+}

--- a/frontend/src/visual/theme.ts
+++ b/frontend/src/visual/theme.ts
@@ -38,6 +38,21 @@ darkTheme.blockKinds.OpComparison = darkTheme.blockKinds.OpComparison || '#607d8
 // ensure color for log blocks exists
 defaultTheme.blockKinds.Log = defaultTheme.blockKinds.Log || '#ffe082';
 darkTheme.blockKinds.Log = darkTheme.blockKinds.Log || '#ffb300';
+// ensure color for arithmetic operator blocks exists
+defaultTheme.blockKinds.Operator = defaultTheme.blockKinds.Operator || '#ffcdd2';
+darkTheme.blockKinds.Operator = darkTheme.blockKinds.Operator || '#e57373';
+// ensure color for sequence blocks exists
+defaultTheme.blockKinds.Sequence = defaultTheme.blockKinds.Sequence || '#e6ee9c';
+darkTheme.blockKinds.Sequence = darkTheme.blockKinds.Sequence || '#9e9d24';
+// ensure color for switch blocks exists
+defaultTheme.blockKinds.Switch = defaultTheme.blockKinds.Switch || '#ffe0b2';
+darkTheme.blockKinds.Switch = darkTheme.blockKinds.Switch || '#ffb74d';
+// ensure color for try blocks exists
+defaultTheme.blockKinds.Try = defaultTheme.blockKinds.Try || '#ffccbc';
+darkTheme.blockKinds.Try = darkTheme.blockKinds.Try || '#ff8a65';
+// ensure color for struct blocks exists
+defaultTheme.blockKinds.Struct = defaultTheme.blockKinds.Struct || '#c5cae9';
+darkTheme.blockKinds.Struct = darkTheme.blockKinds.Struct || '#5c6bc0';
 
 const themeMap: Record<string, VisualTheme> = {
   default: defaultTheme,


### PR DESCRIPTION
## Summary
- generate deterministic block ids from content and start offsets
- assign stable ids during parsing to preserve anchors/UI
- expand theme categories to cover operator, sequence, switch, try and struct nodes
- add merge test ensuring ids survive appends

## Testing
- `cargo test --test merge`
- `npm test --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_68a0471651b0832387f8b311e53ea9f2