### PR TITLE
feat: add file read/write blocks

### DIFF
--- a/backend/meta.schema.json
+++ b/backend/meta.schema.json
@@ -136,7 +136,7 @@
     "BlockKind": {
       "description": "Available built-in block kinds.",
       "type": "string",
-      "enum": ["Op/+", "Op/*", "Op/Inc", "Op/Dec", "Op/Ternary", "Cast"]
+      "enum": ["Op/+", "Op/*", "Op/Inc", "Op/Dec", "Op/Ternary", "Cast", "File/Read", "File/Write"]
     }
   }
 }

--- a/frontend/src/editor/meta.schema.json
+++ b/frontend/src/editor/meta.schema.json
@@ -136,7 +136,7 @@
     "BlockKind": {
       "description": "Available built-in block kinds.",
       "type": "string",
-      "enum": ["Op/+", "Op/*", "Op/Inc", "Op/Dec", "Op/Ternary", "Cast"]
+      "enum": ["Op/+", "Op/*", "Op/Inc", "Op/Dec", "Op/Ternary", "Cast", "File/Read", "File/Write"]
     }
   }
 }

--- a/frontend/src/visual/blocks.js
+++ b/frontend/src/visual/blocks.js
@@ -257,6 +257,50 @@ export class LogBlock extends Block {
   }
 }
 
+export class FileReadBlock extends Block {
+  static defaultSize = { width: 120, height: 50 };
+  static ports = [
+    { id: 'path', kind: 'data', dir: 'in' },
+    { id: 'content', kind: 'data', dir: 'out' },
+    { id: 'exec', kind: 'exec', dir: 'in' },
+    { id: 'out', kind: 'exec', dir: 'out' }
+  ];
+  constructor(id, x, y) {
+    super(
+      id,
+      x,
+      y,
+      FileReadBlock.defaultSize.width,
+      FileReadBlock.defaultSize.height,
+      'File Read',
+      getTheme().blockKinds.File
+    );
+    this.ports = FileReadBlock.ports;
+  }
+}
+
+export class FileWriteBlock extends Block {
+  static defaultSize = { width: 120, height: 50 };
+  static ports = [
+    { id: 'path', kind: 'data', dir: 'in' },
+    { id: 'content', kind: 'data', dir: 'in' },
+    { id: 'exec', kind: 'exec', dir: 'in' },
+    { id: 'out', kind: 'exec', dir: 'out' }
+  ];
+  constructor(id, x, y) {
+    super(
+      id,
+      x,
+      y,
+      FileWriteBlock.defaultSize.width,
+      FileWriteBlock.defaultSize.height,
+      'File Write',
+      getTheme().blockKinds.File
+    );
+    this.ports = FileWriteBlock.ports;
+  }
+}
+
 class OperatorBlockBase extends Block {
   static defaultSize = { width: 120, height: 50 };
   static ports = [
@@ -1075,6 +1119,8 @@ registerBlock('Function/Define', FunctionDefineBlock);
 registerBlock('Function/Call', FunctionCallBlock);
 registerBlock('Return', ReturnBlock);
 registerBlock('Log', LogBlock);
+registerBlock('File/Read', FileReadBlock);
+registerBlock('File/Write', FileWriteBlock);
 registerBlock('Variable', VariableBlock);
 registerBlock('Variable/Get', VariableGetBlock);
 registerBlock('Variable/Set', VariableSetBlock);

--- a/frontend/src/visual/blocks.test.js
+++ b/frontend/src/visual/blocks.test.js
@@ -24,6 +24,8 @@ import {
   FunctionCallBlock,
   ReturnBlock,
   LogBlock,
+  FileReadBlock,
+  FileWriteBlock,
   ForLoopBlock,
   WhileLoopBlock,
   ForEachLoopBlock,
@@ -220,6 +222,20 @@ describe('block utilities', () => {
       expect(b).toBeInstanceOf(Ctor);
       expect(b.ports).toEqual(Ctor.ports);
       expect(b.color).toBe(theme.blockKinds.Function);
+    }
+  });
+
+  it('provides file read/write blocks', () => {
+    const theme = getTheme();
+    const cases = [
+      ['File/Read', FileReadBlock, FileReadBlock.ports],
+      ['File/Write', FileWriteBlock, FileWriteBlock.ports]
+    ];
+    for (const [kind, Ctor, ports] of cases) {
+      const b = createBlock(kind, 'file', 0, 0, '');
+      expect(b).toBeInstanceOf(Ctor);
+      expect(b.ports).toEqual(ports);
+      expect(b.color).toBe(theme.blockKinds.File || theme.blockFill);
     }
   });
 

--- a/frontend/src/visual/palette.ts
+++ b/frontend/src/visual/palette.ts
@@ -5,7 +5,10 @@ export interface PaletteBlock {
   tags?: string[];
 }
 
-let registry: PaletteBlock[] = [];
+let registry: PaletteBlock[] = [
+  { kind: 'File/Read', name: 'File Read', tags: ['file', 'read'] },
+  { kind: 'File/Write', name: 'File Write', tags: ['file', 'write'] }
+];
 
 /**
  * Replace current registry with provided blocks. Useful for tests.

--- a/frontend/src/visual/theme.ts
+++ b/frontend/src/visual/theme.ts
@@ -56,6 +56,9 @@ darkTheme.blockKinds.Struct = darkTheme.blockKinds.Struct || '#5c6bc0';
 // ensure color for cast blocks exists
 defaultTheme.blockKinds.Cast = defaultTheme.blockKinds.Cast || '#f8bbd0';
 darkTheme.blockKinds.Cast = darkTheme.blockKinds.Cast || '#c2185b';
+// ensure color for file blocks exists
+defaultTheme.blockKinds.File = defaultTheme.blockKinds.File || '#d7ccc8';
+darkTheme.blockKinds.File = darkTheme.blockKinds.File || '#6d4c41';
 
 const themeMap: Record<string, VisualTheme> = {
   default: defaultTheme,


### PR DESCRIPTION
## Summary
- add FileReadBlock and FileWriteBlock with exec/data ports
- include file blocks in palette registry and theme colors
- extend meta schema and serialization tests for new block kinds

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a06821b7a8832391229390176aef55