### PR TITLE
ci: use default rustup backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         env:
           RUSTUP_MAX_RETRIES: 10
-          RUSTUP_USE_CURL: 1
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y libglib2.0-dev libgtk-3-dev libsoup-3.0-dev libwebkit2gtk-4.1-dev pkg-config
       - name: Set PKG_CONFIG_PATH


### PR DESCRIPTION
## Summary
- remove deprecated `RUSTUP_USE_CURL` env var to rely on default rustup backend

## Testing
- `npm test` *(fails: waiting for file changes then terminated)*
- `cargo test` *(failed: process terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68a0f6aea20c8323a38b4f9b8b4d628b