### PR TITLE
Expose toolbar across screens with default visibility

### DIFF
--- a/desktop/src/app/mod.rs
+++ b/desktop/src/app/mod.rs
@@ -330,6 +330,10 @@ fn default_syntect_theme() -> String {
     "InspiredGitHub".into()
 }
 
+fn default_true() -> bool {
+    true
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct UserSettings {
     #[serde(default)]
@@ -350,7 +354,7 @@ struct UserSettings {
     show_line_numbers: bool,
     #[serde(default)]
     show_status_bar: bool,
-    #[serde(default)]
+    #[serde(default = "default_true")]
     show_toolbar: bool,
     #[serde(default)]
     show_markdown_preview: bool,
@@ -1039,7 +1043,12 @@ impl Application for MulticodeApp {
         if let Some(tabs) = tabs {
             page = page.push(tabs);
         }
-        let page: Element<_> = page.push(self.mode_bar()).push(content).spacing(10).into();
+        let page: Element<_> = page
+            .push(self.mode_bar())
+            .push(self.toolbar())
+            .push(content)
+            .spacing(10)
+            .into();
         let content = if self.loading {
             container(spinner())
                 .width(Length::Fill)


### PR DESCRIPTION
## Summary
- extract toolbar construction into a reusable function
- display toolbar below mode bar on all screens
- default toolbar visibility to true in settings

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a5cf8f25c88323aa0d8d3a302f97af