### PR TITLE
Parse and validate visual meta comments

### DIFF
--- a/desktop/src/app/events/handler.rs
+++ b/desktop/src/app/events/handler.rs
@@ -5,6 +5,7 @@ use crate::app::{
     MulticodeApp, PendingAction, Screen, Tab, TabDragState, ViewMode, EntryType,
 };
 use crate::components::file_manager::{self, ContextMenu};
+use crate::editor::meta_integration::validate_meta_json;
 use crate::editor::autocomplete::{self, AutocompleteState};
 use chrono::Utc;
 use iced::widget::{
@@ -650,6 +651,7 @@ impl MulticodeApp {
                     .unwrap_or_default();
                 let blame_path = path.clone();
                 let meta = meta::read_all(&content).into_iter().next();
+                let diagnostics = validate_meta_json(&content);
                 file_manager::emit_open(&path);
                 self.tabs.push(Tab {
                     path,
@@ -657,7 +659,7 @@ impl MulticodeApp {
                     editor,
                     dirty: false,
                     blame: HashMap::new(),
-                    diagnostics: Vec::new(),
+                    diagnostics,
                     blocks,
                     meta,
                     undo_stack: Vec::new(),
@@ -699,6 +701,7 @@ impl MulticodeApp {
                             f.blocks.clear();
                         }
                     }
+                    f.diagnostics = validate_meta_json(&f.content);
                     if is_edit {
                         f.dirty = true;
                     }

--- a/desktop/src/editor/meta_integration.rs
+++ b/desktop/src/editor/meta_integration.rs
@@ -1,0 +1,59 @@
+use once_cell::sync::Lazy;
+use regex::Regex;
+use std::ops::Range;
+
+use multicode_core::meta::{self, VisualMeta};
+
+use crate::app::Diagnostic;
+
+static META_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(r"@VISUAL_META\s*(\{.*\})").unwrap());
+
+/// Find all `@VISUAL_META` comments in `content`.
+/// Returns tuples of `(line_index, json_range, json)`.
+pub fn find_meta_comments(content: &str) -> Vec<(usize, Range<usize>, String)> {
+    let mut out = Vec::new();
+    for (line_idx, line) in content.lines().enumerate() {
+        if let Some(caps) = META_REGEX.captures(line) {
+            if let Some(m) = caps.get(1) {
+                out.push((line_idx, m.start()..m.end(), m.as_str().to_string()));
+            }
+        }
+    }
+    out
+}
+
+/// Insert a new visual meta comment into `content`.
+pub fn insert_meta_comment(content: &str, meta: &VisualMeta) -> String {
+    meta::upsert(content, meta)
+}
+
+/// Update existing `@VISUAL_META` comment or insert if missing.
+pub fn update_meta_comment(content: &str, meta: &VisualMeta) -> String {
+    meta::upsert(content, meta)
+}
+
+/// Validate JSON inside `@VISUAL_META` comments and produce diagnostics.
+pub fn validate_meta_json(content: &str) -> Vec<Diagnostic> {
+    let mut diags = Vec::new();
+    for (line, range, json) in find_meta_comments(content) {
+        match serde_json::from_str::<VisualMeta>(&json) {
+            Ok(meta) => {
+                if let Err(errors) = meta::validate(&meta) {
+                    for e in errors {
+                        diags.push(Diagnostic {
+                            line,
+                            range: range.clone(),
+                            message: format!("{}: {}", e.field, e.message),
+                        });
+                    }
+                }
+            }
+            Err(e) => diags.push(Diagnostic {
+                line,
+                range,
+                message: e.to_string(),
+            }),
+        }
+    }
+    diags
+}

--- a/desktop/src/editor/mod.rs
+++ b/desktop/src/editor/mod.rs
@@ -1,10 +1,11 @@
-pub mod code_editor;
 pub mod autocomplete;
+pub mod code_editor;
+pub mod meta_integration;
 pub mod syntax_highlighter;
 
+pub use autocomplete::{suggestions, AutocompleteState, Suggestion};
 pub use code_editor::CodeEditor;
 pub use syntax_highlighter::THEME_SET;
-pub use autocomplete::{AutocompleteState, Suggestion, suggestions};
 
 #[cfg(test)]
 mod code_editor_tests;


### PR DESCRIPTION
## Summary
- integrate helper for finding and validating `@VISUAL_META` comments
- flag malformed meta JSON as diagnostics when opening or editing files

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68a7490fa1248323b28463eba1d41fb8