### PR TITLE
feat: add file-manager plugin hooks

### DIFF
--- a/desktop/src/app/events/handler.rs
+++ b/desktop/src/app/events/handler.rs
@@ -599,6 +599,7 @@ impl MulticodeApp {
                     .unwrap_or_default();
                 let blame_path = path.clone();
                 let meta = meta::read_all(&content).into_iter().next();
+                file_manager::emit_open(&path);
                 self.tabs.push(Tab {
                     path,
                     content,
@@ -756,6 +757,7 @@ impl MulticodeApp {
             }
             Message::FileCreated(Ok(path)) => {
                 self.log.push(format!("создан {}", path.display()));
+                file_manager::emit_create(&path);
                 self.new_file_name.clear();
                 self.tabs.push(Tab {
                     path: path.clone(),
@@ -831,7 +833,9 @@ impl MulticodeApp {
             Message::FileRenamed(Ok(path)) => {
                 self.log.push(format!("переименовано в {}", path.display()));
                 if let Some(i) = self.active_tab {
+                    let old = self.tabs[i].path.clone();
                     self.tabs[i].path = path.clone();
+                    file_manager::emit_rename(&old, &path);
                 }
                 self.rename_file_name.clear();
                 return self.load_files(self.current_root_path().unwrap());
@@ -872,6 +876,7 @@ impl MulticodeApp {
             }
             Message::FileDeleted(Ok(path)) => {
                 self.log.push(format!("удален {}", path.display()));
+                file_manager::emit_delete(&path);
                 if let Some(idx) = self.tabs.iter().position(|f| f.path == path) {
                     self.tabs.remove(idx);
                     if let Some(active) = self.active_tab {

--- a/desktop/src/components/mod.rs
+++ b/desktop/src/components/mod.rs
@@ -1,3 +1,10 @@
 pub mod file_manager;
 
-pub use file_manager::{file_tree, view_entries, ContextMenu, ContextMenuItem};
+pub use file_manager::{
+    file_tree,
+    view_entries,
+    ContextMenu,
+    ContextMenuItem,
+    FileManagerPlugin,
+    register_plugin,
+};

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -17,6 +17,25 @@ pub trait Plugin: Send + Sync {
 `BlockDescriptor` описывает тип блока, который предоставляет плагин: идентификатор
 вида, человекочитаемую метку и версию реализации.
 
+## События файлового менеджера
+
+Помимо расширения системы новыми блоками, плагины могут реагировать на события
+файлового менеджера. Для этого следует реализовать трейт `FileManagerPlugin`:
+
+```rust
+use std::path::Path;
+
+pub trait FileManagerPlugin: Send + Sync {
+    fn on_open(&self, path: &Path) {}
+    fn on_create(&self, path: &Path) {}
+    fn on_delete(&self, path: &Path) {}
+    fn on_rename(&self, from: &Path, to: &Path) {}
+}
+```
+
+Методы вызываются после соответствующих операций и позволяют добавлять
+кастомное поведение при открытии, создании, удалении и переименовании файлов.
+
 ## WebAssembly плагины
 
 Backend может загружать плагины, собранные в WebAssembly, через


### PR DESCRIPTION
## Summary
- add `FileManagerPlugin` trait and registration utilities
- emit plugin events on open/create/rename/delete
- document file-manager plugin interface

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68a6d638245883239ae4d6fa5e784dee