### PR TITLE
Add file picker support to desktop project picker

### DIFF
--- a/desktop/src/app/events/message.rs
+++ b/desktop/src/app/events/message.rs
@@ -7,6 +7,8 @@ use crate::app::{AppTheme, CreateTarget, HotkeyField, Language, FileEntry};
 pub enum Message {
     PickFolder,
     FolderPicked(Option<PathBuf>),
+    PickFile,
+    FilePicked(Option<PathBuf>),
     FilesLoaded(Vec<FileEntry>),
     QueryChanged(String),
     SelectFile(PathBuf),

--- a/desktop/src/app/io.rs
+++ b/desktop/src/app/io.rs
@@ -14,6 +14,15 @@ pub fn pick_folder() -> impl std::future::Future<Output = Option<PathBuf>> {
     }
 }
 
+pub fn pick_file() -> impl std::future::Future<Output = Option<PathBuf>> {
+    async {
+        task::spawn_blocking(|| rfd::FileDialog::new().pick_file())
+            .await
+            .ok()
+            .flatten()
+    }
+}
+
 impl MulticodeApp {
     pub fn load_files(&self, root: PathBuf) -> Command<Message> {
         Command::perform(

--- a/desktop/src/app/mod.rs
+++ b/desktop/src/app/mod.rs
@@ -429,6 +429,7 @@ impl Application for MulticodeApp {
                 let content = column![
                     text("Выберите папку проекта"),
                     button("Выбрать папку").on_press(Message::PickFolder),
+                    button("Выбрать файл").on_press(Message::PickFile),
                     button(settings_label).on_press(Message::OpenSettings),
                 ]
                 .align_items(alignment::Alignment::Center)


### PR DESCRIPTION
## Summary
- allow picking individual project file using new `PickFile`/`FilePicked` messages
- implement `pick_file` helper using `rfd::FileDialog::pick_file`
- handle file pick to open the project and selected file
- add "Выбрать файл" button in ProjectPicker view

## Testing
- `cargo check -p desktop`


------
https://chatgpt.com/codex/tasks/task_e_68a4922fa1c483239eb9a68472a5345c