### PR TITLE
ci: track failure state in backend script

### DIFF
--- a/scripts/ci_backend.sh
+++ b/scripts/ci_backend.sh
@@ -6,11 +6,15 @@ LOG_FILE="$PWD/backend-ci.log"
 pushd backend >/dev/null
 
 set -o pipefail
+FAILED=0
 
 run() {
   local cmd="$1"
   echo "+ $cmd" | tee -a "$LOG_FILE"
-  bash -c "$cmd" 2>&1 | tee -a "$LOG_FILE" || echo "::error file=$LOG_FILE,line=1::${cmd} failed" >> "$LOG_FILE"
+  if ! bash -c "$cmd" 2>&1 | tee -a "$LOG_FILE"; then
+    echo "::error file=$LOG_FILE,line=1::${cmd} failed" >> "$LOG_FILE"
+    FAILED=1
+  fi
 }
 
 run "cargo fmt --all -- --check"
@@ -27,4 +31,4 @@ cat "$LOG_FILE"
 if grep -q "::error" "$LOG_FILE"; then
   echo "Some steps failed. See log."
 fi
-exit 0
+exit $FAILED


### PR DESCRIPTION
## Summary
- ensure backend CI script propagates errors by setting FAILED flag
- exit with non-zero status when any command fails

## Testing
- `bash scripts/ci_backend.sh` *(fails: rustfmt issues and clippy compile; run aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68a1776e9b748323a16423c604bdf72f