### PR TITLE
Use from_timestamp for blame date

### DIFF
--- a/desktop/src/app/ui.rs
+++ b/desktop/src/app/ui.rs
@@ -256,9 +256,9 @@ impl MulticodeApp {
                         .map(|i| {
                             let ln = text(i.to_string());
                             if let Some(info) = file.blame.get(&i) {
-                                let date = NaiveDateTime::from_timestamp_opt(info.time, 0)
-                                    .map(|dt| dt.format("%Y-%m-%d").to_string())
-                                    .unwrap_or_default();
+                                let date = NaiveDateTime::from_timestamp(info.time, 0)
+                                    .format("%Y-%m-%d")
+                                    .to_string();
                                 Tooltip::new(
                                     ln,
                                     text(format!("{} – {}", info.author, date)),


### PR DESCRIPTION
## Summary
- use `NaiveDateTime::from_timestamp` for blame info dates

## Testing
- `cargo test -p desktop` *(fails: cannot assign to `self.meta_tags` because it is borrowed)*

------
https://chatgpt.com/codex/tasks/task_e_68a686fc3388832392ea154f95f39679