### PR TITLE
feat: reference desktop icon asset in packaging scripts

### DIFF
--- a/scripts/build_appimage.sh
+++ b/scripts/build_appimage.sh
@@ -23,8 +23,8 @@ Icon=$APP_NAME
 Categories=Utility;
 EOF2
 
-if [ -f "$ROOT_DIR/frontend/assets/icon.png" ]; then
-  cp "$ROOT_DIR/frontend/assets/icon.png" "$APPDIR/usr/share/icons/hicolor/256x256/apps/$APP_NAME.png"
+if [ -f "$ROOT_DIR/desktop/assets/icon.png" ]; then
+  cp "$ROOT_DIR/desktop/assets/icon.png" "$APPDIR/usr/share/icons/hicolor/256x256/apps/$APP_NAME.png"
 fi
 
 mkdir -p "$DIST_DIR"

--- a/scripts/installer.iss
+++ b/scripts/installer.iss
@@ -10,9 +10,10 @@ DisableProgramGroupPage=yes
 
 [Files]
 Source: "..\\target\\release\\desktop.exe"; DestDir: "{app}"; Flags: ignoreversion
+Source: "..\\desktop\\assets\\icon.png"; DestDir: "{app}"; Flags: ignoreversion
 
 [Icons]
-Name: "{group}\\Multicode"; Filename: "{app}\\desktop.exe"
+Name: "{group}\\Multicode"; Filename: "{app}\\desktop.exe"; IconFilename: "{app}\\icon.png"
 
 ; Placeholder for future WinSparkle auto-updater integration
 ; #define EnableWinSparkle

--- a/scripts/macos_bundle.sh
+++ b/scripts/macos_bundle.sh
@@ -13,6 +13,10 @@ mkdir -p "$APP_BUNDLE/Contents/Resources"
 
 cp "$BIN_PATH" "$APP_BUNDLE/Contents/MacOS/$APP_NAME"
 
+if [ -f "$ROOT_DIR/desktop/assets/icon.png" ]; then
+  cp "$ROOT_DIR/desktop/assets/icon.png" "$APP_BUNDLE/Contents/Resources/icon.png"
+fi
+
 cat > "$APP_BUNDLE/Contents/Info.plist" <<'PLIST'
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -22,6 +26,7 @@ cat > "$APP_BUNDLE/Contents/Info.plist" <<'PLIST'
   <key>CFBundleIdentifier</key><string>com.example.multicode</string>
   <key>CFBundleName</key><string>Multicode</string>
   <key>CFBundleVersion</key><string>0.1.0</string>
+  <key>CFBundleIconFile</key><string>icon.png</string>
 </dict>
 </plist>
 PLIST


### PR DESCRIPTION
## Summary
- remove redundant desktop icon asset
- reference shared icon in linux, macOS, and Windows packaging scripts

## Testing
- `cargo test -p desktop`
- `npm run check:scripts`


------
https://chatgpt.com/codex/tasks/task_e_68a33c1ea8a8832392ca5a8746584ca8