### PR TITLE
chore: run frontend lint in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,9 @@ jobs:
       - name: Check dependencies
         run: npx depcheck
         working-directory: frontend
+      - name: Lint frontend
+        run: npm run lint -- --max-warnings=0
+        working-directory: frontend
       - name: Run frontend tests
         run: npm test
         working-directory: frontend


### PR DESCRIPTION
## Summary
- lint frontend code in CI before tests

## Testing
- `npm run lint -- --max-warnings=0` *(fails: ESLint couldn't find an eslint.config.js file)*
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68a0fb19778483239b027037d7a5d11c