### PR TITLE
Enable logging summary and tolerant CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   backend:
+    continue-on-error: true
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
@@ -32,6 +33,7 @@ jobs:
           name: backend-log
           path: backend-ci.log
   node-workspaces:
+    continue-on-error: true
     strategy:
       matrix:
         workdir: [frontend, plugins/lsp]
@@ -49,6 +51,7 @@ jobs:
           name: ${{ matrix.workdir }}-log
           path: ${{ matrix.workdir }}-ci.log
   desktop-build:
+    continue-on-error: true
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]

--- a/scripts/ci_backend.sh
+++ b/scripts/ci_backend.sh
@@ -22,4 +22,7 @@ run "cargo test --all-features -- --nocapture"
 popd >/dev/null
 
 tee "$LOG_FILE"
+if grep -q "::error" *.log; then
+  echo "Some steps failed. See log."
+fi
 exit 0

--- a/scripts/ci_node.sh
+++ b/scripts/ci_node.sh
@@ -24,5 +24,8 @@ fi
 popd >/dev/null
 
 tee "$LOG_FILE"
+if grep -q "::error" *.log; then
+  echo "Some steps failed. See log."
+fi
 exit 0
 


### PR DESCRIPTION
## Summary
- Allow backend, node-workspaces, and desktop-build CI jobs to continue on errors
- Print log summary in backend and node CI scripts

## Testing
- `bash -n scripts/ci_backend.sh`
- `bash -n scripts/ci_node.sh`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a16d2ba2f48323b99a4704fbc89f24