### PR TITLE
feat: add diff view to desktop

### DIFF
--- a/desktop/src/app/events/message.rs
+++ b/desktop/src/app/events/message.rs
@@ -77,4 +77,6 @@ pub enum Message {
     TerminalCmdChanged(String),
     RunTerminalCmd(String),
     ShowTerminalHelp,
+    OpenDiff(PathBuf, PathBuf),
+    OpenGitDiff(PathBuf, String),
 }

--- a/desktop/src/app/mod.rs
+++ b/desktop/src/app/mod.rs
@@ -1,8 +1,10 @@
 pub mod events;
 pub mod io;
 pub mod ui;
+pub mod diff;
 
 use crate::modal::Modal;
+use diff::DiffView;
 use events::Message;
 use iced::futures::stream;
 use iced::widget::{
@@ -82,6 +84,7 @@ pub enum Screen {
     ProjectPicker,
     TextEditor { root: PathBuf },
     VisualEditor { root: PathBuf },
+    Diff(DiffView),
     Settings,
 }
 
@@ -978,6 +981,12 @@ impl Application for MulticodeApp {
                     .center_y()
                     .into()
             }
+            Screen::Diff(diff) => {
+                container(self.diff_component(diff))
+                    .width(Length::Fill)
+                    .height(Length::Fill)
+                    .into()
+            }
         }
     }
 }
@@ -1008,6 +1017,7 @@ impl MulticodeApp {
     fn current_root_path(&self) -> Option<PathBuf> {
         match &self.screen {
             Screen::TextEditor { root } | Screen::VisualEditor { root } => Some(root.clone()),
+            Screen::Diff(_) => self.settings.last_folders.first().cloned(),
             Screen::ProjectPicker => None,
             Screen::Settings => self.settings.last_folders.first().cloned(),
         }

--- a/desktop/src/app/ui.rs
+++ b/desktop/src/app/ui.rs
@@ -14,6 +14,7 @@ use syntect::easy::HighlightLines;
 use syntect::highlighting::ThemeSet;
 use syntect::parsing::SyntaxSet;
 
+use crate::app::diff::DiffView;
 use crate::app::events::Message;
 use crate::app::{EntryType, FileEntry, MulticodeApp};
 
@@ -242,6 +243,10 @@ impl MulticodeApp {
                 .height(Length::Fill)
                 .into()
         }
+    }
+
+    pub fn diff_component(&self, diff: &DiffView) -> Element<Message> {
+        diff.view()
     }
 
     pub fn visual_editor_component(&self) -> Element<Message> {


### PR DESCRIPTION
## Summary
- add diff module to view two files side by side with line diff highlighting
- handle OpenDiff and OpenGitDiff messages to load file contents and show diff view
- wire up UI and screen variants for DiffView

## Testing
- `cargo test -p desktop`


------
https://chatgpt.com/codex/tasks/task_e_68a4fa58f1408323b3bbf22681d71861