### PR TITLE
feat(ui): add open file button

### DIFF
--- a/desktop/src/app/ui.rs
+++ b/desktop/src/app/ui.rs
@@ -414,10 +414,19 @@ impl MulticodeApp {
                 }
             }
         } else {
-            container(text("файл не выбран"))
-                .width(Length::Fill)
-                .height(Length::Fill)
-                .into()
+            container(
+                column![
+                    button("Открыть файл").on_press(Message::PickFile),
+                    text("Файл можно перетащить в окно"),
+                ]
+                .spacing(5)
+                .align_items(Alignment::Center),
+            )
+            .width(Length::Fill)
+            .height(Length::Fill)
+            .center_x()
+            .center_y()
+            .into()
         }
     }
 


### PR DESCRIPTION
## Summary
- show "Open file" button when no file selected
- allow opening via Message::PickFile and hint drag-and-drop

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68a606d6a3e88323a71753a520b90868