### PR TITLE
feat: add ternary operator block

### DIFF
--- a/backend/meta.schema.json
+++ b/backend/meta.schema.json
@@ -136,7 +136,7 @@
     "BlockKind": {
       "description": "Available built-in block kinds.",
       "type": "string",
-      "enum": ["Op/+", "Op/*", "Op/Inc", "Op/Dec", "Cast"]
+      "enum": ["Op/+", "Op/*", "Op/Inc", "Op/Dec", "Op/Ternary", "Cast"]
     }
   }
 }

--- a/backend/src/parser/mod.rs
+++ b/backend/src/parser/mod.rs
@@ -75,6 +75,7 @@ pub fn parse_to_blocks(tree: &Tree) -> Vec<Block> {
             "+" | "-" | "*" | "/" | "%" | "&&" | "||" | "==" | "!=" | ">" | ">=" | "<" | "<=" => {
                 format!("Op/{kind}")
             }
+            "?" => "Op/Ternary".into(),
             "identifier" => "Variable/Get".into(),
             _ => {
                 let k = kind.to_lowercase();
@@ -184,5 +185,13 @@ mod tests {
             }
         }
         assert_eq!(found, 5);
+    }
+
+    #[test]
+    fn parse_ternary_expression_into_op() {
+        let src = "a ? b : c";
+        let tree = parse(src, Lang::JavaScript, None).expect("failed to parse");
+        let blocks = parse_to_blocks(&tree);
+        assert!(blocks.iter().any(|b| b.kind == "Op/Ternary"));
     }
 }

--- a/backend/tests/viz_comments.rs
+++ b/backend/tests/viz_comments.rs
@@ -38,9 +38,10 @@ fn roundtrip_import_export() -> std::io::Result<()> {
 
 #[test]
 fn parse_inc_dec_ops() {
-    let src = "// @viz op=inc node=1 id=i in=a out=b\n// @viz op=dec node=2 id=d in=b out=c";
+    let src = "// @viz op=inc node=1 id=i in=a out=b\n// @viz op=dec node=2 id=d in=b out=c\n// @viz op=ternary node=3 id=t in=a,b,c out=d";
     let doc = parse_viz_comments(src);
-    assert_eq!(doc.nodes.len(), 2);
+    assert_eq!(doc.nodes.len(), 3);
     assert_eq!(doc.nodes[0].op.as_deref(), Some("inc"));
     assert_eq!(doc.nodes[1].op.as_deref(), Some("dec"));
+    assert_eq!(doc.nodes[2].op.as_deref(), Some("ternary"));
 }

--- a/frontend/src/editor/meta.schema.json
+++ b/frontend/src/editor/meta.schema.json
@@ -136,7 +136,7 @@
     "BlockKind": {
       "description": "Available built-in block kinds.",
       "type": "string",
-      "enum": ["Op/+", "Op/*", "Op/Inc", "Op/Dec", "Cast"]
+      "enum": ["Op/+", "Op/*", "Op/Inc", "Op/Dec", "Op/Ternary", "Cast"]
     }
   }
 }

--- a/frontend/src/visual/blocks.js
+++ b/frontend/src/visual/blocks.js
@@ -314,6 +314,28 @@ export class OpConcatBlock extends OperatorBlockBase {
   }
 }
 
+export class TernaryBlock extends Block {
+  static defaultSize = { width: 120, height: 50 };
+  static ports = [
+    { id: 'cond', kind: 'data', dir: 'in' },
+    { id: 'then', kind: 'data', dir: 'in' },
+    { id: 'else', kind: 'data', dir: 'in' },
+    { id: 'out', kind: 'data', dir: 'out' }
+  ];
+  constructor(id, x, y) {
+    super(
+      id,
+      x,
+      y,
+      TernaryBlock.defaultSize.width,
+      TernaryBlock.defaultSize.height,
+      '?:',
+      getTheme().blockKinds.Operator || getTheme().blockFill
+    );
+    this.ports = TernaryBlock.ports;
+  }
+}
+
 class MicroOpBlock extends Block {
   static defaultSize = { width: 56, height: 28 };
   static ports = [
@@ -1034,6 +1056,7 @@ registerBlock('Operator/Multiply', MultiplyBlock);
 registerBlock('Operator/Divide', DivideBlock);
 registerBlock('Operator/Modulo', ModuloBlock);
 registerBlock('Operator/Concat', OpConcatBlock);
+registerBlock('Op/Ternary', TernaryBlock);
 registerBlock('Op/+', OpPlusMicroBlock);
 registerBlock('Op/*', OpMultiplyMicroBlock);
 registerBlock('Op/Inc', OpIncBlock);

--- a/frontend/src/visual/blocks.test.js
+++ b/frontend/src/visual/blocks.test.js
@@ -35,6 +35,7 @@ import {
   DivideBlock,
   ModuloBlock,
   OpConcatBlock,
+  TernaryBlock,
   OpPlusMicroBlock,
   OpMultiplyMicroBlock,
   OpIncBlock,
@@ -161,6 +162,15 @@ describe('block utilities', () => {
       expect(b.label).toBe(label);
       expect(b.color).toBe(theme.blockKinds.Operator || theme.blockFill);
     }
+  });
+
+  it('provides ternary block', () => {
+    const theme = getTheme();
+    const b = createBlock('Op/Ternary', 'tern', 0, 0, '');
+    expect(b).toBeInstanceOf(TernaryBlock);
+    expect(b.ports).toEqual(TernaryBlock.ports);
+    expect(b.label).toBe('?:');
+    expect(b.color).toBe(theme.blockKinds.Operator || theme.blockFill);
   });
 
   it('provides logic operator blocks', () => {

--- a/frontend/src/visual/hotkeys.spec.ts
+++ b/frontend/src/visual/hotkeys.spec.ts
@@ -38,6 +38,7 @@ describe('hotkeys block insertion', () => {
     { keys: ['*'], kind: 'Operator/Multiply' },
     { keys: ['/'], kind: 'Operator/Divide' },
     { keys: ['%'], kind: 'Operator/Modulo' },
+    { keys: ['?', ':'], kind: 'Op/Ternary' },
     { keys: ['=', '='], kind: 'OpComparison/Equal' },
     { keys: ['!', '='], kind: 'OpComparison/NotEqual' },
     { keys: ['>', 'x'], kind: 'OpComparison/Greater' },

--- a/frontend/src/visual/hotkeys.ts
+++ b/frontend/src/visual/hotkeys.ts
@@ -224,7 +224,19 @@ function handleKey(e: KeyboardEvent) {
   }
 
   if (!e.ctrlKey && !e.altKey && !e.metaKey && e.key.length === 1) {
-    if (e.key === '+') {
+    if (e.key === '?') {
+      pendingSymbol = '?';
+      keywordBuffer = '';
+      symbolBuffer = '';
+    } else if (e.key === ':') {
+      if (pendingSymbol === '?') {
+        e.preventDefault();
+        insertTernaryBlock();
+      }
+      pendingSymbol = '';
+      keywordBuffer = '';
+      symbolBuffer = '';
+    } else if (e.key === '+') {
       if (pendingSymbol === '+') {
         e.preventDefault();
         insertOpBlock('++');
@@ -587,6 +599,33 @@ function insertOpBlock(op: OpSymbol) {
     x: pos.x,
     y: pos.y,
     translations: { en: conf.label }
+  };
+  canvasRef.blocksData.push(data);
+  canvasRef.blockDataMap.set(id, data);
+  canvasRef.selected = new Set([block]);
+  canvasRef.moveCallback?.(block);
+  canvasRef.draw?.();
+}
+
+function insertTernaryBlock() {
+  if (!canvasRef) return;
+  const theme = getTheme();
+  const kind = 'Op/Ternary';
+  const label = '?:';
+  const id =
+    (globalThis.crypto && typeof globalThis.crypto.randomUUID === 'function')
+      ? globalThis.crypto.randomUUID()
+      : Math.random().toString(36).slice(2);
+  const pos = canvasRef.getFreePos ? canvasRef.getFreePos() : { x: 0, y: 0 };
+  const color = theme.blockKinds.Operator || theme.blockFill;
+  const block = createBlock(kind, id, pos.x, pos.y, label, color);
+  canvasRef.blocks.push(block);
+  const data: any = {
+    kind,
+    visual_id: id,
+    x: pos.x,
+    y: pos.y,
+    translations: { en: label }
   };
   canvasRef.blocksData.push(data);
   canvasRef.blockDataMap.set(id, data);


### PR DESCRIPTION
## Summary
- implement `TernaryBlock` with cond/then/else ports and register as `Op/Ternary`
- add `?:` hotkey to insert a ternary block
- parse ternary expressions and `@viz op=ternary` into `Op/Ternary`

## Testing
- `npm test`
- `cargo test` *(fails: The system library `glib-2.0` required by crate `glib-sys` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a06109db388323add34f7535a638ff