### PR TITLE
feat: highlight anchors in code editor

### DIFF
--- a/frontend/src/code-sync.ts
+++ b/frontend/src/code-sync.ts
@@ -1,0 +1,37 @@
+import { highlightRange as highlightEffect } from './editor/active-block.js';
+import type { EditorView } from '@codemirror/view';
+
+// Current editor instance used for synchronisation.
+let currentView: EditorView | null = null;
+
+/**
+ * Register the CodeMirror view used for highlighting.
+ */
+export function registerEditor(view: EditorView) {
+  currentView = view;
+}
+
+/**
+ * Highlight a range in the editor defined by an anchor.
+ *
+ * The anchor is expected to be a tuple [from, to] representing
+ * character offsets inside the document. If the anchor is `null`
+ * or invalid the current highlight is cleared.
+ *
+ * @param anchor Tuple containing start and end positions or null to clear
+ * @returns `true` if a range was highlighted, otherwise `false`
+ */
+export function highlightRange(anchor: [number, number] | null): boolean {
+  if (!currentView) return false;
+  if (!anchor || anchor.length !== 2) {
+    currentView.dispatch({ effects: [highlightEffect.of(null)] });
+    return false;
+  }
+  const [from, to] = anchor;
+  currentView.dispatch({
+    effects: [highlightEffect.of({ from, to })],
+    selection: { anchor: from, head: to },
+    scrollIntoView: true,
+  });
+  return true;
+}

--- a/frontend/src/visual/canvas.js
+++ b/frontend/src/visual/canvas.js
@@ -9,6 +9,7 @@ import { emit, on } from '../shared/event-bus.js';
 import { openBlockEditor } from './block-editor.ts';
 import { openInspector } from './inspector.tsx';
 import { searchBlocks, replaceBlockLabels, createReplaceDialog } from './search.ts';
+import { highlightRange } from '../code-sync.ts';
 
 export const VIEW_STATE_KEY = 'visual-view-state';
 
@@ -249,6 +250,13 @@ export class VisualCanvas {
     emit('blockSelected', { id });
     const block = id ? this.blocks.find(b => b.id === id) : null;
     openInspector(this, block || null);
+
+    const anchors = id ? this.blockDataMap.get(id)?.anchors : null;
+    if (Array.isArray(anchors) && anchors.length > 0) {
+      anchors.forEach(a => highlightRange(a));
+    } else {
+      highlightRange(null);
+    }
   }
 
   search(label) {

--- a/frontend/tests/code-sync.test.ts
+++ b/frontend/tests/code-sync.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('../src/editor/active-block.js', () => ({
+  highlightRange: { of: (v: any) => ({ value: v }) }
+}));
+
+import { registerEditor, highlightRange } from '../src/code-sync.ts';
+
+describe('code-sync highlightRange', () => {
+  it('dispatches highlight for a valid anchor', () => {
+    const dispatch = vi.fn();
+    registerEditor({ dispatch } as any);
+    const result = highlightRange([1, 5]);
+    expect(result).toBe(true);
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    const arg = dispatch.mock.calls[0][0];
+    expect(arg.selection).toEqual({ anchor: 1, head: 5 });
+    expect(arg.effects[0].value).toEqual({ from: 1, to: 5 });
+  });
+
+  it('clears highlight when anchor is missing', () => {
+    const dispatch = vi.fn();
+    registerEditor({ dispatch } as any);
+    const result = highlightRange(null);
+    expect(result).toBe(false);
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    expect(dispatch.mock.calls[0][0].effects[0].value).toBeNull();
+  });
+});

--- a/frontend/tests/reroute.test.ts
+++ b/frontend/tests/reroute.test.ts
@@ -3,12 +3,13 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 
 vi.mock('@codemirror/state', () => ({
   StateField: { define: vi.fn() },
-  RangeSetBuilder: class {}
+  RangeSetBuilder: class {},
+  StateEffect: { define: vi.fn(() => ({ of: vi.fn() })) }
 }));
 
 vi.mock('@codemirror/view', () => ({
   Decoration: { mark: () => ({}) },
-  EditorView: { decorations: { from: vi.fn() }, updateListener: { of: vi.fn() } }
+  EditorView: { decorations: { from: vi.fn() }, updateListener: { of: vi.fn() }, baseTheme: vi.fn() }
 }));
 
 vi.mock('@codemirror/language', () => ({


### PR DESCRIPTION
## Summary
- add code sync module with highlightRange to highlight arbitrary code anchors
- trigger anchor highlighting from visual canvas selection
- cover anchor highlighting with unit tests and update mocks

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0b6dd90388323a58eb9e5c342ab96