### PR TITLE
docs: add NodeTemplate transformation to AnalysisNode

### DIFF
--- a/docs/neira/analysis-nodes.md
+++ b/docs/neira/analysis-nodes.md
@@ -64,6 +64,20 @@ struct NodeTemplate {
 }
 ```
 
+### Преобразование NodeTemplate → AnalysisNode
+
+| Поле NodeTemplate | Поле AnalysisNode |
+| --- | --- |
+| `id` | `id` |
+| `node_type` | `analysis_type` |
+| `links` | `links` |
+| `metadata` | `metadata` |
+| `draft_content` | — |
+
+Поля `status`, `confidence_threshold`, `reasoning_chain` и `uncertainty_score` в шаблон не входят, поскольку задаются или вычисляются после ревью.
+
+**Пример (JSON)**
+
 ```json
 {
   "id": "example.template",
@@ -77,12 +91,51 @@ struct NodeTemplate {
 }
 ```
 
+→
+
+```json
+{
+  "id": "example.template",
+  "analysis_type": "ProgrammingSyntaxNode",
+  "links": ["prog.syntax.base"],
+  "status": "draft",
+  "confidence_threshold": 0.8,
+  "reasoning_chain": [
+    "initial review complete"
+  ],
+  "uncertainty_score": 0.2,
+  "metadata": {
+    "schema": "1.0",
+    "source": "https://example.org"
+  }
+}
+```
+
+**Пример (YAML)**
+
 ```yaml
 id: example.template
 node_type: ProgrammingSyntaxNode
 links:
   - prog.syntax.base
 draft_content: Initial description
+metadata:
+  schema: "1.0"
+  source: "https://example.org"
+```
+
+→
+
+```yaml
+id: example.template
+analysis_type: ProgrammingSyntaxNode
+links:
+  - prog.syntax.base
+status: draft
+confidence_threshold: 0.8
+reasoning_chain:
+  - initial review complete
+uncertainty_score: 0.2
 metadata:
   schema: "1.0"
   source: "https://example.org"


### PR DESCRIPTION
## Summary
- document how NodeTemplate fields map to AnalysisNode
- clarify which fields are assigned post-review
- provide JSON and YAML examples of NodeTemplate-to-AnalysisNode conversion

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a57981fb7c8323b1c1123bdbc7fad8