### PR TITLE
Use OS-specific name for backend logs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: backend-log
+          name: backend-log-${{ matrix.os }}
           path: backend-ci.log
   node-workspaces:
     continue-on-error: true


### PR DESCRIPTION
## Summary
- give backend workflow artifacts OS-specific names to avoid collisions

## Testing
- `npm test`
- `cargo test` *(fails: build dependencies; aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68a1cf2772688323b449113351a6ae24