### PR TITLE
feat: skip gtk pkg-config checks on non-linux

### DIFF
--- a/scripts/check-env.js
+++ b/scripts/check-env.js
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 const { execSync } = require('child_process');
 
+const isLinux = process.platform === 'linux';
+
 function has(command, label) {
   try {
     execSync(command, { stdio: 'ignore' });
@@ -14,8 +16,12 @@ function has(command, label) {
 
 let ok = true;
 ok &= has('pkg-config --version', 'pkg-config');
-ok &= has('pkg-config --exists gdk-3.0', 'gdk-3.0');
-ok &= has('pkg-config --exists gtk+-3.0', 'gtk+-3.0');
+if (isLinux) {
+  ok &= has('pkg-config --exists gdk-3.0', 'gdk-3.0');
+  ok &= has('pkg-config --exists gtk+-3.0', 'gtk+-3.0');
+} else {
+  console.log('Skipped on non-Linux platforms');
+}
 
 if (!ok) {
   console.error('\nMissing required system dependencies.');


### PR DESCRIPTION
## Summary
- add `isLinux` flag to check-env script
- run gtk pkg-config checks only on Linux and log skip message otherwise

## Testing
- `npm test`
- `npm run check:scripts`
- `node scripts/check-env.js`
- `node -e "Object.defineProperty(process, 'platform', { value: 'win32', configurable: true }); require('./scripts/check-env.js');"`


------
https://chatgpt.com/codex/tasks/task_e_68a2e88d69888323aba7f514f8ebef03