### PR TITLE
fix: run env check after dependency setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,9 +72,6 @@ jobs:
       - name: Install dependencies
         run: npm ci
         working-directory: frontend
-      - name: Check environment
-        if: runner.os != 'macOS'
-        run: npm run check-env
       - name: Install system dependencies
         if: runner.os == 'Linux'
         run: |
@@ -84,6 +81,9 @@ jobs:
       - name: Set PKG_CONFIG_PATH
         if: runner.os == 'Linux'
         run: echo "PKG_CONFIG_PATH=/usr/lib/x86_64-linux-gnu/pkgconfig" >> $GITHUB_ENV
+      - name: Check environment
+        if: runner.os != 'macOS'
+        run: npm run check-env
       - name: Build backend
         run: cargo build --release --manifest-path backend/Cargo.toml
       - name: Ensure backend binary path exists


### PR DESCRIPTION
## Summary
- ensure system packages and PKG_CONFIG_PATH are configured before running `npm run check-env` in the desktop build workflow

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a2f30ab4408323bbcea43ec6e65d0b