### PR TITLE
core: derive Debug for BlameLine

### DIFF
--- a/core/src/git.rs
+++ b/core/src/git.rs
@@ -111,7 +111,7 @@ pub fn log() -> Result<Vec<String>, git2::Error> {
     Ok(entries)
 }
 
-#[derive(serde::Serialize)]
+#[derive(Debug, serde::Serialize)]
 pub struct BlameLine {
     pub line: usize,
     pub author: String,


### PR DESCRIPTION
## Summary
- derive `Debug` for `BlameLine` in core git utilities

## Testing
- `cargo test -p core`

------
https://chatgpt.com/codex/tasks/task_e_68a62900b3508323ba1b62819c3bc921