### PR TITLE
Ensure CI scripts exit on failure and gate build steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,13 +72,16 @@ jobs:
       - name: Build backend
         run: cargo build --release --manifest-path backend/Cargo.toml
       - name: Ensure backend binary path exists
+        if: ${{ success() }}
         run: |
           ls backend/target/release/
           test -e backend/target/release/backend || test -e backend/target/release/backend.exe
         shell: bash
       - name: Build debug
+        if: ${{ success() }}
         run: npm run build:debug
         working-directory: frontend
       - name: Build release
+        if: ${{ success() }}
         run: npm run build:release -- --no-bundle
         working-directory: frontend

--- a/scripts/ci_backend.sh
+++ b/scripts/ci_backend.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 LOG_FILE="backend-ci.log"
 : > "$LOG_FILE"
 
@@ -8,7 +10,10 @@ pushd backend >/dev/null
 run() {
   local cmd="$1"
   echo "+ $cmd" >> "../$LOG_FILE"
-  bash -c "$cmd" >> "../$LOG_FILE" 2>&1 || echo "::error file=backend step=$cmd::failed" >> "../$LOG_FILE"
+  bash -c "$cmd" >> "../$LOG_FILE" 2>&1 || {
+    echo "::error file=backend step=$cmd::failed" >> "../$LOG_FILE"
+    return 1
+  }
 }
 
 run "cargo fmt --all -- --check"

--- a/scripts/ci_node.sh
+++ b/scripts/ci_node.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 WORKDIR="$1"
 LOG_FILE="$PWD/${WORKDIR}-ci.log"
@@ -9,7 +10,10 @@ pushd "$WORKDIR" >/dev/null
 run() {
   local cmd="$1"
   echo "+ $cmd" >> "$LOG_FILE"
-  bash -c "$cmd" >> "$LOG_FILE" 2>&1 || echo "::error file=$WORKDIR step=$cmd::failed" >> "$LOG_FILE"
+  bash -c "$cmd" >> "$LOG_FILE" 2>&1 || {
+    echo "::error file=$WORKDIR step=$cmd::failed" >> "$LOG_FILE"
+    return 1
+  }
 }
 
 run "npm ci"


### PR DESCRIPTION
## Summary
- stop backend and node CI scripts on first failing command
- skip dependent desktop build steps when earlier ones fail

## Testing
- `bash scripts/ci_backend.sh`
- `bash scripts/ci_node.sh plugins/lsp`


------
https://chatgpt.com/codex/tasks/task_e_68a1e0e57aec8323ba95bb71f176b427