### PR TITLE
Handle window id in file dropped event

### DIFF
--- a/desktop/src/app/events/handler.rs
+++ b/desktop/src/app/events/handler.rs
@@ -137,7 +137,7 @@ impl MulticodeApp {
                 }
                 Command::none()
             }
-            Message::IcedEvent(Event::Window(window::Event::FileDropped(path))) => {
+            Message::IcedEvent(Event::Window(_, window::Event::FileDropped(path))) => {
                 if path.is_dir() {
                     return self.handle_message(Message::FolderPicked(Some(path)));
                 } else if path.is_file() {


### PR DESCRIPTION
## Summary
- adjust FileDropped iced event to include the window id

## Testing
- `cargo test -p desktop` *(fails: unresolved import `iced::widget::spinner` and other compile errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a62d7553ac8323b0b7df752389519e