### PR TITLE
Add confirmation modal before file deletion

### DIFF
--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "MIT"
 
 [dependencies]
-iced = { version = "0.12", features = ["tokio"] }
+iced = { version = "0.12", features = ["tokio", "advanced"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "fs"] }
 directories = "5"
 serde = { version = "1", features = ["derive"] }

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -1,3 +1,5 @@
+mod modal;
+
 use iced::futures::stream;
 #[allow(unused_imports)]
 use iced::widget::overlay::menu as menu;
@@ -5,6 +7,7 @@ use iced::widget::{
     button, column, container, pick_list, row, scrollable, text, text_editor, text_input,
     MouseArea, Space,
 };
+use crate::modal::Modal;
 use iced::{
     alignment, event, keyboard, subscription, Application, Command, Element, Event, Length,
     Settings, Subscription, Theme,
@@ -479,7 +482,7 @@ impl Application for MulticodeApp {
                     return self.update(Message::RenameFile);
                 }
                 if hotkeys.delete_file.matches(&key, modifiers) {
-                    return self.update(Message::DeleteFile);
+                    return self.update(Message::RequestDeleteFile);
                 }
                 Command::none()
             }
@@ -1132,30 +1135,35 @@ impl Application for MulticodeApp {
 
                 let body = row![sidebar, content].spacing(10);
 
-                let delete_warning: Element<_> = if self.show_delete_confirm {
-                    row![
-                        text("Удалить выбранный файл?"),
-                        button("Да").on_press(Message::DeleteFile),
-                        button("Нет").on_press(Message::CancelDeleteFile)
-                    ]
-                    .spacing(5)
-                    .into()
-                } else {
-                    Space::with_width(Length::Shrink).into()
-                };
-
-                column![
+                let page = column![
                     menu,
                     mode_bar,
                     file_menu,
-                    delete_warning,
                     warning,
                     dirty_warning,
                     body,
                     text("Готово")
                 ]
-                .spacing(10)
-                .into()
+                .spacing(10);
+
+                if self.show_delete_confirm {
+                    let modal_content = container(
+                        column![
+                            text("Удалить выбранный файл?"),
+                            row![
+                                button("Да").on_press(Message::DeleteFile),
+                                button("Нет").on_press(Message::CancelDeleteFile)
+                            ]
+                            .spacing(5)
+                        ]
+                        .spacing(10),
+                    );
+                    Modal::new(page, modal_content)
+                        .on_blur(Message::CancelDeleteFile)
+                        .into()
+                } else {
+                    page.into()
+                }
             }
             Screen::VisualEditor { .. } => {
                 let settings_label = if self.settings.language == Language::Russian {
@@ -1263,30 +1271,35 @@ impl Application for MulticodeApp {
 
                 let body = row![sidebar, content].spacing(10);
 
-                let delete_warning: Element<_> = if self.show_delete_confirm {
-                    row![
-                        text("Удалить выбранный файл?"),
-                        button("Да").on_press(Message::DeleteFile),
-                        button("Нет").on_press(Message::CancelDeleteFile)
-                    ]
-                    .spacing(5)
-                    .into()
-                } else {
-                    Space::with_width(Length::Shrink).into()
-                };
-
-                column![
+                let page = column![
                     menu,
                     mode_bar,
                     file_menu,
-                    delete_warning,
                     warning,
                     dirty_warning,
                     body,
                     text("Готово")
                 ]
-                .spacing(10)
-                .into()
+                .spacing(10);
+
+                if self.show_delete_confirm {
+                    let modal_content = container(
+                        column![
+                            text("Удалить выбранный файл?"),
+                            row![
+                                button("Да").on_press(Message::DeleteFile),
+                                button("Нет").on_press(Message::CancelDeleteFile)
+                            ]
+                            .spacing(5)
+                        ]
+                        .spacing(10),
+                    );
+                    Modal::new(page, modal_content)
+                        .on_blur(Message::CancelDeleteFile)
+                        .into()
+                } else {
+                    page.into()
+                }
             }
             Screen::Settings => {
                 let hotkeys = &self.settings.hotkeys;

--- a/desktop/src/modal.rs
+++ b/desktop/src/modal.rs
@@ -1,0 +1,312 @@
+use iced::advanced::layout::{self, Layout};
+use iced::advanced::overlay;
+use iced::advanced::renderer;
+use iced::advanced::widget::{self, Widget};
+use iced::advanced::{self, Clipboard, Shell};
+use iced::alignment::Alignment;
+use iced::event;
+use iced::mouse;
+use iced::{Color, Element, Event, Length, Point, Rectangle, Size, Vector};
+
+/// A widget that centers a modal element over some base element
+pub struct Modal<'a, Message, Theme, Renderer> {
+    base: Element<'a, Message, Theme, Renderer>,
+    modal: Element<'a, Message, Theme, Renderer>,
+    on_blur: Option<Message>,
+}
+
+impl<'a, Message, Theme, Renderer> Modal<'a, Message, Theme, Renderer> {
+    /// Returns a new [`Modal`]
+    pub fn new(
+        base: impl Into<Element<'a, Message, Theme, Renderer>>,
+        modal: impl Into<Element<'a, Message, Theme, Renderer>>,
+    ) -> Self {
+        Self {
+            base: base.into(),
+            modal: modal.into(),
+            on_blur: None,
+        }
+    }
+
+    /// Sets the message that will be produced when the background
+    /// of the [`Modal`] is pressed
+    pub fn on_blur(self, on_blur: Message) -> Self {
+        Self {
+            on_blur: Some(on_blur),
+            ..self
+        }
+    }
+}
+
+impl<'a, Message, Theme, Renderer> Widget<Message, Theme, Renderer>
+    for Modal<'a, Message, Theme, Renderer>
+where
+    Renderer: advanced::Renderer,
+    Message: Clone,
+{
+    fn children(&self) -> Vec<widget::Tree> {
+        vec![
+            widget::Tree::new(&self.base),
+            widget::Tree::new(&self.modal),
+        ]
+    }
+
+    fn diff(&self, tree: &mut widget::Tree) {
+        tree.diff_children(&[&self.base, &self.modal]);
+    }
+
+    fn size(&self) -> Size<Length> {
+        self.base.as_widget().size()
+    }
+
+    fn layout(
+        &self,
+        tree: &mut widget::Tree,
+        renderer: &Renderer,
+        limits: &layout::Limits,
+    ) -> layout::Node {
+        self.base
+            .as_widget()
+            .layout(&mut tree.children[0], renderer, limits)
+    }
+
+    fn on_event(
+        &mut self,
+        state: &mut widget::Tree,
+        event: Event,
+        layout: Layout<'_>,
+        cursor: mouse::Cursor,
+        renderer: &Renderer,
+        clipboard: &mut dyn Clipboard,
+        shell: &mut Shell<'_, Message>,
+        viewport: &Rectangle,
+    ) -> event::Status {
+        self.base.as_widget_mut().on_event(
+            &mut state.children[0],
+            event,
+            layout,
+            cursor,
+            renderer,
+            clipboard,
+            shell,
+            viewport,
+        )
+    }
+
+    fn draw(
+        &self,
+        state: &widget::Tree,
+        renderer: &mut Renderer,
+        theme: &Theme,
+        style: &renderer::Style,
+        layout: Layout<'_>,
+        cursor: mouse::Cursor,
+        viewport: &Rectangle,
+    ) {
+        self.base.as_widget().draw(
+            &state.children[0],
+            renderer,
+            theme,
+            style,
+            layout,
+            cursor,
+            viewport,
+        );
+    }
+
+    fn overlay<'b>(
+        &'b mut self,
+        state: &'b mut widget::Tree,
+        layout: Layout<'_>,
+        _renderer: &Renderer,
+        translation: Vector,
+    ) -> Option<overlay::Element<'b, Message, Theme, Renderer>> {
+        Some(overlay::Element::new(Box::new(Overlay {
+            position: layout.position() + translation,
+            content: &mut self.modal,
+            tree: &mut state.children[1],
+            size: layout.bounds().size(),
+            on_blur: self.on_blur.clone(),
+        })))
+    }
+
+    fn mouse_interaction(
+        &self,
+        state: &widget::Tree,
+        layout: Layout<'_>,
+        cursor: mouse::Cursor,
+        viewport: &Rectangle,
+        renderer: &Renderer,
+    ) -> mouse::Interaction {
+        self.base.as_widget().mouse_interaction(
+            &state.children[0],
+            layout,
+            cursor,
+            viewport,
+            renderer,
+        )
+    }
+
+    fn operate(
+        &self,
+        state: &mut widget::Tree,
+        layout: Layout<'_>,
+        renderer: &Renderer,
+        operation: &mut dyn widget::Operation<Message>,
+    ) {
+        self.base.as_widget().operate(
+            &mut state.children[0],
+            layout,
+            renderer,
+            operation,
+        );
+    }
+}
+
+struct Overlay<'a, 'b, Message, Theme, Renderer> {
+    position: Point,
+    content: &'b mut Element<'a, Message, Theme, Renderer>,
+    tree: &'b mut widget::Tree,
+    size: Size,
+    on_blur: Option<Message>,
+}
+
+impl<'a, 'b, Message, Theme, Renderer> overlay::Overlay<Message, Theme, Renderer>
+    for Overlay<'a, 'b, Message, Theme, Renderer>
+where
+    Renderer: advanced::Renderer,
+    Message: Clone,
+{
+    fn layout(
+        &mut self,
+        renderer: &Renderer,
+        _bounds: Size,
+    ) -> layout::Node {
+        let limits = layout::Limits::new(Size::ZERO, self.size)
+            .width(Length::Fill)
+            .height(Length::Fill);
+
+        let child = self
+            .content
+            .as_widget()
+            .layout(self.tree, renderer, &limits)
+            .align(Alignment::Center, Alignment::Center, limits.max());
+
+        layout::Node::with_children(self.size, vec![child]).move_to(self.position)
+    }
+
+    fn on_event(
+        &mut self,
+        event: Event,
+        layout: Layout<'_>,
+        cursor: mouse::Cursor,
+        renderer: &Renderer,
+        clipboard: &mut dyn Clipboard,
+        shell: &mut Shell<'_, Message>,
+    ) -> event::Status {
+        let content_bounds = layout.children().next().unwrap().bounds();
+
+        if let Some(message) = self.on_blur.as_ref() {
+            if let Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left)) = &event {
+                if !cursor.is_over(content_bounds) {
+                    shell.publish(message.clone());
+                    return event::Status::Captured;
+                }
+            }
+        }
+
+        self.content.as_widget_mut().on_event(
+            self.tree,
+            event,
+            layout.children().next().unwrap(),
+            cursor,
+            renderer,
+            clipboard,
+            shell,
+            &layout.bounds(),
+        )
+    }
+
+    fn draw(
+        &self,
+        renderer: &mut Renderer,
+        theme: &Theme,
+        style: &renderer::Style,
+        layout: Layout<'_>,
+        cursor: mouse::Cursor,
+    ) {
+        renderer.fill_quad(
+            renderer::Quad {
+                bounds: layout.bounds(),
+                ..renderer::Quad::default()
+            },
+            Color {
+                a: 0.80,
+                ..Color::BLACK
+            },
+        );
+
+        self.content.as_widget().draw(
+            self.tree,
+            renderer,
+            theme,
+            style,
+            layout.children().next().unwrap(),
+            cursor,
+            &layout.bounds(),
+        );
+    }
+
+    fn operate(
+        &mut self,
+        layout: Layout<'_>,
+        renderer: &Renderer,
+        operation: &mut dyn widget::Operation<Message>,
+    ) {
+        self.content.as_widget().operate(
+            self.tree,
+            layout.children().next().unwrap(),
+            renderer,
+            operation,
+        );
+    }
+
+    fn mouse_interaction(
+        &self,
+        layout: Layout<'_>,
+        cursor: mouse::Cursor,
+        viewport: &Rectangle,
+        renderer: &Renderer,
+    ) -> mouse::Interaction {
+        self.content.as_widget().mouse_interaction(
+            self.tree,
+            layout.children().next().unwrap(),
+            cursor,
+            viewport,
+            renderer,
+        )
+    }
+
+    fn overlay<'c>(
+        &'c mut self,
+        layout: Layout<'_>,
+        renderer: &Renderer,
+    ) -> Option<overlay::Element<'c, Message, Theme, Renderer>> {
+        self.content
+            .as_widget_mut()
+            .overlay(self.tree, layout.children().next().unwrap(), renderer, Vector::ZERO)
+    }
+}
+
+impl<'a, Message, Theme, Renderer> From<Modal<'a, Message, Theme, Renderer>>
+    for Element<'a, Message, Theme, Renderer>
+where
+    Theme: 'a,
+    Message: 'a + Clone,
+    Renderer: 'a + advanced::Renderer,
+{
+    fn from(modal: Modal<'a, Message, Theme, Renderer>) -> Self {
+        Element::new(modal)
+    }
+}
+


### PR DESCRIPTION
## Summary
- add modal overlay to confirm file deletion
- ensure delete hotkey asks for confirmation first

## Testing
- `cargo test -p desktop`


------
https://chatgpt.com/codex/tasks/task_e_68a43fdc618c8323afd550ecf9b08333