### PR TITLE
feat: add visual snippets tab

### DIFF
--- a/frontend/src/visual/palette.ts
+++ b/frontend/src/visual/palette.ts
@@ -1,3 +1,5 @@
+import { getSnippets } from './snippets.ts';
+
 export interface PaletteBlock {
   kind: string;
   name: string;
@@ -46,14 +48,23 @@ export function filterBlocks(query: string): PaletteBlock[] {
 /**
  * Create simple palette component inside given container element. It consists
  * of a search input and a list of blocks filtered according to the input
- * value. The list is populated from the loaded registry.
+ * value. Additionally, a "Snippets" tab lists predefined sub-graphs.
  */
 export function createPalette(container: HTMLElement): void {
+  const tabs = document.createElement('div');
+  const blocksBtn = document.createElement('button');
+  blocksBtn.textContent = 'Blocks';
+  const snippetsBtn = document.createElement('button');
+  snippetsBtn.textContent = 'Snippets';
+  tabs.appendChild(blocksBtn);
+  tabs.appendChild(snippetsBtn);
+
+  // --- Blocks pane ---
+  const blocksPane = document.createElement('div');
   const search = document.createElement('input');
   search.type = 'search';
   const list = document.createElement('ul');
-
-  const render = () => {
+  const renderBlocks = () => {
     list.innerHTML = '';
     for (const block of filterBlocks(search.value)) {
       const li = document.createElement('li');
@@ -61,11 +72,34 @@ export function createPalette(container: HTMLElement): void {
       list.appendChild(li);
     }
   };
+  search.addEventListener('input', renderBlocks);
+  blocksPane.appendChild(search);
+  blocksPane.appendChild(list);
 
-  search.addEventListener('input', render);
-  container.appendChild(search);
-  container.appendChild(list);
-  render();
+  // --- Snippets pane ---
+  const snippetsPane = document.createElement('div');
+  const snippetList = document.createElement('ul');
+  for (const snip of getSnippets()) {
+    const li = document.createElement('li');
+    li.textContent = snip.name;
+    snippetList.appendChild(li);
+  }
+  snippetsPane.appendChild(snippetList);
+
+  // --- Tab switching ---
+  const showPane = (pane: 'blocks' | 'snippets') => {
+    blocksPane.style.display = pane === 'blocks' ? '' : 'none';
+    snippetsPane.style.display = pane === 'snippets' ? '' : 'none';
+  };
+  blocksBtn.addEventListener('click', () => showPane('blocks'));
+  snippetsBtn.addEventListener('click', () => showPane('snippets'));
+
+  container.appendChild(tabs);
+  container.appendChild(blocksPane);
+  container.appendChild(snippetsPane);
+
+  renderBlocks();
+  showPane('blocks');
 }
 
 export function getRegistry(): PaletteBlock[] {

--- a/frontend/src/visual/snippets.ts
+++ b/frontend/src/visual/snippets.ts
@@ -1,0 +1,54 @@
+export interface Snippet {
+  name: string;
+  /** Blocks composing the snippet graph. Only id and kind are required for tests. */
+  blocks: { id: string; kind: string }[];
+  /** Directed edges represented as tuples [from, to]. */
+  edges: [string, string][];
+}
+
+let registry: Snippet[] = [
+  {
+    name: 'Sum loop',
+    blocks: [
+      { id: 'i', kind: 'Variable/Get' },
+      { id: 'sum', kind: 'Variable/Get' },
+      { id: 'add', kind: 'Operator/Add' }
+    ],
+    edges: [
+      ['i', 'add'],
+      ['sum', 'add'],
+      ['add', 'sum']
+    ]
+  }
+];
+
+export function getSnippets(): Snippet[] {
+  return [...registry];
+}
+
+export function setSnippets(snips: Snippet[]): void {
+  registry = [...snips];
+}
+
+/**
+ * Load snippets from backend endpoint and replace current registry.
+ */
+export async function loadSnippets(fetcher: typeof fetch = fetch): Promise<Snippet[]> {
+  const res = await fetcher('/api/registry/snippets');
+  const list: Snippet[] = await res.json();
+  registry = list;
+  return list;
+}
+
+/**
+ * Insert snippet blocks and edges into provided graph object. The graph must
+ * contain `blocks` and `edges` arrays.
+ */
+export function insertSnippet(target: { blocks: any[]; edges: any[] }, snippet: Snippet): void {
+  for (const b of snippet.blocks) {
+    target.blocks.push({ ...b });
+  }
+  for (const e of snippet.edges) {
+    target.edges.push([...e]);
+  }
+}

--- a/frontend/tests/snippets.test.ts
+++ b/frontend/tests/snippets.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { loadSnippets, insertSnippet, setSnippets, getSnippets, Snippet } from '../src/visual/snippets.ts';
+
+describe('snippets', () => {
+  it('loads snippets from backend', async () => {
+    const snips: Snippet[] = [{ name: 'X', blocks: [], edges: [] }];
+    const fetcher = async () => ({ json: async () => snips }) as any;
+    const res = await loadSnippets(fetcher);
+    expect(res).toEqual(snips);
+    expect(getSnippets()).toEqual(snips);
+  });
+
+  it('inserts snippet into graph', () => {
+    const snippet: Snippet = {
+      name: 'A',
+      blocks: [{ id: 'n1', kind: 'K' }],
+      edges: [['n1', 'n2']]
+    };
+    setSnippets([snippet]);
+    const graph = { blocks: [{ id: 'n2', kind: 'Q' }], edges: [] as [string, string][] };
+    insertSnippet(graph, snippet);
+    expect(graph.blocks).toHaveLength(2);
+    expect(graph.edges).toContainEqual(['n1', 'n2']);
+  });
+});


### PR DESCRIPTION
## Summary
- add predefined snippet registry and insertion helpers
- expose snippets in palette via new tab
- test snippet loading and insertion

## Testing
- `npx vitest run`
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_68a0a2c7c10c8323b012ec7f8860eead