### PR TITLE
Integrate viz lint diagnostics

### DIFF
--- a/desktop/src/app/events/message.rs
+++ b/desktop/src/app/events/message.rs
@@ -2,7 +2,7 @@ use iced::{widget::text_editor, Event};
 use std::path::PathBuf;
 
 use crate::app::diff::DiffView;
-use crate::app::{AppTheme, CreateTarget, FileEntry, HotkeyField, Language};
+use crate::app::{AppTheme, CreateTarget, Diagnostic, FileEntry, HotkeyField, Language};
 
 #[derive(Debug, Clone)]
 pub enum Message {
@@ -52,6 +52,8 @@ pub enum Message {
     SearchFinished(Result<Vec<String>, String>),
     RunParse,
     ParseFinished(Result<Vec<String>, String>),
+    RunLint,
+    LintFinished(Vec<Diagnostic>),
     RunGitBlame(PathBuf),
     RunGitLog,
     GitFinished(Result<Vec<String>, String>),

--- a/desktop/src/app/mod.rs
+++ b/desktop/src/app/mod.rs
@@ -110,6 +110,13 @@ pub struct FileEntry {
     children: Vec<FileEntry>,
 }
 
+#[derive(Debug, Clone)]
+pub struct Diagnostic {
+    pub line: usize,
+    pub range: Range<usize>,
+    pub message: String,
+}
+
 #[derive(Debug)]
 pub struct Tab {
     path: PathBuf,
@@ -117,6 +124,7 @@ pub struct Tab {
     editor: text_editor::Content,
     dirty: bool,
     blame: HashMap<usize, git::BlameLine>,
+    diagnostics: Vec<Diagnostic>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -669,7 +677,13 @@ impl Application for MulticodeApp {
 
                 let search_panel = self.search_panel_component();
 
-                let content = column![search_panel, editor, self.terminal_component(),].spacing(10);
+                let content = column![
+                    search_panel,
+                    editor,
+                    self.lint_panel_component(),
+                    self.terminal_component(),
+                ]
+                .spacing(10);
 
                 let body = row![sidebar, content].spacing(10);
 


### PR DESCRIPTION
## Summary
- add RunLint and LintFinished events
- analyze `@viz` comments via core::viz_lint and record diagnostics
- highlight lint problems and show diagnostics panel in UI

## Testing
- `cargo test -p desktop`

------
https://chatgpt.com/codex/tasks/task_e_68a5752227bc8323880e628386221fe7