### PR TITLE
chore(ci): annotate action failures

### DIFF
--- a/scripts/ci_backend.sh
+++ b/scripts/ci_backend.sh
@@ -5,10 +5,12 @@ LOG_FILE="backend-ci.log"
 
 pushd backend >/dev/null
 
+set -o pipefail
+
 run() {
   local cmd="$1"
-  echo "+ $cmd" >> "../$LOG_FILE"
-  bash -c "$cmd" >> "../$LOG_FILE" 2>&1 || echo "::error file=backend step=$cmd::failed" >> "../$LOG_FILE"
+  echo "+ $cmd" | tee -a "../$LOG_FILE"
+  bash -c "$cmd" 2>&1 | tee -a "../$LOG_FILE" || echo "::error file=$(pwd)/../$LOG_FILE,line=1::${cmd} failed" >> "../$LOG_FILE"
 }
 
 run "cargo fmt --all -- --check"

--- a/scripts/ci_node.sh
+++ b/scripts/ci_node.sh
@@ -6,10 +6,12 @@ LOG_FILE="$PWD/${WORKDIR}-ci.log"
 
 pushd "$WORKDIR" >/dev/null
 
+set -o pipefail
+
 run() {
   local cmd="$1"
-  echo "+ $cmd" >> "$LOG_FILE"
-  bash -c "$cmd" >> "$LOG_FILE" 2>&1 || echo "::error file=$WORKDIR step=$cmd::failed" >> "$LOG_FILE"
+  echo "+ $cmd" | tee -a "$LOG_FILE"
+  bash -c "$cmd" 2>&1 | tee -a "$LOG_FILE" || echo "::error file=$(pwd)/../${WORKDIR}-ci.log,line=1::${cmd} failed" >> "$LOG_FILE"
 }
 
 run "npm ci"


### PR DESCRIPTION
## Summary
- use tee to capture command output and add GitHub error annotations on failure in backend CI
- apply same exit-code handling and annotation to node CI script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a16ebad0dc8323b1c1914e6408e666