### PR TITLE
ci: build backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,9 @@ jobs:
       - name: Audit Rust dependencies
         run: cargo audit
         working-directory: backend
+      - name: Build backend
+        run: cargo build --verbose
+        working-directory: backend
       - name: Run backend tests
         run: cargo test --all-features -- --nocapture
         working-directory: backend


### PR DESCRIPTION
## Summary
- ensure backend is compiled in CI after auditing dependencies

## Testing
- `cargo build` *(fails: The system library `gobject-2.0` required by crate `gobject-sys` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a156043dd4832395e9df192f9c00db