### PR TITLE
Improve run function error annotations

### DIFF
--- a/scripts/ci_backend.sh
+++ b/scripts/ci_backend.sh
@@ -10,10 +10,14 @@ pushd backend >/dev/null
 run() {
   local cmd="$1"
   echo "+ $cmd" >> "../$LOG_FILE"
-  bash -c "$cmd" >> "../$LOG_FILE" 2>&1 || {
-    echo "::error file=backend step=$cmd::failed" >> "../$LOG_FILE"
+  if ! err=$(bash -c "$cmd" 2>&1); then
+    echo "$err" >> "../$LOG_FILE"
+    local path=$(printf '%s\n' "$err" | grep -oE '[^ :]+\.[a-z]+:[0-9]+' | head -n1)
+    echo "::error file=${path:-backend} step=$cmd::failed" >> "../$LOG_FILE"
     return 1
-  }
+  else
+    echo "$err" >> "../$LOG_FILE"
+  fi
 }
 
 run "cargo fmt --all -- --check"

--- a/scripts/ci_node.sh
+++ b/scripts/ci_node.sh
@@ -10,10 +10,14 @@ pushd "$WORKDIR" >/dev/null
 run() {
   local cmd="$1"
   echo "+ $cmd" >> "$LOG_FILE"
-  bash -c "$cmd" >> "$LOG_FILE" 2>&1 || {
-    echo "::error file=$WORKDIR step=$cmd::failed" >> "$LOG_FILE"
+  if ! err=$(bash -c "$cmd" 2>&1); then
+    echo "$err" >> "$LOG_FILE"
+    local path=$(printf '%s\n' "$err" | grep -oE '[^ :]+\.[a-z]+:[0-9]+' | head -n1)
+    echo "::error file=${path:-$WORKDIR} step=$cmd::failed" >> "$LOG_FILE"
     return 1
-  }
+  else
+    echo "$err" >> "$LOG_FILE"
+  fi
 }
 
 run "npm ci"


### PR DESCRIPTION
## Summary
- capture command output in CI scripts and use first `path:line` for GitHub Actions error annotations

## Testing
- `bash -n scripts/ci_node.sh`
- `bash -n scripts/ci_backend.sh`
- `npm test`
- `cargo test --manifest-path backend/Cargo.toml` *(fails: gio-2.0 not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1e26758288323a94fcbda45916de7