### PR TITLE
feat: add type cast block

### DIFF
--- a/backend/meta.schema.json
+++ b/backend/meta.schema.json
@@ -136,7 +136,7 @@
     "BlockKind": {
       "description": "Available built-in block kinds.",
       "type": "string",
-      "enum": ["Op/+", "Op/*", "Op/Inc", "Op/Dec"]
+      "enum": ["Op/+", "Op/*", "Op/Inc", "Op/Dec", "Cast"]
     }
   }
 }

--- a/frontend/src/editor/meta.schema.json
+++ b/frontend/src/editor/meta.schema.json
@@ -136,7 +136,7 @@
     "BlockKind": {
       "description": "Available built-in block kinds.",
       "type": "string",
-      "enum": ["Op/+", "Op/*", "Op/Inc", "Op/Dec"]
+      "enum": ["Op/+", "Op/*", "Op/Inc", "Op/Dec", "Cast"]
     }
   }
 }

--- a/frontend/src/visual/block-editor.ts
+++ b/frontend/src/visual/block-editor.ts
@@ -40,6 +40,7 @@ export function openBlockEditor(vc: VisualCanvasLike, block: { id: string; x: nu
   const fieldInputs: HTMLInputElement[] = [];
   const caseInputs: HTMLInputElement[] = [];
   const exceptionInputs: HTMLInputElement[] = [];
+  let typeSelect: HTMLSelectElement | null = null;
   if (data.kind === 'Struct') {
     let metaObj: any = {};
     try {
@@ -108,6 +109,24 @@ export function openBlockEditor(vc: VisualCanvasLike, block: { id: string; x: nu
     addBtn.addEventListener('click', () => addExc());
     excContainer.appendChild(addBtn);
     overlay.appendChild(excContainer);
+  } else if (data.kind === 'Cast') {
+    let metaObj: any = {};
+    try {
+      metaObj = JSON.parse(textarea.value);
+    } catch (_) {}
+    const current = metaObj?.data?.targetType || 'number';
+    const typeContainer = document.createElement('div');
+    typeContainer.style.marginTop = '4px';
+    typeSelect = document.createElement('select');
+    ['number', 'string', 'boolean'].forEach(t => {
+      const opt = document.createElement('option');
+      opt.value = t;
+      opt.textContent = t;
+      if (t === current) opt.selected = true;
+      typeSelect!.appendChild(opt);
+    });
+    typeContainer.appendChild(typeSelect);
+    overlay.appendChild(typeContainer);
   }
 
   const btnBar = document.createElement('div');
@@ -163,6 +182,17 @@ export function openBlockEditor(vc: VisualCanvasLike, block: { id: string; x: nu
         obj.data.exceptions = exceptions;
         (block as any).exceptions = exceptions;
       }
+      newText = JSON.stringify(obj);
+      data.data = obj.data;
+    }
+    if (typeSelect) {
+      let obj: any = {};
+      try {
+        obj = JSON.parse(newText);
+      } catch (_) {}
+      obj.data = obj.data || {};
+      obj.data.targetType = typeSelect.value;
+      (block as any).targetType = typeSelect.value;
       newText = JSON.stringify(obj);
       data.data = obj.data;
     }

--- a/frontend/src/visual/blocks.js
+++ b/frontend/src/visual/blocks.js
@@ -207,6 +207,27 @@ export class NullLiteralBlock extends Block {
   }
 }
 
+export class TypeCastBlock extends Block {
+  static defaultSize = { width: 120, height: 50 };
+  static ports = [
+    { id: 'value', kind: 'data', dir: 'in' },
+    { id: 'out', kind: 'data', dir: 'out' }
+  ];
+  constructor(id, x, y, _w, _h, label, color, data) {
+    super(
+      id,
+      x,
+      y,
+      TypeCastBlock.defaultSize.width,
+      TypeCastBlock.defaultSize.height,
+      label || 'Cast',
+      color ?? getTheme().blockKinds.Cast
+    );
+    this.targetType = data?.targetType || 'number';
+    this.ports = TypeCastBlock.ports;
+  }
+}
+
 export class LogBlock extends Block {
   static defaultSize = { width: 120, height: 50 };
   constructor(id, x, y, _w, _h, label, color, data) {
@@ -1006,6 +1027,7 @@ registerBlock('Literal/Number', NumberLiteralBlock);
 registerBlock('Literal/String', StringLiteralBlock);
 registerBlock('Literal/Boolean', BooleanLiteralBlock);
 registerBlock('Literal/Null', NullLiteralBlock);
+registerBlock('Cast', TypeCastBlock);
 registerBlock('Operator/Add', AddBlock);
 registerBlock('Operator/Subtract', SubtractBlock);
 registerBlock('Operator/Multiply', MultiplyBlock);

--- a/frontend/src/visual/theme.ts
+++ b/frontend/src/visual/theme.ts
@@ -53,6 +53,9 @@ darkTheme.blockKinds.Try = darkTheme.blockKinds.Try || '#ff8a65';
 // ensure color for struct blocks exists
 defaultTheme.blockKinds.Struct = defaultTheme.blockKinds.Struct || '#c5cae9';
 darkTheme.blockKinds.Struct = darkTheme.blockKinds.Struct || '#5c6bc0';
+// ensure color for cast blocks exists
+defaultTheme.blockKinds.Cast = defaultTheme.blockKinds.Cast || '#f8bbd0';
+darkTheme.blockKinds.Cast = darkTheme.blockKinds.Cast || '#c2185b';
 
 const themeMap: Record<string, VisualTheme> = {
   default: defaultTheme,


### PR DESCRIPTION
## Summary
- add TypeCastBlock with input/output ports and target type parameter
- expose target type dropdown in block editor
- support Cast block color and schema entry

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a059c739108323bcccc6052011794d