### PR TITLE
Fix button and tooltip text handling

### DIFF
--- a/desktop/src/app/ui.rs
+++ b/desktop/src/app/ui.rs
@@ -186,9 +186,9 @@ impl MulticodeApp {
         let items = self
             .project_search_results
             .iter()
-            .map(|(path, line, text)| {
-                let label = format!("{}:{}: {}", path.display(), line + 1, text);
-                button(label)
+            .map(|(path, line, snippet)| {
+                let label = format!("{}:{}: {}", path.display(), line + 1, snippet);
+                button(text(label))
                     .on_press(Message::OpenSearchResult(path.clone(), *line))
                     .into()
             })
@@ -268,7 +268,7 @@ impl MulticodeApp {
                                     .unwrap_or_default();
                                 Tooltip::new(
                                     ln,
-                                    format!("{} – {}", info.author, date),
+                                    text(format!("{} – {}", info.author, date)),
                                     tooltip::Position::FollowCursor,
                                 )
                                 .into()


### PR DESCRIPTION
## Summary
- Fix project search to create button with text widget
- Wrap tooltip content in text to avoid string inference issues

## Testing
- `cargo test -p desktop` *(fails: unresolved import `iced::widget::spinner` and other compile errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a6378aafc48323a4f20116f58840d6