### PR TITLE
chore: update upload-artifact to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Backend quality
         run: bash scripts/ci_backend.sh
         continue-on-error: true
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: backend-log
@@ -45,7 +45,7 @@ jobs:
       - name: Node quality
         run: bash scripts/ci_node.sh ${{ matrix.workdir }}
         continue-on-error: true
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: ${{ matrix.workdir }}-log


### PR DESCRIPTION
## Summary
- switch backend and node-workspace jobs to `actions/upload-artifact@v4`

## Testing
- `yamllint --strict .github/workflows/ci.yml`
- `./bin/act -l` *(fails: Couldn't get a valid docker connection: no DOCKER_HOST and an invalid container socket '')*


------
https://chatgpt.com/codex/tasks/task_e_68a1b56e425c8323a595e01f5ca57443