### PR TITLE
chore: verify gdk library before builds

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,9 +8,9 @@
     "dev": "tauri dev",
     "build": "tauri build",
     "prebuild:debug": "rimraf src-tauri/target",
-    "build:debug": "pkg-config --libs gdk-3.0 >/dev/null || { echo 'gdk-3.0 libraries not found. Install Windows prerequisites.'; exit 1; } && tauri build --debug",
+    "build:debug": "node ../scripts/check-gdk.js && tauri build --debug",
     "prebuild:release": "rimraf src-tauri/target",
-    "build:release": "pkg-config --libs gdk-3.0 >/dev/null || { echo 'gdk-3.0 libraries not found. Install Windows prerequisites.'; exit 1; } && tauri build",
+    "build:release": "node ../scripts/check-gdk.js && tauri build",
     "lint": "npx eslint .",
     "e2e": "playwright test"
   },

--- a/scripts/check-gdk.js
+++ b/scripts/check-gdk.js
@@ -1,0 +1,13 @@
+#!/usr/bin/env node
+const { execSync } = require('child_process');
+
+const isLinux = process.platform === 'linux';
+
+if (isLinux) {
+  try {
+    execSync('pkg-config --libs gdk-3.0', { stdio: 'ignore' });
+  } catch (err) {
+    console.error('gdk-3.0 libraries not found. Install Windows prerequisites.');
+    process.exit(1);
+  }
+}


### PR DESCRIPTION
## Summary
- add `scripts/check-gdk.js` to ensure `gdk-3.0` is available on Linux
- run the check before debug and release frontend builds

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a2ead4d1e483239cf1db8790d27c0c