### PR TITLE
Sync visual blocks with text changes and core events

### DIFF
--- a/desktop/src/app/mod.rs
+++ b/desktop/src/app/mod.rs
@@ -22,7 +22,7 @@ use ui::{ContextMenu, THEME_SET};
 const TERMINAL_HELP: &str = include_str!("../../assets/terminal-help.md");
 
 use directories::ProjectDirs;
-use multicode_core::git;
+use multicode_core::{git, BlockInfo};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::fmt;
@@ -132,6 +132,7 @@ pub struct Tab {
     dirty: bool,
     blame: HashMap<usize, git::BlameLine>,
     diagnostics: Vec<Diagnostic>,
+    blocks: Vec<BlockInfo>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -562,8 +563,7 @@ impl Application for MulticodeApp {
                 };
                 let menu = row![
                     button("Разбор").on_press(Message::RunParse),
-                    button("Поиск")
-                        .on_press(Message::ProjectSearch(self.query.clone())),
+                    button("Поиск").on_press(Message::ProjectSearch(self.query.clone())),
                     button("Журнал Git").on_press(Message::RunGitLog),
                     button("Экспорт").on_press(Message::RunExport),
                     button("Терминал").on_press(Message::ToggleTerminal),
@@ -753,8 +753,7 @@ impl Application for MulticodeApp {
                 };
                 let menu = row![
                     button("Разбор").on_press(Message::RunParse),
-                    button("Поиск")
-                        .on_press(Message::ProjectSearch(self.query.clone())),
+                    button("Поиск").on_press(Message::ProjectSearch(self.query.clone())),
                     button("Журнал Git").on_press(Message::RunGitLog),
                     button("Экспорт").on_press(Message::RunExport),
                     button("Терминал").on_press(Message::ToggleTerminal),

--- a/desktop/src/app/ui.rs
+++ b/desktop/src/app/ui.rs
@@ -385,14 +385,10 @@ impl MulticodeApp {
                 if !buf.is_empty() {
                     elements.push(text(buf).into());
                 }
-                let preview = scrollable(column(elements).spacing(5))
-                    .width(Length::FillPortion(1));
-                row![
-                    editor_column.width(Length::FillPortion(1)),
-                    preview
-                ]
-                .spacing(5)
-                .into()
+                let preview = scrollable(column(elements).spacing(5)).width(Length::FillPortion(1));
+                row![editor_column.width(Length::FillPortion(1)), preview]
+                    .spacing(5)
+                    .into()
             } else {
                 editor_column.into()
             }
@@ -502,17 +498,11 @@ impl MulticodeApp {
             let (line, column) = file.editor.cursor_position();
             let path = file.path.to_string_lossy().to_string();
             let dirty = if file.dirty { "*" } else { "" };
-            container(
-                row![
-                    text(path).width(Length::Fill),
-                    text(format!("{}:{}", line + 1, column + 1)),
-                    text(dirty)
-                ]
-                .spacing(10),
-            )
-            .width(Length::Fill)
-            .padding(5)
-            .into()
+            let info = format!("{}:{} | blocks {}", line + 1, column + 1, file.blocks.len());
+            container(row![text(path).width(Length::Fill), text(info), text(dirty)].spacing(10))
+                .width(Length::Fill)
+                .padding(5)
+                .into()
         } else {
             Space::with_height(Length::Shrink).into()
         }
@@ -589,8 +579,7 @@ impl MulticodeApp {
                 let label = if self.shortcut_capture.as_deref() == Some(cmd.id) {
                     String::from("...")
                 } else {
-                    self
-                        .settings
+                    self.settings
                         .shortcuts
                         .get(cmd.id)
                         .map(|h| h.to_string())
@@ -598,8 +587,7 @@ impl MulticodeApp {
                 };
                 row![
                     text(cmd.title),
-                    button(text(label))
-                        .on_press(Message::StartCaptureShortcut(cmd.id.to_string()))
+                    button(text(label)).on_press(Message::StartCaptureShortcut(cmd.id.to_string()))
                 ]
                 .spacing(10)
                 .into()


### PR DESCRIPTION
## Summary
- Track visual block metadata in editor tabs
- Parse files and update block state on edits and core watcher events
- Display current block count in status bar

## Testing
- `cargo test -p core`
- `cargo check -p desktop` *(fails: interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68a5acbae1e88323be3ab57d0a55964b