### PR TITLE
refactor: modular canvas utilities

### DIFF
--- a/archived/frontend/src/visual/canvas/blocks.js
+++ b/archived/frontend/src/visual/canvas/blocks.js
@@ -1,0 +1,22 @@
+export function addBlock(state, block) {
+  if (!block || typeof block.id !== 'string') {
+    throw new TypeError('block.id string required');
+  }
+  state.blocks.push(block);
+  return block;
+}
+
+export function removeBlock(state, id) {
+  const idx = state.blocks.findIndex(b => b.id === id);
+  if (idx === -1) throw new Error('block not found');
+  return state.blocks.splice(idx, 1)[0];
+}
+
+export function diffBlocks(a, b) {
+  if (!a || !b) throw new TypeError('two blocks required');
+  const diff = {};
+  for (const key of ['id', 'x', 'y', 'w', 'h']) {
+    if (a[key] !== b[key]) diff[key] = { from: a[key], to: b[key] };
+  }
+  return diff;
+}

--- a/archived/frontend/src/visual/canvas/canvas.js
+++ b/archived/frontend/src/visual/canvas/canvas.js
@@ -1,0 +1,29 @@
+import { initCanvas } from './init.js';
+import { attachEventHandlers } from './events.js';
+import { addBlock, removeBlock, diffBlocks } from './blocks.js';
+import { drawBlock, clearCanvas } from './helpers.js';
+
+export {
+  initCanvas,
+  attachEventHandlers,
+  addBlock,
+  removeBlock,
+  diffBlocks,
+  drawBlock,
+  clearCanvas
+};
+
+export function createCanvasApp(canvas) {
+  const { ctx, state } = initCanvas(canvas);
+  attachEventHandlers(canvas, state);
+  return {
+    canvas,
+    ctx,
+    state,
+    addBlock: block => addBlock(state, block),
+    removeBlock: id => removeBlock(state, id),
+    diffBlocks,
+    drawBlock: block => drawBlock(ctx, block),
+    clear: () => clearCanvas(canvas, ctx)
+  };
+}

--- a/archived/frontend/src/visual/canvas/canvas.test.js
+++ b/archived/frontend/src/visual/canvas/canvas.test.js
@@ -1,0 +1,79 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import {
+  initCanvas,
+  attachEventHandlers,
+  addBlock,
+  removeBlock,
+  diffBlocks,
+  drawBlock,
+  createCanvasApp
+} from './canvas.js';
+
+class MockCanvas {
+  constructor() {
+    this.width = 100;
+    this.height = 100;
+    this.listeners = {};
+    this.ctx = {
+      fillRect: () => { this.fillCalled = true; },
+      clearRect: () => { this.clearCalled = true; }
+    };
+  }
+  getContext() { return this.ctx; }
+  addEventListener(type, handler) { this.listeners[type] = handler; }
+  removeEventListener(type) { delete this.listeners[type]; }
+  dispatchEvent(ev) { const h = this.listeners[ev.type]; if (h) h(ev); }
+}
+
+test('initCanvas validates input', () => {
+  assert.throws(() => initCanvas({}), /getContext/);
+  const canvas = new MockCanvas();
+  const { state } = initCanvas(canvas);
+  assert.deepStrictEqual(state.blocks, []);
+});
+
+test('event handlers record events', () => {
+  const canvas = new MockCanvas();
+  const { state } = initCanvas(canvas);
+  attachEventHandlers(canvas, state);
+  canvas.dispatchEvent({ type: 'mousedown' });
+  canvas.dispatchEvent({ type: 'keydown' });
+  assert.strictEqual(state.events.length, 2);
+});
+
+test('block operations validate input', () => {
+  const state = { blocks: [] };
+  assert.throws(() => addBlock(state, {}), /block.id/);
+  addBlock(state, { id: 'a', x:0, y:0, w:1, h:1 });
+  assert.strictEqual(state.blocks.length, 1);
+  const removed = removeBlock(state, 'a');
+  assert.strictEqual(removed.id, 'a');
+  assert.strictEqual(state.blocks.length, 0);
+  assert.throws(() => removeBlock(state, 'missing'), /block not found/);
+});
+
+test('diffBlocks reports changes', () => {
+  const a = { id: 'a', x: 0, y: 0, w: 1, h: 1 };
+  const b = { id: 'a', x: 5, y: 0, w: 1, h: 1 };
+  const diff = diffBlocks(a, b);
+  assert.deepStrictEqual(diff, { x: { from: 0, to: 5 } });
+});
+
+test('drawBlock uses canvas context', () => {
+  const canvas = new MockCanvas();
+  const { ctx } = initCanvas(canvas);
+  drawBlock(ctx, { x: 1, y: 2, w: 3, h: 4 });
+  assert.ok(canvas.fillCalled);
+});
+
+test('createCanvasApp wires modules together', () => {
+  const canvas = new MockCanvas();
+  const app = createCanvasApp(canvas);
+  app.addBlock({ id: 'x', x:0, y:0, w:1, h:1 });
+  assert.strictEqual(app.state.blocks.length, 1);
+  canvas.dispatchEvent({ type: 'mousedown' });
+  assert.strictEqual(app.state.events.length, 1);
+  app.clear();
+  assert.ok(canvas.clearCalled);
+});

--- a/archived/frontend/src/visual/canvas/events.js
+++ b/archived/frontend/src/visual/canvas/events.js
@@ -1,0 +1,15 @@
+export function attachEventHandlers(canvas, state) {
+  if (!canvas || typeof canvas.addEventListener !== 'function') {
+    throw new TypeError('A valid canvas with event support is required');
+  }
+  const onMouse = e => state.events.push({ type: e.type });
+  const onKey = e => state.events.push({ type: e.type });
+  canvas.addEventListener('mousedown', onMouse);
+  canvas.addEventListener('keydown', onKey);
+  return {
+    detach() {
+      canvas.removeEventListener('mousedown', onMouse);
+      canvas.removeEventListener('keydown', onKey);
+    }
+  };
+}

--- a/archived/frontend/src/visual/canvas/helpers.js
+++ b/archived/frontend/src/visual/canvas/helpers.js
@@ -1,0 +1,11 @@
+export function drawBlock(ctx, block) {
+  if (!ctx || typeof ctx.fillRect !== 'function') {
+    throw new TypeError('ctx with fillRect() required');
+  }
+  if (!block) throw new TypeError('block required');
+  ctx.fillRect(block.x, block.y, block.w, block.h);
+}
+
+export function clearCanvas(canvas, ctx) {
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+}

--- a/archived/frontend/src/visual/canvas/init.js
+++ b/archived/frontend/src/visual/canvas/init.js
@@ -1,0 +1,8 @@
+export function initCanvas(canvas) {
+  if (!canvas || typeof canvas.getContext !== 'function') {
+    throw new TypeError('A canvas with getContext() is required');
+  }
+  const ctx = canvas.getContext('2d');
+  const state = { blocks: [], events: [] };
+  return { canvas, ctx, state };
+}

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "dev": "cargo run",
     "build": "cargo build",
     "test": "cargo test",
+    "test:canvas": "node --test archived/frontend/src/visual/canvas/canvas.test.js",
     "clean": "cargo clean",
     "check:scripts": "node scripts/check-scripts.js",
     "check-env": "node scripts/check-env.js"


### PR DESCRIPTION
## Summary
- split canvas logic into modules for init, events, blocks and visuals
- expose unified entry point and basic app helper
- add node-based tests and npm script

## Testing
- `npm run test:canvas`
- `npm test` *(fails: compilation aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68a466ed25408323b8c15be52e1fd5d5