### PR TITLE
Fix Tauri backend binary path

### DIFF
--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -9,7 +9,7 @@
   },
   "bundle": {
     "externalBin": [
-      "../backend/target/release/backend"
+      "../../backend/target/release/backend"
     ]
   },
   "app": {


### PR DESCRIPTION
## Summary
- point Tauri `externalBin` to backend in repo root

## Testing
- `npx @tauri-apps/cli build --debug` (fails: incomplete due to environment constraints but backend built and copied)


------
https://chatgpt.com/codex/tasks/task_e_68a23dd6c4cc8323bb2dc288e7192684