### PR TITLE
Display status bar across all screens

### DIFF
--- a/desktop/src/app/mod.rs
+++ b/desktop/src/app/mod.rs
@@ -563,11 +563,13 @@ impl Application for MulticodeApp {
                     }
                 }
 
-                let content = container(content)
+                let picker = container(content)
                     .width(Length::Fill)
                     .height(Length::Fill)
                     .center_x()
-                    .center_y()
+                    .center_y();
+                let content = column![picker, self.status_bar_component()]
+                    .spacing(10)
                     .into();
                 (None, content)
             }
@@ -1023,21 +1025,25 @@ impl Application for MulticodeApp {
                 .align_items(alignment::Alignment::Center)
                 .spacing(20);
 
-                let content = container(content)
+                let settings_page = container(content)
                     .width(Length::Fill)
                     .height(Length::Fill)
                     .center_x()
-                    .center_y()
+                    .center_y();
+                let content = column![settings_page, self.status_bar_component()]
+                    .spacing(10)
                     .into();
                 (None, content)
             }
-            Screen::Diff(diff) => (
-                None,
-                container(self.diff_component(diff))
+            Screen::Diff(diff) => {
+                let diff_view = container(self.diff_component(diff))
                     .width(Length::Fill)
-                    .height(Length::Fill)
-                    .into(),
-            ),
+                    .height(Length::Fill);
+                let content = column![diff_view, self.status_bar_component()]
+                    .spacing(10)
+                    .into();
+                (None, content)
+            }
         };
         let mut page = column![self.main_menu()];
         if let Some(tabs) = tabs {

--- a/desktop/src/app/ui.rs
+++ b/desktop/src/app/ui.rs
@@ -585,7 +585,11 @@ impl MulticodeApp {
                 .padding(5)
                 .into()
         } else {
-            Space::with_height(Length::Shrink).into()
+            let root = self.current_root();
+            container(row![text(root).width(Length::Fill)].spacing(10))
+                .width(Length::Fill)
+                .padding(5)
+                .into()
         }
     }
 


### PR DESCRIPTION
## Summary
- generalize status bar component to show current project path when no file is open
- append the status bar to the layout of every screen

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a5d696951c832399b7844ca579c40b