### PR TITLE
ci: build backend before desktop build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,13 @@ jobs:
       - name: Install dependencies
         run: npm ci
         working-directory: frontend
+      - name: Build backend
+        run: cargo build --release --manifest-path backend/Cargo.toml
+      - name: Ensure backend binary path exists
+        run: |
+          ls backend/target/release/
+          test -e backend/target/release/backend || test -e backend/target/release/backend.exe
+        shell: bash
       - name: Build debug
         run: npm run build:debug
         working-directory: frontend


### PR DESCRIPTION
## Summary
- build backend during desktop CI job
- verify backend release binary exists before Tauri builds

## Testing
- `npm ci`
- `cargo build --release --manifest-path backend/Cargo.toml`
- `npm run build:debug` *(fails: manifest path `../../backend/Cargo.toml` does not exist)*


------
https://chatgpt.com/codex/tasks/task_e_68a1daeb116083238913eb3d4070d998