### PR TITLE
Check for recent folders on startup

### DIFF
--- a/desktop/src/app/mod.rs
+++ b/desktop/src/app/mod.rs
@@ -30,8 +30,10 @@ use std::ops::Range;
 use std::path::PathBuf;
 
 pub fn run(path: Option<PathBuf>) -> iced::Result {
+    let settings = UserSettings::load();
+    let flags = if settings.last_folders.is_empty() { None } else { path };
     MulticodeApp::run(Settings {
-        flags: path,
+        flags,
         ..Settings::default()
     })
 }


### PR DESCRIPTION
## Summary
- Show the project picker when no recent folders exist

## Testing
- `cargo test -p desktop`

------
https://chatgpt.com/codex/tasks/task_e_68a5e58ebfe08323b5c2c6917dfebe9c