### PR TITLE
Add undo/redo to desktop code editor

### DIFF
--- a/desktop/src/app/events/message.rs
+++ b/desktop/src/app/events/message.rs
@@ -17,6 +17,8 @@ pub enum Message {
     SelectFile(PathBuf),
     FileLoaded(Result<(PathBuf, String), String>),
     FileContentEdited(text_editor::Action),
+    Undo,
+    Redo,
     SearchTermChanged(String),
     ReplaceTermChanged(String),
     Find,

--- a/desktop/src/app/state.rs
+++ b/desktop/src/app/state.rs
@@ -145,6 +145,8 @@ pub struct Tab {
     pub diagnostics: Vec<Diagnostic>,
     pub blocks: Vec<BlockInfo>,
     pub meta: Option<VisualMeta>,
+    pub undo_stack: Vec<String>,
+    pub redo_stack: Vec<String>,
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
## Summary
- extend Message enum with Undo and Redo
- maintain undo/redo stacks per tab and handle actions
- map Ctrl+Z/Y hotkeys to undo/redo

## Testing
- `cargo test -p desktop`

------
https://chatgpt.com/codex/tasks/task_e_68a718a309b08323b239bb7a6131508f