### PR TITLE
refactor: extract file menu and add icon buttons

### DIFF
--- a/desktop/assets/create.svg
+++ b/desktop/assets/create.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <line x1="12" y1="5" x2="12" y2="19"/>
+  <line x1="5" y1="12" x2="19" y2="12"/>
+</svg>

--- a/desktop/assets/delete.svg
+++ b/desktop/assets/delete.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <polyline points="3 6 5 6 21 6"/>
+  <path d="M19 6l-2 14H7L5 6"/>
+  <path d="M10 11v6"/>
+  <path d="M14 11v6"/>
+  <path d="M9 6V4h6v2"/>
+</svg>

--- a/desktop/assets/rename.svg
+++ b/desktop/assets/rename.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M12 20h9"/>
+  <path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4 12.5-12.5z"/>
+</svg>


### PR DESCRIPTION
## Summary
- deduplicate file menu into `file_menu` helper
- use SVG icons for create/rename/delete with tooltips

## Testing
- `cargo test -p desktop`

------
https://chatgpt.com/codex/tasks/task_e_68a5fd740f948323b1330466b09c6fdb