### PR TITLE
feat(desktop): add loading overlay

### DIFF
--- a/desktop/src/app/events/handler.rs
+++ b/desktop/src/app/events/handler.rs
@@ -971,6 +971,7 @@ impl MulticodeApp {
                 Command::none()
             }
             Message::RunParse => {
+                self.loading = true;
                 let files = self.file_paths();
                 Command::perform(
                     async move {
@@ -1013,10 +1014,12 @@ impl MulticodeApp {
                 )
             }
             Message::ParseFinished(Ok(lines)) => {
+                self.loading = false;
                 self.log.extend(lines);
                 Command::none()
             }
             Message::ParseFinished(Err(e)) => {
+                self.loading = false;
                 self.log.push(format!("ошибка разбора: {e}"));
                 Command::none()
             }
@@ -1086,19 +1089,25 @@ impl MulticodeApp {
                 }
                 Command::none()
             }
-            Message::RunGitLog => Command::perform(
-                async move { git::log().map_err(|e| e.to_string()) },
-                Message::GitFinished,
-            ),
+            Message::RunGitLog => {
+                self.loading = true;
+                Command::perform(
+                    async move { git::log().map_err(|e| e.to_string()) },
+                    Message::GitFinished,
+                )
+            }
             Message::GitFinished(Ok(lines)) => {
+                self.loading = false;
                 self.log.extend(lines);
                 Command::none()
             }
             Message::GitFinished(Err(e)) => {
+                self.loading = false;
                 self.log.push(format!("ошибка git: {e}"));
                 Command::none()
             }
             Message::RunExport => {
+                self.loading = true;
                 let files = self.file_paths();
                 Command::perform(
                     async move {
@@ -1121,10 +1130,12 @@ impl MulticodeApp {
                 )
             }
             Message::ExportFinished(Ok(lines)) => {
+                self.loading = false;
                 self.log.extend(lines);
                 Command::none()
             }
             Message::ExportFinished(Err(e)) => {
+                self.loading = false;
                 self.log.push(format!("ошибка экспорта: {e}"));
                 Command::none()
             }

--- a/desktop/src/app/mod.rs
+++ b/desktop/src/app/mod.rs
@@ -972,22 +972,26 @@ impl Application for MulticodeApp {
             .push(content)
             .spacing(10)
             .into();
-        let content = if self.loading {
-            container(spinner())
-                .width(Length::Fill)
-                .height(Length::Fill)
-                .center_x()
-                .center_y()
-                .into()
-        } else {
-            page
-        };
+        let content = self.loading_overlay(page);
         let content = self.command_palette_modal(content);
         self.error_modal(content)
     }
 }
 
 impl MulticodeApp {
+    fn loading_overlay(&self, content: Element<Message>) -> Element<Message> {
+        if self.loading {
+            let overlay = container(spinner())
+                .width(Length::Fill)
+                .height(Length::Fill)
+                .center_x()
+                .center_y();
+            Modal::new(content, overlay).into()
+        } else {
+            content
+        }
+    }
+
     fn main_menu(&self) -> Element<Message> {
         let settings_label = if self.settings.language == Language::Russian {
             "Настройки"


### PR DESCRIPTION
## Summary
- show spinner overlay while background tasks run
- toggle loading state for parsing, git log, and export

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68a60a1ef9a48323a5c95bec94433799