### PR TITLE
feat: add frontend plugin loader and docs

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,0 +1,45 @@
+# Плагины визуализации
+
+Фронтенд поддерживает подключение плагинов, которые могут регистрировать
+дополнительные визуальные блоки или иной функционал.  Каждый плагин должен
+реализовать интерфейс `VizPlugin` с методом `register`.
+
+```ts
+export interface VizPlugin {
+  register(registry: PluginRegistry): void;
+}
+```
+
+Метод `register` получает объект `registry` с функциями, которые плагин
+может вызывать для добавления своих компонентов.  В частности, для блоков
+доступна функция `registerBlock` и базовый класс `Block`.
+
+## Загрузчик
+
+Файл `frontend/src/plugins/plugin-loader.ts` автоматически ищет модули
+`index.ts` или `index.js` в каталоге `plugins/` и вызывает их метод
+`register`.
+
+```ts
+import { loadPlugins } from '../frontend/src/plugins/plugin-loader';
+loadPlugins({ Block, registerBlock });
+```
+
+## Пример плагина
+
+В репозитории присутствует пример плагина в каталоге
+`plugins/example/index.ts`:
+
+```ts
+export function register({ Block, registerBlock }: any) {
+  class ExampleBlock extends Block {
+    constructor(id: string, x: number, y: number) {
+      super(id, x, y, 120, 50, 'Example');
+    }
+  }
+  registerBlock('ExampleBlock', ExampleBlock);
+}
+```
+
+Плагин регистрирует новый блок `ExampleBlock`, который сразу можно
+использовать после загрузки.

--- a/frontend/src/plugins/index.ts
+++ b/frontend/src/plugins/index.ts
@@ -1,0 +1,9 @@
+export interface PluginRegistry {
+  registerBlock: (kind: string, ctor: unknown) => void;
+  unregisterBlock?: (kind: string) => void;
+  [key: string]: unknown;
+}
+
+export interface VizPlugin {
+  register(registry: PluginRegistry): void;
+}

--- a/frontend/src/plugins/plugin-loader.ts
+++ b/frontend/src/plugins/plugin-loader.ts
@@ -1,0 +1,20 @@
+import type { VizPlugin, PluginRegistry } from './index.ts';
+
+/**
+ * Load all visual plugins from the `plugins/` directory.
+ *
+ * Each plugin should export a `register` function that accepts a registry
+ * object.  The function is invoked immediately when the plugin is loaded.
+ */
+export function loadPlugins(registry: PluginRegistry) {
+  const modules = import.meta.glob<Promise<VizPlugin | { register: Function }>>(
+    '../../../plugins/*/index.{ts,js}',
+    { eager: true }
+  );
+  for (const path in modules) {
+    const mod: any = modules[path];
+    if (mod && typeof mod.register === 'function') {
+      mod.register(registry);
+    }
+  }
+}

--- a/plugins/example/index.ts
+++ b/plugins/example/index.ts
@@ -1,0 +1,8 @@
+export function register({ Block, registerBlock }: any) {
+  class ExampleBlock extends Block {
+    constructor(id: string, x: number, y: number) {
+      super(id, x, y, 120, 50, 'Example');
+    }
+  }
+  registerBlock('ExampleBlock', ExampleBlock);
+}

--- a/plugins/example/package.json
+++ b/plugins/example/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@multicode/example-plugin",
+  "version": "0.1.0",
+  "private": true,
+  "main": "index.ts"
+}


### PR DESCRIPTION
## Summary
- define `VizPlugin` interface
- load visual plugins from `plugins/` directory
- document plugin API and include example plugin

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a0bed82fc8832399b59df8fa1c90f9