### PR TITLE
ci: remove redundant no-bundle flag from debug build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
         run: npm ci
         working-directory: frontend
       - name: Build debug
-        run: npm run build:debug -- --no-bundle
+        run: npm run build:debug
         working-directory: frontend
       - name: Build release
         run: npm run build:release -- --no-bundle


### PR DESCRIPTION
## Summary
- avoid passing a duplicate `--no-bundle` flag to the debug build step

## Testing
- `npm run build:debug` *(fails: No such file or directory (os error 2) about ["/workspace/Multicode_V3/frontend/src-tauri/Cargo.toml"])*

------
https://chatgpt.com/codex/tasks/task_e_68a1bd7927448323bb342c83ac871f19