### PR TITLE
Gracefully handle file manager errors

### DIFF
--- a/desktop/src/app/events/handler.rs
+++ b/desktop/src/app/events/handler.rs
@@ -415,6 +415,10 @@ impl MulticodeApp {
                 self.files = list;
                 Command::none()
             }
+            Message::FileError(e) => {
+                self.log.push(format!("ошибка файла: {e}"));
+                Command::none()
+            }
             Message::DefaultEntryPicked(path) => {
                 if let Some(p) = path {
                     self.settings.default_entry = Some(p.clone());

--- a/desktop/src/app/events/message.rs
+++ b/desktop/src/app/events/message.rs
@@ -115,4 +115,5 @@ pub enum Message {
     ToggleCommandPalette,
     ExecuteCommand(String),
     SwitchViewMode(ViewMode),
+    FileError(String),
 }

--- a/desktop/src/app/io.rs
+++ b/desktop/src/app/io.rs
@@ -85,9 +85,12 @@ impl MulticodeApp {
                     visit(&root, &tabs_meta)
                 })
                 .await
-                .unwrap()
+                .map_err(|e| e.to_string())
             },
-            Message::FilesLoaded,
+            |res| match res {
+                Ok(list) => Message::FilesLoaded(list),
+                Err(e) => Message::FileError(e),
+            },
         )
     }
 

--- a/desktop/src/components/file_manager.rs
+++ b/desktop/src/components/file_manager.rs
@@ -117,16 +117,30 @@ pub fn view_entries(
             });
         match &entry.ty {
             EntryType::File => {
-                let name = entry
-                    .path
-                    .file_name()
-                    .unwrap()
-                    .to_string_lossy()
-                    .to_string();
-                let name = if entry.has_meta {
-                    format!("{} ◆", name)
+                let name = if let Some(name) = entry.path.file_name() {
+                    let name = name.to_string_lossy().to_string();
+                    if entry.has_meta {
+                        format!("{} ◆", name)
+                    } else {
+                        name
+                    }
                 } else {
-                    name
+                    rows.push(
+                        row![
+                            indent,
+                            fav_button,
+                            button(text("Ошибка"))
+                                .on_press(Message::FileError(format!(
+                                    "не удалось получить имя файла: {}",
+                                    entry.path.display()
+                                ))),
+                        ]
+                        .spacing(5)
+                        .align_items(Alignment::Center)
+                        .height(Length::Fixed(20.0))
+                        .into(),
+                    );
+                    continue;
                 };
                 let ext = entry
                     .path
@@ -156,12 +170,26 @@ pub fn view_entries(
                 rows.push(row);
             }
             EntryType::Dir => {
-                let name = entry
-                    .path
-                    .file_name()
-                    .unwrap()
-                    .to_string_lossy()
-                    .to_string();
+                let name = if let Some(name) = entry.path.file_name() {
+                    name.to_string_lossy().to_string()
+                } else {
+                    rows.push(
+                        row![
+                            indent,
+                            fav_button,
+                            button(text("Ошибка"))
+                                .on_press(Message::FileError(format!(
+                                    "не удалось получить имя каталога: {}",
+                                    entry.path.display()
+                                ))),
+                        ]
+                        .spacing(5)
+                        .align_items(Alignment::Center)
+                        .height(Length::Fixed(20.0))
+                        .into(),
+                    );
+                    continue;
+                };
                 let expanded = expanded_dirs.contains(&entry.path);
                 let icon = if expanded { "▼" } else { "▶" };
                 let content = row![text(icon), text(name)]


### PR DESCRIPTION
## Summary
- avoid unwraps in file manager component and propagate errors as `Message::FileError`
- add `FileError` message variant and log handling
- map async file loading failures to `FileError`

## Testing
- `cargo test -p desktop`

------
https://chatgpt.com/codex/tasks/task_e_68a6b7b284608323aca411103d705ed5