### PR TITLE
feat: add explicit lifetimes for ui elements

### DIFF
--- a/desktop/src/app/ui.rs
+++ b/desktop/src/app/ui.rs
@@ -368,7 +368,7 @@ impl MulticodeApp {
         }
     }
 
-    pub fn diff_component(&self, diff: &DiffView) -> Element<Message> {
+    pub fn diff_component<'a>(&self, diff: &'a DiffView) -> Element<'a, Message> {
         let toggle = checkbox("Игнорировать пробелы", diff.ignore_whitespace)
             .on_toggle(Message::ToggleDiffIgnoreWhitespace);
         column![toggle, diff.view()].spacing(5).into()
@@ -491,7 +491,7 @@ impl MulticodeApp {
         .into()
     }
 
-    pub fn error_modal(&self, content: Element<Message>) -> Element<Message> {
+    pub fn error_modal<'a>(&self, content: Element<'a, Message>) -> Element<'a, Message> {
         if let Some(err) = &self.diff_error {
             let modal_content = container(
                 column![
@@ -509,7 +509,7 @@ impl MulticodeApp {
         }
     }
 
-    pub fn command_palette_modal(&self, content: Element<Message>) -> Element<Message> {
+    pub fn command_palette_modal<'a>(&self, content: Element<'a, Message>) -> Element<'a, Message> {
         if !self.show_command_palette {
             return content;
         }

--- a/desktop/src/app/view.rs
+++ b/desktop/src/app/view.rs
@@ -455,7 +455,7 @@ impl MulticodeApp {
 }
 
 impl MulticodeApp {
-    fn loading_overlay(&self, content: Element<Message>) -> Element<Message> {
+    fn loading_overlay<'a>(&self, content: Element<'a, Message>) -> Element<'a, Message> {
         if self.loading {
             let overlay = container(text("Loading…"))
                 .width(Length::Fill)


### PR DESCRIPTION
## Summary
- give diff component explicit lifetime
- add lifetimes to error and command palette modals
- propagate lifetime through loading overlay

## Testing
- `cargo test -p desktop` *(fails: borrow check errors in events handler and ui)*

------
https://chatgpt.com/codex/tasks/task_e_68a68ad53fdc8323a143f8a5b50e22fa