### PR TITLE
chore: remove unused imports in desktop app

### DIFF
--- a/desktop/src/app/actions.rs
+++ b/desktop/src/app/actions.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 
 use iced::futures::stream;
 use iced::{
-    application, event, subscription, Application, Command, Element, Settings, Subscription, Theme,
+    event, subscription, Application, Command, Element, Subscription, Theme,
 };
 use tokio::sync::broadcast;
 

--- a/desktop/src/app/events/handler.rs
+++ b/desktop/src/app/events/handler.rs
@@ -23,7 +23,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tokio::fs;
 use tokio::io::{AsyncBufReadExt, BufReader};
-use tokio::process::{Child, Command as TokioCommand};
+use tokio::process::Command as TokioCommand;
 
 impl MulticodeApp {
     pub fn handle_message(&mut self, message: Message) -> Command<Message> {

--- a/desktop/src/app/view.rs
+++ b/desktop/src/app/view.rs
@@ -2,7 +2,7 @@ use crate::modal::Modal;
 use iced::widget::{
     button, checkbox, column, container, pick_list, row, scrollable,
     svg::{Handle, Svg},
-    text, text_editor, text_input,
+    text, text_input,
     tooltip::{self, Tooltip},
     Space,
 };


### PR DESCRIPTION
## Summary
- remove unused Child from tokio process imports
- drop unused `application` and `Settings` from iced imports
- clean up unused `text_editor` widget import

## Testing
- `cargo build` *(fails: cannot assign to self.meta_tags, use of deprecated chrono function)*

------
https://chatgpt.com/codex/tasks/task_e_68a68e9a7cdc832384aac0c6b2d7b467