### PR TITLE
chore: remove unused vite dev dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,9 +12,6 @@
       "dependencies": {
         "fs-extra": "^11.3.1",
         "ora": "^5.4.1"
-      },
-      "devDependencies": {
-        "vite": "^7.1.0"
       }
     },
     "frontend": {

--- a/package.json
+++ b/package.json
@@ -16,8 +16,5 @@
   "dependencies": {
     "fs-extra": "^11.3.1",
     "ora": "^5.4.1"
-  },
-  "devDependencies": {
-    "vite": "^7.1.0"
   }
 }


### PR DESCRIPTION
## Summary
- remove vite from root devDependencies since it's unused

## Testing
- `npm install`
- `npm test`
- `npx depcheck`


------
https://chatgpt.com/codex/tasks/task_e_68a0e4e9aab883239c94c5d4749c139e