### PR TITLE
ci: setup rust toolchain for desktop builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
       - uses: actions/setup-node@v3
         with:
           node-version: 18


### PR DESCRIPTION
## Summary
- setup Rust toolchain for desktop builds before Node setup

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1bbc1d9648323bffa77fedf2f7317