### PR TITLE
feat: add backend copy script

### DIFF
--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -3,7 +3,7 @@
   "identifier": "com.example.multicode",
   "build": {
     "beforeDevCommand": "cargo run --manifest-path ../backend/Cargo.toml",
-    "beforeBuildCommand": "cargo build --release --manifest-path ../backend/Cargo.toml && node -e \"const fs=require('fs'); const p='../backend/target/release/backend'; const ext=process.platform==='win32'?'.exe':''; fs.copyFileSync(p+ext, p+'-'+process.env.TAURI_ENV_TARGET_TRIPLE+ext);\"",
+    "beforeBuildCommand": "cargo build --release --manifest-path ../backend/Cargo.toml && node ../scripts/copy-backend.cjs",
     "devUrl": "http://localhost:1420",
     "frontendDist": "../dist"
   },

--- a/scripts/copy-backend.cjs
+++ b/scripts/copy-backend.cjs
@@ -1,0 +1,11 @@
+const fs = require('fs');
+const path = require('path');
+const triple = process.env.TAURI_ENV_TARGET_TRIPLE;
+if (!triple) {
+  console.error('TAURI_ENV_TARGET_TRIPLE not set');
+  process.exit(1);
+}
+const ext = process.platform === 'win32' ? '.exe' : '';
+const src = path.resolve(__dirname, '../backend/target/release/backend' + ext);
+const dest = path.resolve(__dirname, '../backend/target/release/backend-' + triple + ext);
+fs.copyFileSync(src, dest);


### PR DESCRIPTION
## Summary
- add helper script to copy backend binary with platform triple
- call the helper from Tauri beforeBuildCommand

## Testing
- `npm test`
- `npm run check:scripts`


------
https://chatgpt.com/codex/tasks/task_e_68a226b5814883239aa190b01a49c0ef