### PR TITLE
feat: add tab bar with activation and reordering

### DIFF
--- a/desktop/src/app/events/message.rs
+++ b/desktop/src/app/events/message.rs
@@ -46,6 +46,8 @@ pub enum Message {
     FileDeleted(Result<PathBuf, String>),
     CloseFile(usize),
     FileClosed(Result<usize, String>),
+    ActivateTab(usize),
+    ReorderTab { from: usize, to: usize },
     RunSearch,
     SearchFinished(Result<Vec<String>, String>),
     RunParse,

--- a/desktop/src/app/ui.rs
+++ b/desktop/src/app/ui.rs
@@ -173,6 +173,41 @@ impl MulticodeApp {
         .into()
     }
 
+    pub fn tabs_component(&self) -> Element<Message> {
+        let len = self.tabs.len();
+        let tabs = self
+            .tabs
+            .iter()
+            .enumerate()
+            .map(|(i, f)| {
+                let name = f
+                    .path
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .unwrap_or("")
+                    .to_string();
+                let tab = row![
+                    button(text(name)).on_press(Message::ActivateTab(i)),
+                    button(text("x")).on_press(Message::CloseFile(i))
+                ]
+                .spacing(5);
+                MouseArea::new(tab).on_drag(move |d| {
+                    if d.x > 30.0 && i + 1 < len {
+                        Message::ReorderTab { from: i, to: i + 1 }
+                    } else if d.x < -30.0 && i > 0 {
+                        Message::ReorderTab {
+                            from: i,
+                            to: i - 1,
+                        }
+                    } else {
+                        Message::ActivateTab(i)
+                    }
+                }).into()
+            })
+            .collect::<Vec<Element<Message>>>();
+        row(tabs).spacing(5).into()
+    }
+
     pub fn text_editor_component(&self) -> Element<Message> {
         if let Some(file) = self.current_file() {
             let ext = file


### PR DESCRIPTION
## Summary
- maintain tabs with editor states
- add draggable, closable tab bar
- handle ActivateTab and ReorderTab messages

## Testing
- `cargo test -p desktop`

------
https://chatgpt.com/codex/tasks/task_e_68a56ccaa3908323974fdc6587dfb48a