### PR TITLE
Add tests for markdown markdown preview

### DIFF
--- a/desktop/src/editor/code_editor.rs
+++ b/desktop/src/editor/code_editor.rs
@@ -36,7 +36,7 @@ fn load_highlighting(
     (syntax, theme)
 }
 
-fn markdown_preview(content: &str) -> Column<Element<Message>> {
+pub(super) fn markdown_preview(content: &str) -> Column<'static, Message> {
     use pulldown_cmark::{Event, HeadingLevel, Parser, Tag};
 
     let parser = Parser::new(content);

--- a/desktop/src/editor/code_editor_tests.rs
+++ b/desktop/src/editor/code_editor_tests.rs
@@ -1,0 +1,14 @@
+use super::code_editor::markdown_preview;
+use iced::advanced::Widget;
+
+#[test]
+fn markdown_preview_renders_heading() {
+    let preview = markdown_preview("# Heading");
+    assert_eq!(preview.children().len(), 1);
+}
+
+#[test]
+fn markdown_preview_renders_list_items() {
+    let preview = markdown_preview("- item1\n- item2");
+    assert_eq!(preview.children().len(), 2);
+}

--- a/desktop/src/editor/mod.rs
+++ b/desktop/src/editor/mod.rs
@@ -2,3 +2,6 @@ pub mod code_editor;
 
 pub use code_editor::CodeEditor;
 pub use code_editor::THEME_SET;
+
+#[cfg(test)]
+mod code_editor_tests;


### PR DESCRIPTION
## Summary
- expose `markdown_preview` for testing
- test heading and list item rendering in markdown preview

## Testing
- `cargo test -p desktop`


------
https://chatgpt.com/codex/tasks/task_e_68a6fd4ff8108323998904b39258fadf