### PR TITLE
Sanitize artifact names in node-workspaces CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,10 +45,12 @@ jobs:
       - name: Node quality
         run: bash scripts/ci_node.sh ${{ matrix.workdir }}
         continue-on-error: true
+      - name: Compute safe artifact name
+        run: echo "SAFE_WORKDIR=${{ matrix.workdir }}" | tr '/' '-' >> $GITHUB_ENV
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: ${{ matrix.workdir }}-log
+          name: ${{ env.SAFE_WORKDIR }}-log
           path: ${{ matrix.workdir }}-ci.log
   desktop-build:
     continue-on-error: true


### PR DESCRIPTION
## Summary
- sanitize artifact names in node-workspaces job to replace `/` with `-`

## Testing
- `npm test`
- `cargo test --manifest-path backend/Cargo.toml` *(fails: The system library `glib-2.0` required by crate `glib-sys` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1d2e9f5a0832385b195a87c8efbda