### PR TITLE
Remove CLI argument parsing from desktop app

### DIFF
--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -15,4 +15,3 @@ rfd = "0.15"
 syntect = "5"
 once_cell = "1"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
-clap = { version = "4", features = ["derive"] }

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -1,23 +1,6 @@
 mod app;
 mod modal;
 
-use clap::Parser;
-use std::path::PathBuf;
-
-#[derive(Parser)]
-struct Args {
-    #[arg(long)]
-    file: Option<PathBuf>,
-    #[arg(long)]
-    project: Option<PathBuf>,
-}
-
 pub fn main() -> iced::Result {
-    let args = Args::parse();
-    let path = if let Some(file) = args.file {
-        file.parent().map(|p| p.to_path_buf())
-    } else {
-        args.project
-    };
-    app::run(path)
+    app::run(None)
 }


### PR DESCRIPTION
## Summary
- drop clap dependency from desktop
- start desktop app without CLI arguments

## Testing
- `cargo check -p desktop`


------
https://chatgpt.com/codex/tasks/task_e_68a48fab70c08323a6214917e2f9fe20