### PR TITLE
Save CI logs and upload as named artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/upload-artifact@v3
         if: always()
         with:
-          name: backend-log
+          name: backend
           path: backend-ci.log
   node-workspaces:
     continue-on-error: true
@@ -48,8 +48,8 @@ jobs:
       - uses: actions/upload-artifact@v3
         if: always()
         with:
-          name: ${{ matrix.workdir }}-log
-          path: ${{ matrix.workdir }}-ci.log
+          name: ${{ replace(matrix.workdir, '/', '-') }}
+          path: ${{ replace(matrix.workdir, '/', '-') }}-ci.log
   desktop-build:
     continue-on-error: true
     strategy:

--- a/scripts/ci_backend.sh
+++ b/scripts/ci_backend.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-LOG_FILE="backend-ci.log"
+LOG_FILE="$PWD/backend-ci.log"
 : > "$LOG_FILE"
 
 pushd backend >/dev/null
@@ -9,8 +9,8 @@ set -o pipefail
 
 run() {
   local cmd="$1"
-  echo "+ $cmd" | tee -a "../$LOG_FILE"
-  bash -c "$cmd" 2>&1 | tee -a "../$LOG_FILE" || echo "::error file=$(pwd)/../$LOG_FILE,line=1::${cmd} failed" >> "../$LOG_FILE"
+  echo "+ $cmd" | tee -a "$LOG_FILE"
+  bash -c "$cmd" 2>&1 | tee -a "$LOG_FILE" || echo "::error file=$LOG_FILE,line=1::${cmd} failed" >> "$LOG_FILE"
 }
 
 run "cargo fmt --all -- --check"
@@ -23,8 +23,8 @@ run "cargo test --all-features -- --nocapture"
 
 popd >/dev/null
 
-tee "$LOG_FILE"
-if grep -q "::error" *.log; then
+cat "$LOG_FILE"
+if grep -q "::error" "$LOG_FILE"; then
   echo "Some steps failed. See log."
 fi
 exit 0

--- a/scripts/ci_node.sh
+++ b/scripts/ci_node.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 
 WORKDIR="$1"
-LOG_FILE="$PWD/${WORKDIR}-ci.log"
+WORKSPACE_SAFE="${WORKDIR//\//-}"
+LOG_FILE="$PWD/${WORKSPACE_SAFE}-ci.log"
 : > "$LOG_FILE"
 
 pushd "$WORKDIR" >/dev/null
@@ -11,7 +12,7 @@ set -o pipefail
 run() {
   local cmd="$1"
   echo "+ $cmd" | tee -a "$LOG_FILE"
-  bash -c "$cmd" 2>&1 | tee -a "$LOG_FILE" || echo "::error file=$(pwd)/../${WORKDIR}-ci.log,line=1::${cmd} failed" >> "$LOG_FILE"
+  bash -c "$cmd" 2>&1 | tee -a "$LOG_FILE" || echo "::error file=$LOG_FILE,line=1::${cmd} failed" >> "$LOG_FILE"
 }
 
 run "npm ci"
@@ -25,8 +26,8 @@ fi
 
 popd >/dev/null
 
-tee "$LOG_FILE"
-if grep -q "::error" *.log; then
+cat "$LOG_FILE"
+if grep -q "::error" "$LOG_FILE"; then
   echo "Some steps failed. See log."
 fi
 exit 0


### PR DESCRIPTION
## Summary
- ensure backend and workspace CI scripts preserve logs instead of truncating
- upload CI logs as artifacts named after their directories

## Testing
- `bash -n scripts/ci_backend.sh scripts/ci_node.sh`
- `npm run check:scripts`


------
https://chatgpt.com/codex/tasks/task_e_68a170346030832390a4fc067ff32367