### PR TITLE
Add syntax highlighting and basic editor tools

### DIFF
--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -12,3 +12,6 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 multicode_core = { package = "core", path = "../core", features = ["git", "watch", "export"] }
 rfd = "0.15"
+syntect = "5"
+once_cell = "1"
+chrono = { version = "0.4", default-features = false, features = ["clock"] }

--- a/desktop/src/app/events/message.rs
+++ b/desktop/src/app/events/message.rs
@@ -16,6 +16,8 @@ pub enum Message {
     ReplaceTermChanged(String),
     Find,
     ReplaceAll,
+    AutoComplete,
+    AutoFormat,
     SaveFile,
     FileSaved(Result<(), String>),
     NewFileNameChanged(String),

--- a/desktop/src/app/mod.rs
+++ b/desktop/src/app/mod.rs
@@ -503,7 +503,18 @@ impl Application for MulticodeApp {
                 let visual_btn: Element<_> = button("Visual")
                     .on_press(Message::SwitchToVisualEditor)
                     .into();
-                let mode_bar = row![text_btn, visual_btn, save_btn].spacing(5);
+                let autocomplete_btn: Element<_> = if self.active_file.is_some() {
+                    button("Автодополнить").on_press(Message::AutoComplete).into()
+                } else {
+                    button("Автодополнить").into()
+                };
+                let format_btn: Element<_> = if self.active_file.is_some() {
+                    button("Форматировать").on_press(Message::AutoFormat).into()
+                } else {
+                    button("Форматировать").into()
+                };
+                let mode_bar =
+                    row![text_btn, visual_btn, save_btn, autocomplete_btn, format_btn].spacing(5);
 
                 let create_select = pick_list(
                     &CreateTarget::ALL[..],


### PR DESCRIPTION
## Summary
- integrate syntect-based highlighter to render file contents with syntax colors
- add simple autocomplete and autoformat actions driven by core parsers
- insert visual meta comments on save via core::meta

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68a479c8b0948323ae09cbe1ef342a8f