### PR TITLE
Translate remaining docs to Russian

### DIFF
--- a/NODE_EDITOR_MANUAL_TESTS.md
+++ b/NODE_EDITOR_MANUAL_TESTS.md
@@ -1,38 +1,38 @@
-# Node Editor Manual Test Scenarios
+# Сценарии ручного тестирования редактора блоков
 
-These scenarios help to manually verify core functionality of the node editor.
+Эти сценарии помогают вручную проверить основную функциональность редактора блоков.
 
-## 1. Block Parsing and Display
-1. Open the application with a sample source file.
-2. Ensure blocks appear for major constructs (functions, variables, conditions, loops).
-3. Change locale to Russian and Spanish; block labels should update accordingly.
+## 1. Разбор и отображение блоков
+1. Откройте приложение с примером исходного файла.
+2. Убедитесь, что для основных конструкций (функции, переменные, условия, циклы) появляются блоки.
+3. Смените язык интерфейса на русский и испанский; подписи блоков должны обновиться.
 
-## 2. Synchronization of Positions
-1. Drag a block to a new position.
-2. Save and reload the project.
-3. Verify the block stays at the moved position.
-4. Use undo/redo buttons to ensure movement history is tracked.
+## 2. Синхронизация координат
+1. Перетащите блок в новое положение.
+2. Сохраните и заново загрузите проект.
+3. Проверьте, что блок остался на перемещённом месте.
+4. Используйте кнопки отмены/повтора, чтобы убедиться, что история перемещений сохраняется.
 
-## 3. Metadata Editing
-1. Select a block and edit its translations.
-2. Confirm changes appear on the canvas after closing the editor.
-3. Add an AI note and hover the block to view the tooltip.
+## 3. Редактирование метаданных
+1. Выберите блок и отредактируйте его переводы.
+2. Убедитесь, что после закрытия редактора изменения отражаются на холсте.
+3. Добавьте AI‑заметку и наведите курсор на блок, чтобы увидеть подсказку.
 
-## 4. Connections
-1. Create a connection between two blocks.
-2. Move one block and ensure the connection updates.
-3. Delete a block and check that associated connections are removed.
+## 4. Связи
+1. Создайте соединение между двумя блоками.
+2. Переместите один блок и убедитесь, что связь обновилась.
+3. Удалите блок и проверьте, что соответствующие соединения тоже удалены.
 
-## 5. Export
-1. Use the export command to save cleaned source code.
-2. Open the exported file and verify no `@VISUAL_META` comments remain.
+## 5. Экспорт
+1. Выполните команду экспорта, чтобы сохранить очищенный исходный код.
+2. Откройте экспортированный файл и убедитесь, что в нём нет комментариев `@VISUAL_META`.
 
-## 6. Import/Parsing
-1. Load a file containing `@VISUAL_META` comments.
-2. Ensure blocks appear at the correct positions with the stored translations.
+## 6. Импорт и разбор
+1. Загрузите файл, содержащий комментарии `@VISUAL_META`.
+2. Убедитесь, что блоки появились на нужных позициях с сохранёнными переводами.
 
-## 7. WebSocket Synchronization
-1. Open the editor in two windows.
-2. Move a block in the first window and verify the change appears in the second.
+## 7. Синхронизация через WebSocket
+1. Откройте редактор в двух окнах.
+2. Переместите блок в первом окне и убедитесь, что изменение отображается во втором.
 
-These steps provide a baseline for manual validation of the editor's parsing, synchronization, and export features.
+Эти шаги служат основой для ручной проверки возможности разбора, синхронизации и экспорта редактора.

--- a/docs/event-bus-plugin-example.md
+++ b/docs/event-bus-plugin-example.md
@@ -1,21 +1,21 @@
-# Plugin reacting to events
+# Плагин, реагирующий на события
 
-Plugins can subscribe to the shared event bus (`frontend/src/shared/event-bus.js`) to react to editor actions.
+Плагины могут подписываться на общую шину событий (`frontend/src/shared/event-bus.js`), чтобы реагировать на действия редактора.
 
-See [glossary.md](glossary.md) for terminology definitions.
+Определения терминов см. в [glossary.md](glossary.md).
 
 ```js
 import { on } from '../src/shared/event-bus.js';
 
 export default function activate() {
   on('blockSelected', ({ id }) => {
-    console.log('Selected block:', id);
+    console.log('Выбран блок:', id);
   });
 
   on('metaUpdated', meta => {
-    console.log('Meta updated:', meta);
+    console.log('Метаданные обновлены:', meta);
   });
 }
 ```
 
-See [plugin-guide.md](plugin-guide.md) for general information on writing plugins.
+Общая информация по созданию плагинов: [plugin-guide.md](plugin-guide.md).

--- a/docs/layout-format.md
+++ b/docs/layout-format.md
@@ -1,10 +1,10 @@
-# Layout export format
+# Формат экспорта размещения
 
-The visual editor can save and restore its state through JSON.
+Визуальный редактор может сохранять и восстанавливать своё состояние в формате JSON.
 
-See [glossary.md](glossary.md) for terminology definitions. Use the **Export** and **Import** buttons in the interface or call the methods directly on `VisualCanvas`.
+Определения терминов см. в [glossary.md](glossary.md). Используйте кнопки **Export** и **Import** в интерфейсе или вызывайте методы напрямую у `VisualCanvas`.
 
-## JSON structure
+## Структура JSON
 
 ```json
 {
@@ -15,17 +15,17 @@ See [glossary.md](glossary.md) for terminology definitions. Use the **Export** a
 }
 ```
 
-- `blocks` — array of block metadata (`blocksData`).
-- `connections` — list of edges as pairs of block `visual_id`s.
-- `offset` — current pan offset of the canvas.
-- `scale` — zoom level.
+- `blocks` — массив метаданных блоков (`blocksData`).
+- `connections` — список связей в виде пар `visual_id` блоков.
+- `offset` — текущий сдвиг холста.
+- `scale` — коэффициент масштабирования холста.
 
-## Example
+## Пример
 
 ```js
-// Export current layout
+// Экспорт текущего размещения
 const json = JSON.stringify(vc.serialize(), null, 2);
 
-// Restore layout
+// Восстановление размещения
 vc.load(JSON.parse(json));
 ```

--- a/plugins/lsp/README.md
+++ b/plugins/lsp/README.md
@@ -1,28 +1,28 @@
-# Metadata LSP Prototype
+# Прототип LSP для метаданных
 
-This directory contains a prototype [Language Server Protocol](https://microsoft.github.io/language-server-protocol/) implementation. The server scans documents for metadata markers and exposes them to editors so they can be highlighted in other IDEs.
+Этот каталог содержит прототип реализации [Language Server Protocol](https://microsoft.github.io/language-server-protocol/). Сервер сканирует документы в поисках маркеров метаданных и передаёт их редакторам, чтобы они могли подсвечивать эти места в других IDE.
 
-## Running the server
+## Запуск сервера
 
 ```bash
 npm install
 npm start
 ```
 
-The server communicates over standard input/output and therefore can be embedded in any LSP‑aware editor.
+Сервер общается через стандартный ввод/вывод, поэтому его можно встроить в любой редактор, поддерживающий LSP.
 
-## Protocol
+## Протокол
 
-The server uses the standard LSP messages:
+Сервер использует стандартные сообщения LSP:
 
-* `initialize` – the client initializes the connection. The server replies with support for basic text document synchronization.
-* `textDocument/didOpen` and `textDocument/didChange` – whenever a document is opened or changed the server scans its contents for `meta:` markers.
-* `textDocument/publishDiagnostics` – for every occurrence of `meta:` the server publishes a diagnostic with severity `Hint`. Editors can use these diagnostics to highlight metadata ranges.
+* `initialize` — клиент инициирует соединение. В ответ сервер сообщает о поддержке базовой синхронизации текстовых документов.
+* `textDocument/didOpen` и `textDocument/didChange` — при открытии или изменении документа сервер ищет маркеры `meta:` в его содержимом.
+* `textDocument/publishDiagnostics` — для каждого найденного `meta:` сервер отправляет диагностическое сообщение с уровнем `Hint`. Редакторы могут использовать эти сообщения для подсветки диапазонов с метаданными.
 
-A metadata marker has the form:
+Маркер метаданных имеет вид:
 
 ```
-meta: description of the data
+meta: описание данных
 ```
 
-The text after `meta:` is included in the diagnostic message so an IDE can render it to the user.
+Текст после `meta:` включается в диагностическое сообщение, чтобы IDE могла показать его пользователю.


### PR DESCRIPTION
## Summary
- Translate node editor manual test scenarios into Russian
- Convert event bus and layout docs to Russian
- Localize metadata LSP README

## Testing
- `cargo fmt -- --check` *(fails: reported formatting diffs)*
- `cargo clippy -- -D warnings` *(aborted: compilation in progress)*
- `cargo test` *(aborted: compilation in progress)*
- `cargo audit` *(not installed, attempt to install aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68a361b99e3c8323aaaa8a145ac4b311