### PR TITLE
Handle magnifier deactivation on blur

### DIFF
--- a/frontend/src/visual/canvas.js
+++ b/frontend/src/visual/canvas.js
@@ -1046,6 +1046,10 @@ export class VisualCanvas {
       this.alignGuides = [];
     });
 
+    window.addEventListener('blur', () => {
+      if (this.magnifier) this.magnifier.active = false;
+    });
+
     this.canvas.addEventListener('mouseleave', () => {
       this.tooltip.style.display = 'none';
     });

--- a/frontend/src/visual/canvas.zoom.test.ts
+++ b/frontend/src/visual/canvas.zoom.test.ts
@@ -1,0 +1,23 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+vi.mock('../editor/visual-meta.js', () => ({
+  updateMetaComment: vi.fn(),
+  previewDiff: vi.fn().mockResolvedValue(true),
+  renameMetaId: vi.fn().mockResolvedValue(true)
+}));
+vi.mock('./block-editor.ts', () => ({ openBlockEditor: vi.fn() }));
+import { VisualCanvas } from './canvas.js';
+
+describe('magnifier', () => {
+  it('deactivates on window blur', () => {
+    const canvasEl = document.createElement('canvas');
+    Object.defineProperty(canvasEl, 'clientWidth', { value: 200 });
+    Object.defineProperty(canvasEl, 'clientHeight', { value: 200 });
+    canvasEl.getContext = () => ({ save(){}, setTransform(){}, clearRect(){}, beginPath(){}, stroke(){}, moveTo(){}, lineTo(){}, fillRect(){}, strokeRect(){}, fillText(){}, restore(){} });
+    globalThis.requestAnimationFrame = () => 0;
+    const vc = new VisualCanvas(canvasEl);
+    vc.magnifier = { active: true };
+    window.dispatchEvent(new Event('blur'));
+    expect(vc.magnifier.active).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Ensure magnifier tool is disabled when the window loses focus
- Add unit test verifying magnifier deactivation on window blur

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a1e48eb7b083238769b50ddbe1c2e3