### PR TITLE
chore: add GitHub error annotation to CI scripts

### DIFF
--- a/scripts/ci_backend.sh
+++ b/scripts/ci_backend.sh
@@ -28,6 +28,9 @@ run "cargo test --all-features -- --nocapture"
 popd >/dev/null
 
 cat "$LOG_FILE"
+if [ "$FAILED" -ne 0 ]; then
+  echo "::error::One or more steps failed (see log above)"
+fi
 if grep -q "::error" "$LOG_FILE"; then
   echo "Some steps failed. See log."
 fi

--- a/scripts/ci_node.sh
+++ b/scripts/ci_node.sh
@@ -31,6 +31,9 @@ fi
 popd >/dev/null
 
 cat "$LOG_FILE"
+if [ "$FAILED" -ne 0 ]; then
+  echo "::error::One or more steps failed (see log above)"
+fi
 if grep -q "::error" "$LOG_FILE"; then
   echo "Some steps failed. See log."
 fi


### PR DESCRIPTION
## Summary
- surface CI failures with GitHub error annotations

## Testing
- `shellcheck scripts/ci_node.sh scripts/ci_backend.sh`
- `bash -n scripts/ci_node.sh scripts/ci_backend.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a182f66f948323888c1ad728d5e0b8