### PR TITLE
feat(desktop): add optional line numbers

### DIFF
--- a/desktop/src/app/events/handler.rs
+++ b/desktop/src/app/events/handler.rs
@@ -89,6 +89,10 @@ impl MulticodeApp {
                 self.settings.language = lang;
                 Command::none()
             }
+            Message::ToggleLineNumbers(value) => {
+                self.settings.show_line_numbers = value;
+                Command::none()
+            }
             Message::StartCaptureHotkey(field) => {
                 self.hotkey_capture = Some(field);
                 Command::none()

--- a/desktop/src/app/events/message.rs
+++ b/desktop/src/app/events/message.rs
@@ -61,6 +61,7 @@ pub enum Message {
     CancelDiscard,
     ThemeSelected(AppTheme),
     LanguageSelected(Language),
+    ToggleLineNumbers(bool),
     StartCaptureHotkey(HotkeyField),
     SwitchToTextEditor,
     SwitchToVisualEditor,

--- a/desktop/src/app/mod.rs
+++ b/desktop/src/app/mod.rs
@@ -6,8 +6,8 @@ use crate::modal::Modal;
 use events::Message;
 use iced::futures::stream;
 use iced::widget::{
-    button, column, container, pick_list, row, scrollable, text, text_editor, text_input,
-    MouseArea, Space,
+    button, checkbox, column, container, pick_list, row, scrollable, text, text_editor,
+    text_input, Space,
 };
 use iced::{
     alignment, event, keyboard, subscription, Application, Color, Command, Element, Event, Length,
@@ -282,6 +282,8 @@ struct UserSettings {
     theme: AppTheme,
     #[serde(default)]
     language: Language,
+    #[serde(default)]
+    show_line_numbers: bool,
 }
 
 impl Default for UserSettings {
@@ -292,6 +294,7 @@ impl Default for UserSettings {
             editor_mode: EditorMode::Text,
             theme: AppTheme::default(),
             language: Language::default(),
+            show_line_numbers: true,
         }
     }
 }
@@ -848,6 +851,12 @@ impl Application for MulticodeApp {
                             Some(self.settings.language),
                             Message::LanguageSelected
                         )
+                    ]
+                    .spacing(10),
+                    row![
+                        text("Номера строк"),
+                        checkbox("", self.settings.show_line_numbers)
+                            .on_toggle(Message::ToggleLineNumbers)
                     ]
                     .spacing(10),
                     row![

--- a/desktop/src/app/ui.rs
+++ b/desktop/src/app/ui.rs
@@ -135,16 +135,34 @@ impl MulticodeApp {
                 extension: ext,
                 matches: self.search_results.clone(),
             };
-            text_editor(&file.editor)
+            let editor = text_editor(&file.editor)
                 .highlight::<SyntectHighlighter>(settings, |c, _| {
                     highlighter::Format {
                         color: Some(*c),
                         font: None,
                     }
                 })
-                .on_action(Message::FileContentEdited)
+                .on_action(Message::FileContentEdited);
+
+            if self.settings.show_line_numbers {
+                let lines = column(
+                    (1..=file.editor.line_count())
+                        .map(|i| text(i.to_string()).into())
+                        .collect::<Vec<Element<Message>>>()
+                );
+
+                scrollable(
+                    row![
+                        container(lines).width(Length::Shrink),
+                        editor.height(Length::Shrink)
+                    ]
+                    .spacing(5)
+                )
                 .height(Length::Fill)
                 .into()
+            } else {
+                editor.height(Length::Fill).into()
+            }
         } else {
             container(text("файл не выбран"))
                 .width(Length::Fill)


### PR DESCRIPTION
## Summary
- show line numbers next to text editor
- allow toggling line numbers in settings

## Testing
- `cargo test -p desktop`


------
https://chatgpt.com/codex/tasks/task_e_68a4a1073d548323bcfb0d680f41bc50