### PR TITLE
docs: clarify Linux rust installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,10 +250,13 @@ sudo apt install rustc cargo
    Проверка: `node -v`
 
 2. **Rust** — компилирует backend и плагины.
+   В Debian/Ubuntu установите инструменты из официальных репозиториев:
    ```bash
-   curl https://sh.rustup.rs -sSf | sh
+   sudo apt update
+   sudo apt install rustc cargo
    ```
    Проверка: `rustc --version`
+   *Этой системной версии Rust достаточно для разработки и сборки проекта.*
 
 3. **Tauri CLI** — управляет сборкой и запуском.
    ```bash


### PR DESCRIPTION
## Summary
- document installing rustc and cargo from system packages on Linux
- note that system-installed Rust is sufficient for building

## Testing
- `npm run check:scripts`
- `npm run setup` (skipped missing dependencies)
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a07fac7e7c83238542dcc392ed2548