### PR TITLE
docs: document core modules and features

### DIFF
--- a/docs/modules.md
+++ b/docs/modules.md
@@ -2,9 +2,30 @@
 
 Ядро Multicode состоит из набора независимых модулей, которые подключаются через флаги Cargo.
 
-- `git` — интеграция с системой контроля версий;
-- `watch` — отслеживание изменений файлов;
-- `export` — экспорт визуальных представлений;
-- `db` — хранение данных в базе.
+| Флаг | Возможность | Зависимости |
+|------|-------------|-------------|
+| `git` | интеграция с системой контроля версий | `git2` |
+| `watch` | отслеживание изменений файлов | `notify`, `tokio` |
+| `export` | экспорт визуальных представлений | — |
+| `db` | хранение данных в базе | `sqlx`, `tokio` |
+
+## Примеры сборки
+
+```bash
+# только интеграция с Git
+cargo build -p core --no-default-features --features "git"
+
+# только отслеживание изменений
+cargo build -p core --no-default-features --features "watch"
+
+# экспорт визуальных представлений
+cargo build -p core --no-default-features --features "export"
+
+# работа с базой данных
+cargo build -p core --no-default-features --features "db"
+
+# комбинирование модулей
+cargo build -p core --no-default-features --features "git,watch"
+```
 
 Подробнее о плагинах см. в [plugin-guide.md](plugin-guide.md). Общий обзор возможностей приведён в [features.md](features.md). Структура каталогов описана в [repo-structure.md](repo-structure.md). Термины смотрите в [глоссарии](glossary.md).


### PR DESCRIPTION
## Summary
- document core module feature flags and dependencies
- show cargo build examples for enabling modules

## Testing
- `cargo fmt --all -- --check` *(fails: formatting differences in existing code)*
- `cargo clippy -p core --no-default-features --features "git,watch,export,db" -- -D warnings` *(aborted)*
- `cargo test -p core --no-default-features`
- `cargo audit` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a354d4ca488323a512525e345dc2d8