### PR TITLE
Add desktop start npm script and update docs

### DIFF
--- a/README-desktop.md
+++ b/README-desktop.md
@@ -25,6 +25,8 @@
 3. Запустите приложение:
 
    ```sh
+   npm run desktop:start
+   # или напрямую через Cargo
    cargo run -p desktop
    ```
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,8 @@ pacman -S --noconfirm mingw-w64-x86_64-gtk3 pkg-config
 ## Быстрый старт
 
 ```bash
-cargo run -p desktop                  # запуск приложения
+npm run desktop:start                 # запуск приложения
+cargo run -p desktop                  # запуск приложения без npm
 cargo test -p core                    # тесты ядра
 cargo build --release -p desktop      # релизная сборка
 ```

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "setup": "node scripts/setup.js",
     "dev": "cargo run",
+    "desktop:start": "cargo run -p desktop",
     "build": "cargo build",
     "test": "cargo test",
     "test:canvas": "node --test archived/frontend/src/visual/canvas/canvas.test.js",


### PR DESCRIPTION
## Summary
- add `desktop:start` npm script to launch desktop package
- document npm-based desktop start in root and desktop READMEs

## Testing
- `npm test`
- `npm run desktop:start -- --help`


------
https://chatgpt.com/codex/tasks/task_e_68a49ca43f3483238c11bafdf3709e40