### PR TITLE
Use Into for tabs element

### DIFF
--- a/desktop/src/app/view.rs
+++ b/desktop/src/app/view.rs
@@ -180,7 +180,7 @@ impl MulticodeApp {
                         .on_blur(Message::CloseMetaDialog)
                         .into();
                 }
-                (Some(tabs), content)
+                (Some(tabs.into()), content)
             }
             Screen::VisualEditor { .. } => {
                 let sidebar = self.sidebar();


### PR DESCRIPTION
## Summary
- convert `tabs` to element with `.into()` when returning from `view`

## Testing
- `cargo test -p desktop` *(fails: no function or associated item named `run` found for `MulticodeApp` and other compile errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a644140ed48323ae452088606bca0b