### PR TITLE
Use rfd for cross-platform folder picking

### DIFF
--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -11,3 +11,4 @@ directories = "5"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 multicode_core = { package = "core", path = "../core", features = ["git", "watch", "export"] }
+rfd = "0.15"

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -669,7 +669,12 @@ impl Application for MulticodeApp {
 }
 
 fn pick_folder() -> impl std::future::Future<Output = Option<PathBuf>> {
-    async { std::env::current_dir().ok() }
+    async {
+        tokio::task::spawn_blocking(|| rfd::FileDialog::new().pick_folder())
+            .await
+            .ok()
+            .flatten()
+    }
 }
 
 impl MulticodeApp {


### PR DESCRIPTION
## Summary
- Use `rfd::FileDialog` to open a native folder picker
- Add `rfd` dependency for desktop crate

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a3f96a145883238e3ee4b956cf2a3d