### PR TITLE
Fix MulticodeApp run import

### DIFF
--- a/desktop/src/app/mod.rs
+++ b/desktop/src/app/mod.rs
@@ -13,6 +13,7 @@ pub use state::{
     Hotkeys, Language, MulticodeApp, PendingAction, Screen, Tab, TabDragState, UserSettings,
 };
 
+use iced::Application;
 use iced::Settings;
 use std::path::PathBuf;
 


### PR DESCRIPTION
## Summary
- import `iced::Application` so `MulticodeApp::run` resolves

## Testing
- `cargo check -p desktop` *(fails: lifetime may not live long enough)*

------
https://chatgpt.com/codex/tasks/task_e_68a68375989c8323817086c9e9884340