### PR TITLE
feat: add selectable syntect theme

### DIFF
--- a/desktop/src/app/events/handler.rs
+++ b/desktop/src/app/events/handler.rs
@@ -90,6 +90,10 @@ impl MulticodeApp {
                 self.settings.theme = theme;
                 Command::none()
             }
+            Message::SyntectThemeSelected(theme) => {
+                self.settings.syntect_theme = theme;
+                Command::none()
+            }
             Message::LanguageSelected(lang) => {
                 self.settings.language = lang;
                 Command::none()

--- a/desktop/src/app/events/message.rs
+++ b/desktop/src/app/events/message.rs
@@ -64,6 +64,7 @@ pub enum Message {
     ConfirmDiscard,
     CancelDiscard,
     ThemeSelected(AppTheme),
+    SyntectThemeSelected(String),
     LanguageSelected(Language),
     ToggleLineNumbers(bool),
     ToggleStatusBar(bool),

--- a/desktop/src/app/mod.rs
+++ b/desktop/src/app/mod.rs
@@ -14,7 +14,7 @@ use iced::{
     Subscription, Theme,
 };
 use tokio::{fs, sync::broadcast};
-use ui::ContextMenu;
+use ui::{ContextMenu, THEME_SET};
 
 use directories::ProjectDirs;
 use serde::{Deserialize, Serialize};
@@ -274,6 +274,10 @@ impl fmt::Display for Language {
     }
 }
 
+fn default_syntect_theme() -> String {
+    "InspiredGitHub".into()
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct UserSettings {
     last_folder: Option<PathBuf>,
@@ -283,6 +287,8 @@ struct UserSettings {
     editor_mode: EditorMode,
     #[serde(default)]
     theme: AppTheme,
+    #[serde(default = "default_syntect_theme")]
+    syntect_theme: String,
     #[serde(default)]
     language: Language,
     #[serde(default)]
@@ -300,6 +306,7 @@ impl Default for UserSettings {
             hotkeys: Hotkeys::default(),
             editor_mode: EditorMode::Text,
             theme: AppTheme::default(),
+            syntect_theme: default_syntect_theme(),
             language: Language::default(),
             show_line_numbers: true,
             show_status_bar: true,
@@ -832,6 +839,8 @@ impl Application for MulticodeApp {
                 } else {
                     hotkeys.delete_file.to_string()
                 };
+                let syntect_themes: Vec<String> =
+                    THEME_SET.themes.keys().cloned().collect();
                 let warning: Element<_> = if let Some(w) = &self.settings_warning {
                     text(w.clone()).into()
                 } else {
@@ -845,6 +854,15 @@ impl Application for MulticodeApp {
                             &AppTheme::ALL[..],
                             Some(self.settings.theme),
                             Message::ThemeSelected
+                        )
+                    ]
+                    .spacing(10),
+                    row![
+                        text("Тема подсветки"),
+                        pick_list(
+                            syntect_themes.clone(),
+                            Some(self.settings.syntect_theme.clone()),
+                            Message::SyntectThemeSelected
                         )
                     ]
                     .spacing(10),

--- a/desktop/src/app/ui.rs
+++ b/desktop/src/app/ui.rs
@@ -51,7 +51,7 @@ impl ToString for ContextMenuItem {
 }
 
 static SYNTAX_SET: Lazy<SyntaxSet> = Lazy::new(SyntaxSet::load_defaults_newlines);
-static THEME_SET: Lazy<ThemeSet> = Lazy::new(ThemeSet::load_defaults);
+pub static THEME_SET: Lazy<ThemeSet> = Lazy::new(ThemeSet::load_defaults);
 
 const OPEN_ICON: &[u8] = include_bytes!("../../assets/open.svg");
 const SAVE_ICON: &[u8] = include_bytes!("../../assets/save.svg");
@@ -62,6 +62,7 @@ const AUTOCOMPLETE_ICON: &[u8] = include_bytes!("../../assets/autocomplete.svg")
 pub struct SyntaxSettings {
     pub extension: String,
     pub matches: Vec<(usize, Range<usize>)>,
+    pub theme: String,
 }
 
 pub struct SyntectHighlighter {
@@ -79,7 +80,10 @@ impl Highlighter for SyntectHighlighter {
         let syntax = SYNTAX_SET
             .find_syntax_by_extension(&settings.extension)
             .unwrap_or_else(|| SYNTAX_SET.find_syntax_plain_text());
-        let theme = &THEME_SET.themes["InspiredGitHub"];
+        let theme = THEME_SET
+            .themes
+            .get(&settings.theme)
+            .unwrap_or(&THEME_SET.themes["InspiredGitHub"]);
         Self {
             settings: settings.clone(),
             highlighter: HighlightLines::new(syntax, theme),
@@ -91,7 +95,10 @@ impl Highlighter for SyntectHighlighter {
         let syntax = SYNTAX_SET
             .find_syntax_by_extension(&new_settings.extension)
             .unwrap_or_else(|| SYNTAX_SET.find_syntax_plain_text());
-        let theme = &THEME_SET.themes["InspiredGitHub"];
+        let theme = THEME_SET
+            .themes
+            .get(&new_settings.theme)
+            .unwrap_or(&THEME_SET.themes["InspiredGitHub"]);
         self.highlighter = HighlightLines::new(syntax, theme);
         self.settings = new_settings.clone();
         self.current_line = 0;
@@ -160,6 +167,7 @@ impl MulticodeApp {
             let settings = SyntaxSettings {
                 extension: ext,
                 matches: self.search_results.clone(),
+                theme: self.settings.syntect_theme.clone(),
             };
             let editor = text_editor(&file.editor)
                 .highlight::<SyntectHighlighter>(settings, |c, _| highlighter::Format {


### PR DESCRIPTION
## Summary
- allow users to choose syntax highlighting theme in settings
- store chosen syntect theme in user settings
- apply selected theme to text editor highlighting

## Testing
- `cargo test -p desktop`

------
https://chatgpt.com/codex/tasks/task_e_68a4c07ea6b08323b8ff40a222c6dad4