### PR TITLE
feat: show git blame info on line numbers

### DIFF
--- a/desktop/src/app/events/message.rs
+++ b/desktop/src/app/events/message.rs
@@ -52,6 +52,7 @@ pub enum Message {
     SearchFinished(Result<Vec<String>, String>),
     RunParse,
     ParseFinished(Result<Vec<String>, String>),
+    RunGitBlame(PathBuf),
     RunGitLog,
     GitFinished(Result<Vec<String>, String>),
     RunExport,

--- a/desktop/src/app/mod.rs
+++ b/desktop/src/app/mod.rs
@@ -22,10 +22,11 @@ const TERMINAL_HELP: &str = include_str!("../../assets/terminal-help.md");
 
 use directories::ProjectDirs;
 use serde::{Deserialize, Serialize};
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::fmt;
 use std::ops::Range;
 use std::path::PathBuf;
+use multicode_core::git;
 
 pub fn run(path: Option<PathBuf>) -> iced::Result {
     MulticodeApp::run(Settings {
@@ -115,6 +116,7 @@ pub struct Tab {
     content: String,
     editor: text_editor::Content,
     dirty: bool,
+    blame: HashMap<usize, git::BlameLine>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]


### PR DESCRIPTION
## Summary
- add `RunGitBlame` message for fetching blame data
- store git blame output in tabs and display as tooltips on line numbers

## Testing
- `cargo test -p desktop`
- `cargo test --workspace` *(fails: The system library `glib-2.0` required by crate `glib-sys` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a570ea3d608323bde2e7aa343eac73