### PR TITLE
Enable full-featured backend tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         run: cargo audit
         working-directory: backend
       - name: Run backend tests
-        run: cargo test
+        run: cargo test --all-features -- --nocapture
         working-directory: backend
   frontend:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Run backend `cargo test` with all features and no output capture in CI

## Testing
- `cargo test --all-features -- --nocapture` *(fails: pkg-config could not find javascriptcoregtk-4.1)*

------
https://chatgpt.com/codex/tasks/task_e_68a0f4705eec8323a50bbc230c9b534b