### PR TITLE
fix tauri backend paths

### DIFF
--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -2,14 +2,14 @@
   "$schema": "https://schema.tauri.app/config/2",
   "identifier": "com.example.multicode",
   "build": {
-    "beforeDevCommand": "cargo run --manifest-path ../../backend/Cargo.toml",
-    "beforeBuildCommand": "cargo build --release --manifest-path ../../backend/Cargo.toml",
+    "beforeDevCommand": "cargo run --manifest-path ../backend/Cargo.toml",
+    "beforeBuildCommand": "cargo build --release --manifest-path ../backend/Cargo.toml",
     "devUrl": "http://localhost:1420",
     "frontendDist": "../dist"
   },
   "bundle": {
     "externalBin": [
-      "../../backend/target/release/backend"
+      "../backend/target/release/backend"
     ]
   },
   "app": {


### PR DESCRIPTION
## Summary
- fix backend manifest paths in Tauri config

## Testing
- `npm run build:debug` *(fails: resource path `../backend/target/release/backend-x86_64-unknown-linux-gnu` doesn't exist)*
- `npm run build:release` *(fails: resource path `../backend/target/release/backend-x86_64-unknown-linux-gnu` doesn't exist)*

------
https://chatgpt.com/codex/tasks/task_e_68a1ef388ea88323a40f1665769c218d