### PR TITLE
ci: run frontend type check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,11 @@ jobs:
       - name: Install dependencies
         run: npm ci
         working-directory: frontend
+      - name: TypeScript type check
+        run: |
+          set -o pipefail
+          npx tsc --noEmit 2>&1 | tee tsc.log
+        working-directory: frontend
       - name: Audit npm dependencies
         run: npm audit
         working-directory: frontend


### PR DESCRIPTION
## Summary
- run `npx tsc --noEmit` in frontend CI job to verify TypeScript types and log output

## Testing
- `npm ci`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68a0feac72048323819d5942c1c4b0e9