### PR TITLE
ci: build backend docs during CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,11 @@ jobs:
       - name: Lint backend
         run: cargo clippy --all-targets --all-features -- -D warnings
         working-directory: backend
+      - name: Build backend documentation
+        run: |
+          set -o pipefail
+          cargo doc --no-deps 2>&1 | tee doc-build.log
+        working-directory: backend
       - name: Audit Rust dependencies
         run: cargo audit
         working-directory: backend


### PR DESCRIPTION
## Summary
- build backend documentation using `cargo doc --no-deps` during CI

## Testing
- `yamllint .github/workflows/ci.yml` *(fails: line-length errors)*
- `cargo doc --no-deps` *(fails: glib-2.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a0f9be61488323a96d5a23a0afabfe