### PR TITLE
Add editor switch commands to command palette

### DIFF
--- a/desktop/src/app/command_palette.rs
+++ b/desktop/src/app/command_palette.rs
@@ -28,4 +28,40 @@ pub const COMMANDS: &[CommandItem] = &[
         title: "Открыть настройки",
         message: Message::OpenSettings,
     },
+    CommandItem {
+        id: "switch_to_text_editor",
+        title: "Switch to Text",
+        message: Message::SwitchToTextEditor,
+    },
+    CommandItem {
+        id: "switch_to_visual_editor",
+        title: "Switch to Visual",
+        message: Message::SwitchToVisualEditor,
+    },
 ];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn command_palette_contains_switch_commands() {
+        assert!(COMMANDS
+            .iter()
+            .any(|c| c.id == "switch_to_text_editor"
+                && matches!(c.message, Message::SwitchToTextEditor)));
+        assert!(COMMANDS.iter().any(|c| c.id == "switch_to_visual_editor"
+            && matches!(c.message, Message::SwitchToVisualEditor)));
+    }
+
+    #[test]
+    fn filtering_by_query_returns_switch_commands() {
+        let query = "switch";
+        let filtered: Vec<&CommandItem> = COMMANDS
+            .iter()
+            .filter(|c| c.title.to_lowercase().contains(&query.to_lowercase()))
+            .collect();
+        assert!(filtered.iter().any(|c| c.id == "switch_to_text_editor"));
+        assert!(filtered.iter().any(|c| c.id == "switch_to_visual_editor"));
+    }
+}


### PR DESCRIPTION
## Summary
- add `Switch to Text` and `Switch to Visual` commands
- link new commands to `SwitchToTextEditor` and `SwitchToVisualEditor`
- verify command palette filtering

## Testing
- `cargo test -p desktop`

------
https://chatgpt.com/codex/tasks/task_e_68a602e8a2988323b07d551d3a85af0f