### PR TITLE
Run Tauri release build in CI without bundling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,9 @@ jobs:
       - name: Build frontend debug
         run: npm run build:debug
         working-directory: frontend
+      - name: Build frontend release
+        run: npm run build:release
+        working-directory: frontend
       - name: Run frontend tests
         run: npm test -- --coverage
         working-directory: frontend

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,6 +8,7 @@
     "dev": "tauri dev",
     "build": "tauri build",
     "build:debug": "tauri build --debug --no-bundle",
+    "build:release": "tauri build --no-bundle",
     "lint": "npx eslint .",
     "e2e": "playwright test"
   },


### PR DESCRIPTION
## Summary
- add `build:release` script to run `tauri build --no-bundle`
- run release build in frontend CI job

## Testing
- `npm run build:release` *(fails: sh: 1: tauri: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a165570bbc8323aa8249d9c69f1691