### PR TITLE
feat: export selected subgraph as macro

### DIFF
--- a/frontend/src/macros.test.ts
+++ b/frontend/src/macros.test.ts
@@ -1,0 +1,37 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import { exportMacro, insertMacro } from './macros.ts';
+
+describe('macros import/export', () => {
+  it('exports selected subgraph', () => {
+    const vc: any = {
+      blocksData: [
+        { visual_id: 'a', kind: 'A', x: 0, y: 0 },
+        { visual_id: 'b', kind: 'B', x: 10, y: 0 },
+        { visual_id: 'c', kind: 'C', x: 20, y: 0 }
+      ],
+      connections: [
+        [{ id: 'a' }, { id: 'b' }],
+        [{ id: 'b' }, { id: 'c' }]
+      ],
+      selected: new Set(['a', 'b'])
+    };
+    const macro = exportMacro(vc)!;
+    expect(macro.blocks.map((b: any) => b.visual_id)).toEqual(['a', 'b']);
+    expect(macro.connections).toEqual([['a', 'b']]);
+  });
+
+  it('inserts macro into target graph', () => {
+    const target = { blocks: [] as any[], connections: [] as [string, string][] };
+    const macro = {
+      blocks: [
+        { visual_id: 'x', kind: 'Test', x: 0, y: 0 }
+      ],
+      connections: [['x', 'x'] as [string, string]]
+    };
+    insertMacro(target, macro);
+    expect(target.blocks.length).toBe(1);
+    expect(target.blocks[0].visual_id).toBe('x');
+    expect(target.connections).toEqual([['x', 'x']]);
+  });
+});

--- a/frontend/src/macros.ts
+++ b/frontend/src/macros.ts
@@ -1,0 +1,58 @@
+import type { VisualCanvas } from './visual/canvas.js';
+
+export interface Macro {
+  blocks: any[];
+  connections: [string, string][];
+}
+
+/**
+ * Create a macro object from currently selected blocks and edges on the canvas.
+ */
+export function exportMacro(vc: VisualCanvas): Macro | null {
+  const selectedIds = Array.from(vc.selected || []);
+  if (!selectedIds.length) return null;
+  const idSet = new Set(selectedIds);
+  const blocks = vc.blocksData
+    .filter(b => idSet.has(b.visual_id))
+    .map(b => ({ ...b }));
+  const connections: [string, string][] = [];
+  for (const [from, to] of vc.connections) {
+    if (idSet.has(from.id) && idSet.has(to.id)) {
+      connections.push([from.id, to.id]);
+    }
+  }
+  return { blocks, connections };
+}
+
+/**
+ * Trigger download of selected subgraph as a `.macro.json` file.
+ */
+export function saveAsMacro(vc: VisualCanvas, name = 'macro'): void {
+  const macro = exportMacro(vc);
+  if (!macro) return;
+  const blob = new Blob([JSON.stringify(macro, null, 2)], {
+    type: 'application/json'
+  });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = `${name}.macro.json`;
+  link.click();
+  setTimeout(() => URL.revokeObjectURL(url), 1000);
+}
+
+/**
+ * Insert blocks and connections from a macro into the provided target object.
+ * The target must contain `blocks` and `connections` arrays.
+ */
+export function insertMacro(
+  target: { blocks: any[]; connections: [string, string][] },
+  macro: Macro
+): void {
+  for (const b of macro.blocks) {
+    target.blocks.push({ ...b });
+  }
+  for (const c of macro.connections) {
+    target.connections.push([...c]);
+  }
+}

--- a/frontend/src/visual/menu.ts
+++ b/frontend/src/visual/menu.ts
@@ -1,6 +1,7 @@
 import { hotkeys, showHotkeyHelp, zoomToFit, focusSearch } from './hotkeys';
 import { exportPNG } from './export.ts';
 import { emit } from '../shared/event-bus.js';
+import { saveAsMacro } from '../macros.ts';
 
 export function createSearchInput(canvas: any) {
   const input = document.createElement('input');
@@ -87,12 +88,14 @@ export const contextMenus = {
   block: [
     { label: 'Copy Block', action: () => console.log('copy'), shortcut: hotkeys.copyBlock },
     { label: 'Paste Block', action: () => console.log('paste'), shortcut: hotkeys.pasteBlock },
+    { label: 'Save as Macro', action: saveAsMacro },
     { label: 'Сгруппировать', action: () => console.log('group') },
     { label: 'Разгруппировать', action: () => console.log('ungroup') }
   ],
   canvas: [
     { label: 'Paste Block', action: () => console.log('paste'), shortcut: hotkeys.pasteBlock },
     { label: 'Select Connections', action: () => console.log('select'), shortcut: hotkeys.selectConnections },
+    { label: 'Save as Macro', action: saveAsMacro },
     { label: 'Zoom to Fit', action: zoomToFit, shortcut: hotkeys.zoomToFit }
   ]
 };


### PR DESCRIPTION
## Summary
- add macro export helpers and insertion utility
- expose Save as Macro in block and canvas context menus
- cover macro import/export with unit tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a171e59d40832390be09f4a5b23301