### PR TITLE
feat: add node inspector in visual editor

### DIFF
--- a/frontend/src/visual/canvas.js
+++ b/frontend/src/visual/canvas.js
@@ -7,6 +7,7 @@ import { createTwoFilesPatch } from 'diff';
 import { updateMetaComment, previewDiff, renameMetaId, getMetaById } from '../editor/visual-meta.js';
 import { emit, on } from '../shared/event-bus.js';
 import { openBlockEditor } from './block-editor.ts';
+import { openInspector } from './inspector.tsx';
 
 export const VIEW_STATE_KEY = 'visual-view-state';
 
@@ -245,6 +246,8 @@ export class VisualCanvas {
     if (id) this.highlightBlocks([id]);
     else this.highlightBlocks([]);
     emit('blockSelected', { id });
+    const block = id ? this.blocks.find(b => b.id === id) : null;
+    openInspector(this, block || null);
   }
 
   search(label) {

--- a/frontend/src/visual/inspector.test.tsx
+++ b/frontend/src/visual/inspector.test.tsx
@@ -1,0 +1,30 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import { openInspector } from './inspector.tsx';
+
+describe('inspector', () => {
+  it('saves changes', () => {
+    const block = {
+      id: 'a',
+      label: 'old',
+      ports: [ { id: 'p1', kind: 'data', dir: 'in' } ]
+    };
+    const vc: any = { blockDataMap: new Map([[ 'a', { data: { foo: 1 } } ]]) };
+
+    openInspector(vc, block);
+
+    const labelInput = document.getElementById('inspector-label') as HTMLInputElement;
+    labelInput.value = 'new';
+    const dataTextarea = document.getElementById('inspector-data') as HTMLTextAreaElement;
+    dataTextarea.value = '{"foo":2}';
+    const portsTextarea = document.getElementById('inspector-ports') as HTMLTextAreaElement;
+    portsTextarea.value = 'p2\np3';
+    const saveBtn = document.getElementById('inspector-save') as HTMLButtonElement;
+    saveBtn.dispatchEvent(new Event('click'));
+
+    expect(block.label).toBe('new');
+    expect(vc.blockDataMap.get('a').data).toEqual({ foo: 2 });
+    expect(block.ports.map((p: any) => p.id)).toEqual(['p2','p3']);
+  });
+});
+

--- a/frontend/src/visual/inspector.tsx
+++ b/frontend/src/visual/inspector.tsx
@@ -1,0 +1,94 @@
+import type { VisualCanvasLike } from './block-editor.ts';
+
+export interface InspectorBlock {
+  id: string;
+  label: string;
+  ports: { id: string; kind: string; dir: string }[];
+}
+
+export function openInspector(vc: VisualCanvasLike & { blockDataMap: Map<string, any> }, block: InspectorBlock | null) {
+  const existing = document.getElementById('vc-inspector');
+  if (existing) existing.remove();
+  if (!block) return;
+
+  const dataEntry = vc.blockDataMap.get(block.id) || {};
+
+  const panel = document.createElement('div');
+  panel.id = 'vc-inspector';
+  panel.style.position = 'fixed';
+  panel.style.top = '0';
+  panel.style.right = '0';
+  panel.style.width = '300px';
+  panel.style.height = '100%';
+  panel.style.background = '#fff';
+  panel.style.borderLeft = '1px solid #ccc';
+  panel.style.padding = '8px';
+  panel.style.overflow = 'auto';
+
+  const lbl = document.createElement('div');
+  lbl.textContent = 'Label';
+  const labelInput = document.createElement('input');
+  labelInput.id = 'inspector-label';
+  labelInput.value = block.label || '';
+  lbl.appendChild(labelInput);
+  panel.appendChild(lbl);
+
+  const dataLbl = document.createElement('div');
+  dataLbl.textContent = 'Data';
+  const dataTextarea = document.createElement('textarea');
+  dataTextarea.id = 'inspector-data';
+  try {
+    dataTextarea.value = JSON.stringify(dataEntry.data || {}, null, 2);
+  } catch (_) {
+    dataTextarea.value = '';
+  }
+  dataLbl.appendChild(dataTextarea);
+  panel.appendChild(dataLbl);
+
+  const portsLbl = document.createElement('div');
+  portsLbl.textContent = 'Ports';
+  const portsTextarea = document.createElement('textarea');
+  portsTextarea.id = 'inspector-ports';
+  portsTextarea.value = (block.ports || []).map(p => p.id).join('\n');
+  portsLbl.appendChild(portsTextarea);
+  panel.appendChild(portsLbl);
+
+  const btnBar = document.createElement('div');
+  btnBar.style.marginTop = '8px';
+  btnBar.style.textAlign = 'right';
+  const saveBtn = document.createElement('button');
+  saveBtn.id = 'inspector-save';
+  saveBtn.textContent = 'Save';
+  const cancelBtn = document.createElement('button');
+  cancelBtn.id = 'inspector-cancel';
+  cancelBtn.textContent = 'Cancel';
+  btnBar.appendChild(saveBtn);
+  btnBar.appendChild(cancelBtn);
+  panel.appendChild(btnBar);
+
+  saveBtn.addEventListener('click', () => {
+    block.label = labelInput.value;
+    const entry = vc.blockDataMap.get(block.id);
+    if (entry) {
+      try {
+        entry.data = JSON.parse(dataTextarea.value || '{}');
+      } catch (_) {
+        entry.data = {};
+      }
+    }
+    const ids = portsTextarea.value
+      .split(/\n|,/) 
+      .map(s => s.trim())
+      .filter(Boolean);
+    block.ports = ids.map((id, idx) => {
+      const orig = (block.ports || [])[idx] || { kind: 'data', dir: 'in' };
+      return { ...orig, id };
+    });
+    panel.remove();
+  });
+
+  cancelBtn.addEventListener('click', () => panel.remove());
+
+  document.body.appendChild(panel);
+}
+


### PR DESCRIPTION
## Summary
- show node details in new inspector panel
- open inspector when selecting a block
- test inspector saving label, data and ports

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a08c7e581c8323a53f010829c7c566