### PR TITLE
fix: mark vite usage for depcheck

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,3 @@
+import { defineConfig } from 'vite';
+
+export default defineConfig({});


### PR DESCRIPTION
## Summary
- add minimal Vite config so depcheck recognizes vite

## Testing
- `npx depcheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0eb7457f08323af83f5753b428585