### PR TITLE
ci: install system dependencies for linux desktop build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,13 @@ jobs:
       - name: Install dependencies
         run: npm ci
         working-directory: frontend
+      - name: Install system dependencies
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y \
+             libglib2.0-dev libgtk-3-dev libsoup-3.0-dev libwebkit2gtk-4.1-dev pkg-config
+      - name: Set PKG_CONFIG_PATH
+        if: runner.os == 'Linux'
+        run: echo "PKG_CONFIG_PATH=/usr/lib/x86_64-linux-gnu/pkgconfig" >> $GITHUB_ENV
       - name: Build backend
         run: cargo build --release --manifest-path backend/Cargo.toml
       - name: Ensure backend binary path exists


### PR DESCRIPTION
## Summary
- install GTK/Webkit dependencies in desktop build workflow on Linux
- set `PKG_CONFIG_PATH` for Linux desktop builds

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a1ecdde0908323841783b799b62e17