### PR TITLE
feat: flag micro blocks for zoom handling

### DIFF
--- a/frontend/src/visual/blocks.js
+++ b/frontend/src/visual/blocks.js
@@ -398,6 +398,7 @@ class MicroOpBlock extends Block {
       getTheme().blockKinds.Operator || getTheme().blockFill
     );
     this.ports = MicroOpBlock.ports;
+    this.isMicro = true;
   }
 }
 
@@ -418,6 +419,7 @@ class UnaryMicroOpBlock extends Block {
       getTheme().blockKinds.Operator || getTheme().blockFill
     );
     this.ports = UnaryMicroOpBlock.ports;
+    this.isMicro = true;
   }
 }
 
@@ -644,6 +646,7 @@ export class VariableGetBlock extends Block {
       getTheme().blockKinds.Variable
     );
     this.ports = VariableGetBlock.ports;
+    this.isMicro = true;
   }
 }
 

--- a/frontend/src/visual/canvas.js
+++ b/frontend/src/visual/canvas.js
@@ -1075,10 +1075,12 @@ export class VisualCanvas {
     if (blocks.length === 0) return;
     let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
     for (const b of blocks) {
+      const w = b.isMicro ? 120 : b.w;
+      const h = b.isMicro ? 50 : b.h;
       minX = Math.min(minX, b.x);
       minY = Math.min(minY, b.y);
-      maxX = Math.max(maxX, b.x + b.w);
-      maxY = Math.max(maxY, b.y + b.h);
+      maxX = Math.max(maxX, b.x + w);
+      maxY = Math.max(maxY, b.y + h);
     }
     const width = maxX - minX;
     const height = maxY - minY;

--- a/frontend/src/visual/canvas.zoom.test.ts
+++ b/frontend/src/visual/canvas.zoom.test.ts
@@ -1,0 +1,27 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+vi.mock('../editor/visual-meta.js', () => ({
+  updateMetaComment: vi.fn(),
+  previewDiff: vi.fn().mockResolvedValue(true),
+  renameMetaId: vi.fn().mockResolvedValue(true)
+}));
+vi.mock('./block-editor.ts', () => ({ openBlockEditor: vi.fn() }));
+import { VisualCanvas } from './canvas.js';
+
+describe('zoomToFit with micro blocks', () => {
+  it('accounts for isMicro flag', () => {
+    const canvasEl = document.createElement('canvas');
+    Object.defineProperty(canvasEl, 'clientWidth', { value: 200 });
+    Object.defineProperty(canvasEl, 'clientHeight', { value: 200 });
+    canvasEl.getContext = () => ({ save(){}, setTransform(){}, clearRect(){}, beginPath(){}, stroke(){}, moveTo(){}, lineTo(){}, fillRect(){}, strokeRect(){}, fillText(){}, restore(){} });
+    globalThis.requestAnimationFrame = () => 0;
+    const vc = new VisualCanvas(canvasEl);
+    vc.blocks = [
+      { x: 0, y: 0, w: 56, h: 28, isMicro: true }
+    ];
+    vc.zoomToFit();
+    expect(vc.scale).toBeCloseTo(1.5);
+    expect(vc.offset.x).toBeCloseTo(10);
+    expect(vc.offset.y).toBeCloseTo(62.5);
+  });
+});


### PR DESCRIPTION
## Summary
- mark micro-size visual blocks with `isMicro`
- rely on `isMicro` during `zoomToFit`
- add zoom test covering micro blocks

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a1af2204008323ab7cab4a96465724