### PR TITLE
Add Tauri project scaffold

### DIFF
--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "src-tauri"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+tauri = { version = "2", features = ["wry"] }
+
+[build-dependencies]
+tauri-build = { version = "2" }

--- a/frontend/src-tauri/build.rs
+++ b/frontend/src-tauri/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    tauri_build::build();
+}

--- a/frontend/src-tauri/src/main.rs
+++ b/frontend/src-tauri/src/main.rs
@@ -1,0 +1,5 @@
+fn main() {
+    tauri::Builder::default()
+        .run(tauri::generate_context!())
+        .expect("error while running tauri application");
+}


### PR DESCRIPTION
## Summary
- add `src-tauri` manifest with Tauri dependency
- wire up `tauri::Builder::default().run(...)` entry point
- include build script for `tauri-build`

## Testing
- `cargo check` *(fails: resource path `../../backend/target/release/backend-x86_64-unknown-linux-gnu` doesn't exist)*

------
https://chatgpt.com/codex/tasks/task_e_68a1d5e40ba08323a4e1483568b0e920