### PR TITLE
Add desktop packaging scripts and CI workflow

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -1,0 +1,38 @@
+name: desktop-build
+
+on:
+  push:
+    paths:
+      - 'desktop/**'
+      - 'scripts/**'
+      - '.github/workflows/desktop.yml'
+  workflow_dispatch:
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: [windows-latest, macos-latest, ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Build desktop
+        run: cargo build --release -p desktop
+      - name: Install Inno Setup
+        if: runner.os == 'Windows'
+        run: choco install innosetup -y
+      - name: Package Windows installer
+        if: runner.os == 'Windows'
+        run: iscc scripts/installer.iss
+      - name: Package macOS app
+        if: runner.os == 'macOS'
+        run: bash scripts/macos_bundle.sh
+      - name: Package AppImage
+        if: runner.os == 'Linux'
+        run: bash scripts/build_appimage.sh
+      - uses: actions/upload-artifact@v4
+        with:
+          name: desktop-${{ matrix.os }}
+          path: dist
+          if-no-files-found: warn

--- a/README-desktop.md
+++ b/README-desktop.md
@@ -1,0 +1,57 @@
+# Сборка Multicode Desktop
+
+Этот документ описывает, как собрать и упаковать приложение `desktop` для основных операционных систем. Все артефакты сборки сохраняются в каталоге `dist/`.
+
+## Предварительные требования
+
+- установленный инструментарий Rust (`cargo`)
+- для упаковки Windows: [Inno Setup](https://jrsoftware.org/isinfo.php)
+- для сборки пакета macOS: macOS с установленными инструментами командной строки Xcode
+- для создания AppImage: `appimagetool` должен быть доступен в `PATH`
+
+## Сборка бинарного файла
+
+```sh
+cargo build --release -p desktop
+```
+
+Скомпилированный бинарник будет находиться по пути `target/release/desktop` (или `desktop.exe` на Windows).
+
+## Упаковка
+
+### Windows
+
+1. Убедитесь, что установлен Inno Setup.
+2. Запустите скрипт установщика:
+   ```sh
+   iscc scripts/installer.iss
+   ```
+3. В каталоге `dist/` появится установщик `MulticodeSetup.exe`.
+
+*В установщик включён заглушенный модуль WinSparkle для будущих автообновлений, сейчас он отключён.*
+
+### macOS
+
+1. Запустите скрипт упаковки:
+   ```sh
+   bash scripts/macos_bundle.sh
+   ```
+2. `.app`-пакет будет создан в `dist/Multicode.app`.
+3. Установите переменную `CODESIGN_IDENTITY`, чтобы при необходимости подписать пакет.
+
+*Заглушки для автообновлений через Sparkle присутствуют, но отключены.*
+
+### Linux (AppImage)
+
+1. Убедитесь, что установлен `appimagetool`.
+2. Запустите скрипт создания AppImage:
+   ```sh
+   bash scripts/build_appimage.sh
+   ```
+3. Полученный файл AppImage будет сохранён как `dist/Multicode-x86_64.AppImage`.
+
+*В скрипте предусмотрена заглушка проверки версии для будущего автообновления, но сейчас она отключена.*
+
+## GitHub Actions
+
+Рабочий процесс `.github/workflows/desktop.yml` собирает проект `desktop` на платформах `windows-latest`, `macos-latest` и `ubuntu-latest`, упаковывает описанные выше артефакты и загружает их как артефакты в Actions.

--- a/scripts/build_appimage.sh
+++ b/scripts/build_appimage.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_NAME="Multicode"
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DIST_DIR="$ROOT_DIR/dist"
+APPDIR="$ROOT_DIR/appimage/${APP_NAME}.AppDir"
+BIN_PATH="$ROOT_DIR/target/release/desktop"
+
+rm -rf "$APPDIR"
+mkdir -p "$APPDIR/usr/bin"
+mkdir -p "$APPDIR/usr/share/applications"
+mkdir -p "$APPDIR/usr/share/icons/hicolor/256x256/apps"
+
+cp "$BIN_PATH" "$APPDIR/usr/bin/$APP_NAME"
+
+cat > "$APPDIR/$APP_NAME.desktop" <<EOF2
+[Desktop Entry]
+Type=Application
+Name=$APP_NAME
+Exec=$APP_NAME
+Icon=$APP_NAME
+Categories=Utility;
+EOF2
+
+if [ -f "$ROOT_DIR/frontend/assets/icon.png" ]; then
+  cp "$ROOT_DIR/frontend/assets/icon.png" "$APPDIR/usr/share/icons/hicolor/256x256/apps/$APP_NAME.png"
+fi
+
+mkdir -p "$DIST_DIR"
+
+if command -v appimagetool >/dev/null 2>&1; then
+  appimagetool "$APPDIR" "$DIST_DIR/${APP_NAME}-x86_64.AppImage"
+else
+  echo "appimagetool not found; skipping AppImage generation" >&2
+fi
+
+# Placeholder for future version check auto-updater
+# export APPIMAGE_AUTOUPDATE=0

--- a/scripts/installer.iss
+++ b/scripts/installer.iss
@@ -1,0 +1,21 @@
+; installer.iss - Windows installer for Multicode Desktop
+
+[Setup]
+AppName=Multicode
+AppVersion=0.1.0
+DefaultDirName={pf}\Multicode
+OutputBaseFilename=MulticodeSetup
+OutputDir=dist
+DisableProgramGroupPage=yes
+
+[Files]
+Source: "..\\target\\release\\desktop.exe"; DestDir: "{app}"; Flags: ignoreversion
+
+[Icons]
+Name: "{group}\\Multicode"; Filename: "{app}\\desktop.exe"
+
+; Placeholder for future WinSparkle auto-updater integration
+; #define EnableWinSparkle
+; If defined EnableWinSparkle then
+;   ; WinSparkle setup tasks would go here
+; endif

--- a/scripts/macos_bundle.sh
+++ b/scripts/macos_bundle.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_NAME="Multicode"
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DIST_DIR="$ROOT_DIR/dist"
+APP_BUNDLE="$DIST_DIR/${APP_NAME}.app"
+BIN_PATH="$ROOT_DIR/target/release/desktop"
+
+rm -rf "$APP_BUNDLE"
+mkdir -p "$APP_BUNDLE/Contents/MacOS"
+mkdir -p "$APP_BUNDLE/Contents/Resources"
+
+cp "$BIN_PATH" "$APP_BUNDLE/Contents/MacOS/$APP_NAME"
+
+cat > "$APP_BUNDLE/Contents/Info.plist" <<'PLIST'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleExecutable</key><string>Multicode</string>
+  <key>CFBundleIdentifier</key><string>com.example.multicode</string>
+  <key>CFBundleName</key><string>Multicode</string>
+  <key>CFBundleVersion</key><string>0.1.0</string>
+</dict>
+</plist>
+PLIST
+
+if [[ -n "${CODESIGN_IDENTITY:-}" ]]; then
+  codesign --deep --force --sign "$CODESIGN_IDENTITY" "$APP_BUNDLE"
+fi
+
+# Placeholder for future Sparkle auto-updater integration
+# export SPARKLE_ENABLED=0
+
+echo "Created $APP_BUNDLE"


### PR DESCRIPTION
## Summary
- add Windows Inno Setup script, macOS bundler, and AppImage builder
- document desktop build/install steps in Russian
- automate desktop builds for Windows, macOS, and Linux in CI

## Testing
- `npm test` *(fails: Cannot find module 'tape')*
- `cargo test -p desktop`


------
https://chatgpt.com/codex/tasks/task_e_68a31c31f96c83238f4d68e8209c28bd