### PR TITLE
ci: add verbose frontend build step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,9 @@ jobs:
       - name: Lint frontend
         run: npm run lint -- --max-warnings=0
         working-directory: frontend
+      - name: Build frontend
+        run: npm run build --verbose
+        working-directory: frontend
       - name: Run frontend tests
         run: npm test
         working-directory: frontend


### PR DESCRIPTION
## Summary
- add frontend build step with verbose npm output

## Testing
- `npm run build --verbose` *(fails: tauri not found)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0fffb99c48323bec709d2a3f8aab6