### PR TITLE
ci: retry rustup downloads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
+        env:
+          RUSTUP_MAX_RETRIES: 10
+          RUSTUP_USE_CURL: 1
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y libglib2.0-dev libgtk-3-dev libsoup-3.0-dev libwebkit2gtk-4.1-dev pkg-config
       - name: Set PKG_CONFIG_PATH


### PR DESCRIPTION
## Summary
- retry rustup network downloads and switch to curl for more reliable toolchain setup

## Testing
- `cargo test` (failed: The system library `glib-2.0` required by crate `glib-sys` was not found)
- `npm test` (passed, vitest entered watch mode; terminated manually)

------
https://chatgpt.com/codex/tasks/task_e_68a0b04093c48323a2763c7baec9a4f4