### PR TITLE
ci: install tauri cli in desktop build workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,8 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18
+      - name: Install Tauri CLI
+        run: npm install -g @tauri-apps/cli
       - name: Install dependencies
         run: npm ci
         working-directory: frontend


### PR DESCRIPTION
## Summary
- install global Tauri CLI in desktop build workflow so Tauri commands are available

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1b8bfc7c48323a25d75f1bba16df0