### PR TITLE
Handle diff loading errors and surface failures

### DIFF
--- a/desktop/src/app/events/handler.rs
+++ b/desktop/src/app/events/handler.rs
@@ -831,28 +831,64 @@ impl MulticodeApp {
                 Command::none()
             }
             Message::OpenDiff(left, right, ignore_ws) => {
-                let left_content = std::fs::read_to_string(&left).unwrap_or_default();
-                let right_content = std::fs::read_to_string(&right).unwrap_or_default();
+                let left_content = match std::fs::read_to_string(&left) {
+                    Ok(c) => c,
+                    Err(e) => {
+                        return self.handle_message(Message::DiffError(format!(
+                            "{}: {}",
+                            left.display(),
+                            e
+                        )))
+                    }
+                };
+                let right_content = match std::fs::read_to_string(&right) {
+                    Ok(c) => c,
+                    Err(e) => {
+                        return self.handle_message(Message::DiffError(format!(
+                            "{}: {}",
+                            right.display(),
+                            e
+                        )))
+                    }
+                };
                 let diff = DiffView::new(left_content, right_content, ignore_ws);
                 self.screen = Screen::Diff(diff);
                 Command::none()
             }
             Message::OpenGitDiff(path, commit, ignore_ws) => {
-                let current = std::fs::read_to_string(&path).unwrap_or_default();
+                let current = match std::fs::read_to_string(&path) {
+                    Ok(c) => c,
+                    Err(e) => {
+                        return self.handle_message(Message::DiffError(format!(
+                            "{}: {}",
+                            path.display(),
+                            e
+                        )))
+                    }
+                };
                 let rel = if let Some(root) = self.current_root_path() {
                     path.strip_prefix(root).unwrap_or(&path).to_path_buf()
                 } else {
                     path.clone()
                 };
                 let spec = format!("{commit}:{}", rel.to_string_lossy());
-                if let Ok(out) = std::process::Command::new("git")
+                match std::process::Command::new("git")
                     .arg("show")
                     .arg(spec)
                     .output()
                 {
-                    let prev = String::from_utf8_lossy(&out.stdout).to_string();
-                    let diff = DiffView::new(prev, current, ignore_ws);
-                    self.screen = Screen::Diff(diff);
+                    Ok(out) if out.status.success() => {
+                        let prev = String::from_utf8_lossy(&out.stdout).to_string();
+                        let diff = DiffView::new(prev, current, ignore_ws);
+                        self.screen = Screen::Diff(diff);
+                    }
+                    Ok(out) => {
+                        let err = String::from_utf8_lossy(&out.stderr).to_string();
+                        return self.handle_message(Message::DiffError(err));
+                    }
+                    Err(e) => {
+                        return self.handle_message(Message::DiffError(format!("{}", e)));
+                    }
                 }
                 Command::none()
             }
@@ -860,6 +896,14 @@ impl MulticodeApp {
                 if let Screen::Diff(ref mut diff) = self.screen {
                     diff.set_ignore_whitespace(val);
                 }
+                Command::none()
+            }
+            Message::DiffError(e) => {
+                self.diff_error = Some(e);
+                Command::none()
+            }
+            Message::ClearDiffError => {
+                self.diff_error = None;
                 Command::none()
             }
             Message::ToggleDir(path) => {

--- a/desktop/src/app/events/message.rs
+++ b/desktop/src/app/events/message.rs
@@ -80,4 +80,6 @@ pub enum Message {
     OpenDiff(PathBuf, PathBuf, bool),
     OpenGitDiff(PathBuf, String, bool),
     ToggleDiffIgnoreWhitespace(bool),
+    DiffError(String),
+    ClearDiffError,
 }

--- a/desktop/src/app/mod.rs
+++ b/desktop/src/app/mod.rs
@@ -1,7 +1,7 @@
+pub mod diff;
 pub mod events;
 pub mod io;
 pub mod ui;
-pub mod diff;
 
 use crate::modal::Modal;
 use diff::DiffView;
@@ -77,6 +77,7 @@ pub struct MulticodeApp {
     pending_action: Option<PendingAction>,
     hotkey_capture: Option<HotkeyField>,
     settings_warning: Option<String>,
+    diff_error: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -414,6 +415,7 @@ impl Application for MulticodeApp {
             pending_action: None,
             hotkey_capture: None,
             settings_warning: None,
+            diff_error: None,
         };
 
         let cmd = match &app.screen {
@@ -464,7 +466,7 @@ impl Application for MulticodeApp {
     }
 
     fn view(&self) -> Element<Message> {
-        match &self.screen {
+        let content: Element<_> = match &self.screen {
             Screen::ProjectPicker => {
                 let settings_label = if self.settings.language == Language::Russian {
                     "Настройки"
@@ -646,12 +648,7 @@ impl Application for MulticodeApp {
 
                 let search_panel = self.search_panel_component();
 
-                let content = column![
-                    search_panel,
-                    editor,
-                    self.terminal_component(),
-                ]
-                .spacing(10);
+                let content = column![search_panel, editor, self.terminal_component(),].spacing(10);
 
                 let body = row![sidebar, content].spacing(10);
 
@@ -981,13 +978,12 @@ impl Application for MulticodeApp {
                     .center_y()
                     .into()
             }
-            Screen::Diff(diff) => {
-                container(self.diff_component(diff))
-                    .width(Length::Fill)
-                    .height(Length::Fill)
-                    .into()
-            }
-        }
+            Screen::Diff(diff) => container(self.diff_component(diff))
+                .width(Length::Fill)
+                .height(Length::Fill)
+                .into(),
+        };
+        self.error_modal(content)
     }
 }
 

--- a/desktop/src/app/ui.rs
+++ b/desktop/src/app/ui.rs
@@ -18,6 +18,7 @@ use syntect::parsing::SyntaxSet;
 use crate::app::diff::DiffView;
 use crate::app::events::Message;
 use crate::app::{EntryType, FileEntry, MulticodeApp};
+use crate::modal::Modal;
 
 #[derive(Debug)]
 pub struct ContextMenu {
@@ -384,6 +385,24 @@ impl MulticodeApp {
         ]
         .spacing(5)
         .into()
+    }
+
+    pub fn error_modal(&self, content: Element<Message>) -> Element<Message> {
+        if let Some(err) = &self.diff_error {
+            let modal_content = container(
+                column![
+                    text(err.clone()),
+                    button("OK").on_press(Message::ClearDiffError)
+                ]
+                .spacing(10),
+            )
+            .padding(10);
+            Modal::new(content, modal_content)
+                .on_blur(Message::ClearDiffError)
+                .into()
+        } else {
+            content
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Handle diff file loading errors and propagate as `DiffError`
- Check `git show` status and forward stderr when failing
- Show diff errors in UI via modal notification

## Testing
- `cargo test -p desktop`

------
https://chatgpt.com/codex/tasks/task_e_68a54bc339b48323b56e928cd6a9338e