### PR TITLE
Fix borrow handling in meta dialog and clone file extension

### DIFF
--- a/desktop/src/app/ui.rs
+++ b/desktop/src/app/ui.rs
@@ -1,6 +1,6 @@
 use std::ops::Range;
 
-use chrono::NaiveDateTime;
+use chrono::DateTime;
 use iced::advanced::text::highlighter::{self, Highlighter};
 use iced::widget::svg::{Handle, Svg};
 use iced::widget::{
@@ -234,7 +234,7 @@ impl MulticodeApp {
                 .unwrap_or("")
                 .to_string();
             let settings = SyntaxSettings {
-                extension: ext,
+                extension: ext.clone(),
                 matches: self.search_results.clone(),
                 diagnostics: file
                     .diagnostics
@@ -256,7 +256,8 @@ impl MulticodeApp {
                         .map(|i| {
                             let ln = text(i.to_string());
                             if let Some(info) = file.blame.get(&i) {
-                                let date = NaiveDateTime::from_timestamp(info.time, 0)
+                                let date = DateTime::from_timestamp(info.time, 0)
+                                    .unwrap_or_default()
                                     .format("%Y-%m-%d")
                                     .to_string();
                                 Tooltip::new(


### PR DESCRIPTION
## Summary
- avoid borrowing conflicts when showing and saving file meta
- clone file extension before reuse and update timestamp parsing to `DateTime::from_timestamp`

## Testing
- `cargo check -p desktop`


------
https://chatgpt.com/codex/tasks/task_e_68a69542d10c83238250c79828480d8d