### PR TITLE
ci: run all matrix jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   backend:
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
@@ -32,6 +33,7 @@ jobs:
           path: backend-ci.log
   node-workspaces:
     strategy:
+      fail-fast: false
       matrix:
         workdir: [frontend, plugins/lsp]
     runs-on: ubuntu-latest
@@ -48,6 +50,7 @@ jobs:
           path: ${{ replace(matrix.workdir, '/', '-') }}-ci.log
   desktop-build:
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
## Summary
- prevent failing early in matrix strategies by disabling fail-fast

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a180412ee4832382fcc9841e7526e3