### PR TITLE
ci: build backend in release mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,11 @@ jobs:
       - name: Build backend
         run: cargo build --verbose
         working-directory: backend
+      - name: Build backend release
+        run: |
+          set -o pipefail
+          cargo build --release 2>&1 | tee release-build.log
+        working-directory: backend
       - name: Run backend tests
         run: cargo test --all-features -- --nocapture
         working-directory: backend


### PR DESCRIPTION
## Summary
- build backend in release mode as part of CI and tee output for visibility

## Testing
- `cargo build --release`

------
https://chatgpt.com/codex/tasks/task_e_68a157c5c75c8323baa92077b6def47f