### PR TITLE
ci: add desktop build job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,25 @@ jobs:
         with:
           name: frontend-coverage
           path: frontend/coverage
+  desktop-build:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - name: Install dependencies
+        run: npm ci
+        working-directory: frontend
+      - name: Build debug
+        run: npm run build:debug -- --no-bundle
+        working-directory: frontend
+      - name: Build release
+        run: npm run build:release -- --no-bundle
+        working-directory: frontend
   lsp:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary
- run desktop builds for debug and release across ubuntu, macOS, and Windows to catch linker/configuration issues

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a166a4102c83238149272a10b05383