### PR TITLE
Display recent project directories in picker

### DIFF
--- a/desktop/src/app/events/message.rs
+++ b/desktop/src/app/events/message.rs
@@ -9,6 +9,7 @@ pub enum Message {
     FolderPicked(Option<PathBuf>),
     PickFile,
     FilePicked(Option<PathBuf>),
+    OpenRecent(PathBuf),
     FilesLoaded(Vec<FileEntry>),
     QueryChanged(String),
     SelectFile(PathBuf),


### PR DESCRIPTION
## Summary
- store a list of recent project paths in user settings
- show recent directories with **Open** buttons on ProjectPicker screen
- update and cap recent list each time a project is opened

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a4ca458f2c8323a36fd443e0b26771