### PR TITLE
feat: add undo history and redo hotkeys

### DIFF
--- a/frontend/src/visual/hotkeys.spec.ts
+++ b/frontend/src/visual/hotkeys.spec.ts
@@ -92,4 +92,19 @@ describe('hotkeys block insertion', () => {
     expect(canvas.connections[0][1]).toMatchObject({ kind: 'Log' });
     mod.unregisterHotkeys();
   });
+
+  it('undos and redoes block insertion', async () => {
+    const { mod, canvas } = await setup();
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'i' }));
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'f' }));
+    await Promise.resolve();
+    expect(canvas.blocksData).toHaveLength(1);
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'z', ctrlKey: true }));
+    await Promise.resolve();
+    expect(canvas.blocksData).toHaveLength(0);
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'z', ctrlKey: true, shiftKey: true }));
+    await Promise.resolve();
+    expect(canvas.blocksData).toHaveLength(1);
+    mod.unregisterHotkeys();
+  });
 });

--- a/frontend/src/visual/hotkeys.ts
+++ b/frontend/src/visual/hotkeys.ts
@@ -11,6 +11,7 @@ import { EditorSelection } from '@codemirror/state';
 import * as commands from '@codemirror/commands';
 import { openCommandPalette } from '../editor/command-palette.ts';
 import { exportPNG } from './export.ts';
+import { push as pushUndo, undo as undoAction, redo as redoAction } from './undo.ts';
 
 export interface HotkeyMap {
   copyBlock: string;
@@ -114,11 +115,11 @@ function handleKey(e: KeyboardEvent) {
       break;
     case hotkeys.undo:
       e.preventDefault();
-      canvasRef?.undo?.();
+      undoAction();
       break;
     case hotkeys.redo:
       e.preventDefault();
-      canvasRef?.redo?.();
+      redoAction();
       break;
     case hotkeys.groupBlocks:
     case 'Meta+G':
@@ -197,13 +198,21 @@ function handleKey(e: KeyboardEvent) {
             break;
         }
         canvasRef.moveCallback?.(block);
-        canvasRef.undoStack?.push({
-          type: 'move',
-          id: block.id,
-          from: before,
-          to: { x: block.x, y: block.y }
+        const after = { x: block.x, y: block.y };
+        pushUndo({
+          undo: async () => {
+            block.x = before.x;
+            block.y = before.y;
+            canvasRef.moveCallback?.(block);
+            canvasRef.draw?.();
+          },
+          redo: async () => {
+            block.x = after.x;
+            block.y = after.y;
+            canvasRef.moveCallback?.(block);
+            canvasRef.draw?.();
+          }
         });
-        if (canvasRef.redoStack) canvasRef.redoStack = [];
       }
       break;
   }
@@ -537,6 +546,24 @@ function insertKeywordBlock(keyword: 'var' | 'let' | 'for' | 'while' | 'if' | 's
   canvasRef.selected = new Set([block]);
   canvasRef.moveCallback?.(block);
   canvasRef.draw?.();
+  pushUndo({
+    undo: () => {
+      const idx = canvasRef.blocks.indexOf(block);
+      if (idx !== -1) canvasRef.blocks.splice(idx, 1);
+      const dataIdx = canvasRef.blocksData.indexOf(data);
+      if (dataIdx !== -1) canvasRef.blocksData.splice(dataIdx, 1);
+      canvasRef.blockDataMap.delete(id);
+      canvasRef.selected?.delete(block);
+      canvasRef.draw?.();
+    },
+    redo: () => {
+      canvasRef.blocks.push(block);
+      canvasRef.blocksData.push(data);
+      canvasRef.blockDataMap.set(id, data);
+      canvasRef.selected = new Set([block]);
+      canvasRef.draw?.();
+    }
+  });
 }
 
 type OperatorSymbol = '+' | '-' | '*' | '/' | '%' | '++';
@@ -573,6 +600,24 @@ function insertOperatorBlock(op: OperatorSymbol) {
   canvasRef.selected = new Set([block]);
   canvasRef.moveCallback?.(block);
   canvasRef.draw?.();
+  pushUndo({
+    undo: () => {
+      const idx = canvasRef.blocks.indexOf(block);
+      if (idx !== -1) canvasRef.blocks.splice(idx, 1);
+      const dataIdx = canvasRef.blocksData.indexOf(data);
+      if (dataIdx !== -1) canvasRef.blocksData.splice(dataIdx, 1);
+      canvasRef.blockDataMap.delete(id);
+      canvasRef.selected?.delete(block);
+      canvasRef.draw?.();
+    },
+    redo: () => {
+      canvasRef.blocks.push(block);
+      canvasRef.blocksData.push(data);
+      canvasRef.blockDataMap.set(id, data);
+      canvasRef.selected = new Set([block]);
+      canvasRef.draw?.();
+    }
+  });
 }
 
 type OpSymbol = '++' | '--';
@@ -605,6 +650,24 @@ function insertOpBlock(op: OpSymbol) {
   canvasRef.selected = new Set([block]);
   canvasRef.moveCallback?.(block);
   canvasRef.draw?.();
+  pushUndo({
+    undo: () => {
+      const idx = canvasRef.blocks.indexOf(block);
+      if (idx !== -1) canvasRef.blocks.splice(idx, 1);
+      const dataIdx = canvasRef.blocksData.indexOf(data);
+      if (dataIdx !== -1) canvasRef.blocksData.splice(dataIdx, 1);
+      canvasRef.blockDataMap.delete(id);
+      canvasRef.selected?.delete(block);
+      canvasRef.draw?.();
+    },
+    redo: () => {
+      canvasRef.blocks.push(block);
+      canvasRef.blocksData.push(data);
+      canvasRef.blockDataMap.set(id, data);
+      canvasRef.selected = new Set([block]);
+      canvasRef.draw?.();
+    }
+  });
 }
 
 function insertTernaryBlock() {
@@ -632,6 +695,24 @@ function insertTernaryBlock() {
   canvasRef.selected = new Set([block]);
   canvasRef.moveCallback?.(block);
   canvasRef.draw?.();
+  pushUndo({
+    undo: () => {
+      const idx = canvasRef.blocks.indexOf(block);
+      if (idx !== -1) canvasRef.blocks.splice(idx, 1);
+      const dataIdx = canvasRef.blocksData.indexOf(data);
+      if (dataIdx !== -1) canvasRef.blocksData.splice(dataIdx, 1);
+      canvasRef.blockDataMap.delete(id);
+      canvasRef.selected?.delete(block);
+      canvasRef.draw?.();
+    },
+    redo: () => {
+      canvasRef.blocks.push(block);
+      canvasRef.blocksData.push(data);
+      canvasRef.blockDataMap.set(id, data);
+      canvasRef.selected = new Set([block]);
+      canvasRef.draw?.();
+    }
+  });
 }
 
 type LogicOperatorSymbol = '&&' | '||' | '!';
@@ -665,6 +746,24 @@ function insertLogicOperatorBlock(op: LogicOperatorSymbol) {
   canvasRef.selected = new Set([block]);
   canvasRef.moveCallback?.(block);
   canvasRef.draw?.();
+  pushUndo({
+    undo: () => {
+      const idx = canvasRef.blocks.indexOf(block);
+      if (idx !== -1) canvasRef.blocks.splice(idx, 1);
+      const dataIdx = canvasRef.blocksData.indexOf(data);
+      if (dataIdx !== -1) canvasRef.blocksData.splice(dataIdx, 1);
+      canvasRef.blockDataMap.delete(id);
+      canvasRef.selected?.delete(block);
+      canvasRef.draw?.();
+    },
+    redo: () => {
+      canvasRef.blocks.push(block);
+      canvasRef.blocksData.push(data);
+      canvasRef.blockDataMap.set(id, data);
+      canvasRef.selected = new Set([block]);
+      canvasRef.draw?.();
+    }
+  });
 }
 
 type ComparisonOperatorSymbol = '==' | '!=' | '>' | '>=' | '<' | '<=';
@@ -701,6 +800,24 @@ function insertComparisonOperatorBlock(op: ComparisonOperatorSymbol) {
   canvasRef.selected = new Set([block]);
   canvasRef.moveCallback?.(block);
   canvasRef.draw?.();
+  pushUndo({
+    undo: () => {
+      const idx = canvasRef.blocks.indexOf(block);
+      if (idx !== -1) canvasRef.blocks.splice(idx, 1);
+      const dataIdx = canvasRef.blocksData.indexOf(data);
+      if (dataIdx !== -1) canvasRef.blocksData.splice(dataIdx, 1);
+      canvasRef.blockDataMap.delete(id);
+      canvasRef.selected?.delete(block);
+      canvasRef.draw?.();
+    },
+    redo: () => {
+      canvasRef.blocks.push(block);
+      canvasRef.blocksData.push(data);
+      canvasRef.blockDataMap.set(id, data);
+      canvasRef.selected = new Set([block]);
+      canvasRef.draw?.();
+    }
+  });
 }
 
 function insertLogBlock() {
@@ -739,5 +856,27 @@ function insertLogBlock() {
     (canvasRef as any).connect(connectFrom, block);
   }
   canvasRef.draw?.();
+  pushUndo({
+    undo: () => {
+      const idx = canvasRef.blocks.indexOf(block);
+      if (idx !== -1) canvasRef.blocks.splice(idx, 1);
+      const dataIdx = canvasRef.blocksData.indexOf(data);
+      if (dataIdx !== -1) canvasRef.blocksData.splice(dataIdx, 1);
+      canvasRef.blockDataMap.delete(id);
+      canvasRef.selected?.delete(block);
+      canvasRef.draw?.();
+    },
+    redo: () => {
+      canvasRef.blocks.push(block);
+      canvasRef.blocksData.push(data);
+      canvasRef.blockDataMap.set(id, data);
+      canvasRef.selected = new Set([block]);
+      canvasRef.moveCallback?.(block);
+      if (connectFrom && typeof (canvasRef as any).connect === 'function') {
+        (canvasRef as any).connect(connectFrom, block);
+      }
+      canvasRef.draw?.();
+    }
+  });
 }
 

--- a/frontend/src/visual/undo.ts
+++ b/frontend/src/visual/undo.ts
@@ -1,0 +1,39 @@
+export interface UndoAction {
+  undo: () => void | Promise<void>;
+  redo: () => void | Promise<void>;
+}
+
+const undoStack: UndoAction[] = [];
+const redoStack: UndoAction[] = [];
+
+export function push(action: UndoAction) {
+  undoStack.push(action);
+  redoStack.length = 0;
+}
+
+export async function undo() {
+  const action = undoStack.pop();
+  if (!action) return;
+  await action.undo();
+  redoStack.push(action);
+}
+
+export async function redo() {
+  const action = redoStack.pop();
+  if (!action) return;
+  await action.redo();
+  undoStack.push(action);
+}
+
+export function clear() {
+  undoStack.length = 0;
+  redoStack.length = 0;
+}
+
+export function canUndo() {
+  return undoStack.length > 0;
+}
+
+export function canRedo() {
+  return redoStack.length > 0;
+}


### PR DESCRIPTION
## Summary
- implement undo history stack with push/undo/redo helpers
- wire Ctrl/Cmd+Z and Ctrl/Cmd+Shift+Z to undo/redo
- test undo/redo for block insertion

## Testing
- `npm --prefix frontend test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_68a0942dc8ac832387fe9c1f1f7e2b08