### PR TITLE
Add configurable status bar

### DIFF
--- a/desktop/src/app/events/handler.rs
+++ b/desktop/src/app/events/handler.rs
@@ -93,6 +93,10 @@ impl MulticodeApp {
                 self.settings.show_line_numbers = value;
                 Command::none()
             }
+            Message::ToggleStatusBar(value) => {
+                self.settings.show_status_bar = value;
+                Command::none()
+            }
             Message::StartCaptureHotkey(field) => {
                 self.hotkey_capture = Some(field);
                 Command::none()
@@ -279,9 +283,12 @@ impl MulticodeApp {
             }
             Message::FileContentEdited(action) => {
                 if let Some(f) = self.current_file_mut() {
+                    let is_edit = action.is_edit();
                     f.editor.perform(action);
                     f.content = f.editor.text();
-                    f.dirty = true;
+                    if is_edit {
+                        f.dirty = true;
+                    }
                 }
                 Command::none()
             }

--- a/desktop/src/app/events/message.rs
+++ b/desktop/src/app/events/message.rs
@@ -62,6 +62,7 @@ pub enum Message {
     ThemeSelected(AppTheme),
     LanguageSelected(Language),
     ToggleLineNumbers(bool),
+    ToggleStatusBar(bool),
     StartCaptureHotkey(HotkeyField),
     SwitchToTextEditor,
     SwitchToVisualEditor,

--- a/desktop/src/app/mod.rs
+++ b/desktop/src/app/mod.rs
@@ -284,6 +284,8 @@ struct UserSettings {
     language: Language,
     #[serde(default)]
     show_line_numbers: bool,
+    #[serde(default)]
+    show_status_bar: bool,
 }
 
 impl Default for UserSettings {
@@ -295,6 +297,7 @@ impl Default for UserSettings {
             theme: AppTheme::default(),
             language: Language::default(),
             show_line_numbers: true,
+            show_status_bar: true,
         }
     }
 }
@@ -614,7 +617,7 @@ impl Application for MulticodeApp {
                     warning,
                     dirty_warning,
                     body,
-                    text("Готово")
+                    self.status_bar_component()
                 ]
                 .spacing(10);
 
@@ -783,7 +786,7 @@ impl Application for MulticodeApp {
                     warning,
                     dirty_warning,
                     body,
-                    text("Готово")
+                    self.status_bar_component()
                 ]
                 .spacing(10);
 
@@ -857,6 +860,12 @@ impl Application for MulticodeApp {
                         text("Номера строк"),
                         checkbox("", self.settings.show_line_numbers)
                             .on_toggle(Message::ToggleLineNumbers)
+                    ]
+                    .spacing(10),
+                    row![
+                        text("Статус-бар"),
+                        checkbox("", self.settings.show_status_bar)
+                            .on_toggle(Message::ToggleStatusBar),
                     ]
                     .spacing(10),
                     row![

--- a/desktop/src/app/ui.rs
+++ b/desktop/src/app/ui.rs
@@ -233,6 +233,30 @@ impl MulticodeApp {
     pub fn file_tree(&self) -> Element<Message> {
         scrollable(self.view_entries(&self.files, 0)).into()
     }
+
+    pub fn status_bar_component(&self) -> Element<Message> {
+        if !self.settings.show_status_bar {
+            return Space::with_height(Length::Shrink).into();
+        }
+        if let Some(file) = self.current_file() {
+            let (line, column) = file.editor.cursor_position();
+            let path = file.path.to_string_lossy().to_string();
+            let dirty = if file.dirty { "*" } else { "" };
+            container(
+                row![
+                    text(path).width(Length::Fill),
+                    text(format!("{}:{}", line + 1, column + 1)),
+                    text(dirty)
+                ]
+                .spacing(10)
+            )
+            .width(Length::Fill)
+            .padding(5)
+            .into()
+        } else {
+            Space::with_height(Length::Shrink).into()
+        }
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- Add status bar showing file path, cursor location and dirty flag
- Expose checkbox in settings to toggle the new status bar
- Track cursor edits without marking file dirty on navigation

## Testing
- `cargo test -p desktop`

------
https://chatgpt.com/codex/tasks/task_e_68a4a934f7b08323bbecf5fc1fea6db7