### PR TITLE
feat: add default entry selection

### DIFF
--- a/desktop/src/app/events/message.rs
+++ b/desktop/src/app/events/message.rs
@@ -10,6 +10,7 @@ pub enum Message {
     FolderPicked(Option<PathBuf>),
     PickFile,
     FilePicked(Option<PathBuf>),
+    DefaultEntryPicked(Option<PathBuf>),
     OpenRecent(PathBuf),
     FilesLoaded(Vec<FileEntry>),
     QueryChanged(String),

--- a/desktop/src/app/io.rs
+++ b/desktop/src/app/io.rs
@@ -23,6 +23,15 @@ pub fn pick_file() -> impl std::future::Future<Output = Option<PathBuf>> {
     }
 }
 
+pub fn pick_file_in_dir(dir: PathBuf) -> impl std::future::Future<Output = Option<PathBuf>> {
+    async move {
+        task::spawn_blocking(move || rfd::FileDialog::new().set_directory(dir).pick_file())
+            .await
+            .ok()
+            .flatten()
+    }
+}
+
 impl MulticodeApp {
     pub fn load_files(&self, root: PathBuf) -> Command<Message> {
         Command::perform(


### PR DESCRIPTION
## Summary
- prompt to choose default file when opening a folder
- store selected file in user settings and reopen automatically

## Testing
- `cargo test`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5f449d5188323a40f51f96abd814d