### PR TITLE
feat: add editor settings and themes

### DIFF
--- a/desktop/src/app/actions.rs
+++ b/desktop/src/app/actions.rs
@@ -129,6 +129,7 @@ impl Application for MulticodeApp {
         match self.settings.theme {
             AppTheme::Light => Theme::Light,
             AppTheme::Dark => Theme::Dark,
+            AppTheme::HighContrast => Theme::Dark,
         }
     }
 

--- a/desktop/src/app/events/handler.rs
+++ b/desktop/src/app/events/handler.rs
@@ -223,6 +223,34 @@ impl MulticodeApp {
                 self.settings.language = lang;
                 Command::none()
             }
+            Message::FontSizeChanged(value) => {
+                if let Ok(v) = value.parse() {
+                    self.settings.editor.font_size = v;
+                }
+                Command::none()
+            }
+            Message::TabWidthChanged(value) => {
+                if let Ok(v) = value.parse() {
+                    self.settings.editor.tab_width = v;
+                }
+                Command::none()
+            }
+            Message::ToggleAutoIndent(val) => {
+                self.settings.editor.auto_indent = val;
+                Command::none()
+            }
+            Message::ToggleLineWrapping(val) => {
+                self.settings.editor.line_wrapping = val;
+                Command::none()
+            }
+            Message::ToggleHighlightCurrentLine(val) => {
+                self.settings.editor.highlight_current_line = val;
+                Command::none()
+            }
+            Message::EditorThemeSelected(theme) => {
+                self.settings.editor.theme = theme;
+                Command::none()
+            }
             Message::ToggleLineNumbers(value) => {
                 self.settings.show_line_numbers = value;
                 Command::none()

--- a/desktop/src/app/events/message.rs
+++ b/desktop/src/app/events/message.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 
 use crate::app::diff::DiffView;
 use crate::app::{AppTheme, CreateTarget, Diagnostic, FileEntry, HotkeyField, Language, ViewMode};
+use crate::editor::EditorTheme;
 
 #[derive(Debug, Clone)]
 pub enum Message {
@@ -87,6 +88,12 @@ pub enum Message {
     ThemeSelected(AppTheme),
     SyntectThemeSelected(String),
     LanguageSelected(Language),
+    FontSizeChanged(String),
+    TabWidthChanged(String),
+    ToggleAutoIndent(bool),
+    ToggleLineWrapping(bool),
+    ToggleHighlightCurrentLine(bool),
+    EditorThemeSelected(EditorTheme),
     ToggleLineNumbers(bool),
     ToggleStatusBar(bool),
     ToggleToolbar(bool),

--- a/desktop/src/app/state.rs
+++ b/desktop/src/app/state.rs
@@ -10,7 +10,7 @@ use tokio::{fs, process::Child, sync::broadcast};
 
 use crate::app::diff::DiffView;
 use crate::components::file_manager::ContextMenu;
-use crate::editor::autocomplete::AutocompleteState;
+use crate::editor::{AutocompleteState, EditorSettings};
 
 mod serde_color {
     use iced::Color;
@@ -303,10 +303,11 @@ impl Default for EditorMode {
 pub enum AppTheme {
     Light,
     Dark,
+    HighContrast,
 }
 
 impl AppTheme {
-    pub const ALL: [AppTheme; 2] = [AppTheme::Light, AppTheme::Dark];
+    pub const ALL: [AppTheme; 3] = [AppTheme::Light, AppTheme::Dark, AppTheme::HighContrast];
 }
 
 impl Default for AppTheme {
@@ -320,6 +321,7 @@ impl fmt::Display for AppTheme {
         match self {
             AppTheme::Light => write!(f, "Light"),
             AppTheme::Dark => write!(f, "Dark"),
+            AppTheme::HighContrast => write!(f, "High Contrast"),
         }
     }
 }
@@ -381,6 +383,8 @@ pub struct UserSettings {
     pub theme: AppTheme,
     #[serde(default = "default_syntect_theme")]
     pub syntect_theme: String,
+    #[serde(default)]
+    pub editor: EditorSettings,
     #[serde(default = "default_match_color", with = "serde_color")]
     pub match_color: Color,
     #[serde(default = "default_diagnostic_color", with = "serde_color")]
@@ -409,6 +413,7 @@ impl Default for UserSettings {
             editor_mode: EditorMode::Text,
             theme: AppTheme::default(),
             syntect_theme: default_syntect_theme(),
+            editor: EditorSettings::default(),
             match_color: default_match_color(),
             diagnostic_color: default_diagnostic_color(),
             language: Language::default(),

--- a/desktop/src/app/view.rs
+++ b/desktop/src/app/view.rs
@@ -10,7 +10,7 @@ use iced::{alignment, theme, Element, Length};
 
 use super::events::Message;
 use super::{AppTheme, CreateTarget, HotkeyField, Language, MulticodeApp, Screen, ViewMode};
-use crate::editor::{CodeEditor, THEME_SET};
+use crate::editor::{CodeEditor, EditorTheme, THEME_SET};
 use crate::components::file_manager;
 
 const TERMINAL_HELP: &str = include_str!("../../assets/terminal-help.md");
@@ -483,6 +483,53 @@ impl MulticodeApp {
                         text("Предпросмотр Markdown"),
                         checkbox("", self.settings.show_markdown_preview)
                             .on_toggle(Message::ToggleMarkdownPreview),
+                    ]
+                    .spacing(10),
+                    row![
+                        text("Размер шрифта"),
+                        text_input(
+                            "",
+                            &self.settings.editor.font_size.to_string()
+                        )
+                        .on_input(Message::FontSizeChanged)
+                        .width(Length::Fixed(50.0)),
+                    ]
+                    .spacing(10),
+                    row![
+                        text("Ширина табуляции"),
+                        text_input(
+                            "",
+                            &self.settings.editor.tab_width.to_string()
+                        )
+                        .on_input(Message::TabWidthChanged)
+                        .width(Length::Fixed(50.0)),
+                    ]
+                    .spacing(10),
+                    row![
+                        text("Автоотступы"),
+                        checkbox("", self.settings.editor.auto_indent)
+                            .on_toggle(Message::ToggleAutoIndent),
+                    ]
+                    .spacing(10),
+                    row![
+                        text("Перенос строк"),
+                        checkbox("", self.settings.editor.line_wrapping)
+                            .on_toggle(Message::ToggleLineWrapping),
+                    ]
+                    .spacing(10),
+                    row![
+                        text("Подсветка строки"),
+                        checkbox("", self.settings.editor.highlight_current_line)
+                            .on_toggle(Message::ToggleHighlightCurrentLine),
+                    ]
+                    .spacing(10),
+                    row![
+                        text("Тема редактора"),
+                        pick_list(
+                            &EditorTheme::ALL[..],
+                            Some(self.settings.editor.theme),
+                            Message::EditorThemeSelected
+                        ),
                     ]
                     .spacing(10),
                     row![

--- a/desktop/src/editor/mod.rs
+++ b/desktop/src/editor/mod.rs
@@ -2,10 +2,12 @@ pub mod autocomplete;
 pub mod code_editor;
 pub mod meta_integration;
 pub mod syntax_highlighter;
+pub mod settings;
 
 pub use autocomplete::{suggestions, AutocompleteState, Suggestion};
 pub use code_editor::CodeEditor;
 pub use syntax_highlighter::THEME_SET;
+pub use settings::{EditorSettings, EditorTheme, CustomTheme};
 
 #[cfg(test)]
 mod code_editor_tests;

--- a/desktop/src/editor/settings.rs
+++ b/desktop/src/editor/settings.rs
@@ -1,0 +1,121 @@
+use iced::Color;
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+mod serde_color {
+    use iced::Color;
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    pub fn serialize<S>(color: &Color, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        [color.r, color.g, color.b].serialize(serializer)
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Color, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let [r, g, b] = <[f32; 3]>::deserialize(deserializer)?;
+        Ok(Color::from_rgb(r, g, b))
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum EditorTheme {
+    Light,
+    Dark,
+    HighContrast,
+    Custom,
+}
+
+impl EditorTheme {
+    pub const ALL: [EditorTheme; 4] = [
+        EditorTheme::Light,
+        EditorTheme::Dark,
+        EditorTheme::HighContrast,
+        EditorTheme::Custom,
+    ];
+}
+
+impl Default for EditorTheme {
+    fn default() -> Self {
+        EditorTheme::Light
+    }
+}
+
+impl fmt::Display for EditorTheme {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            EditorTheme::Light => write!(f, "Light"),
+            EditorTheme::Dark => write!(f, "Dark"),
+            EditorTheme::HighContrast => write!(f, "High Contrast"),
+            EditorTheme::Custom => write!(f, "Custom"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CustomTheme {
+    #[serde(with = "serde_color")]
+    pub background: Color,
+    #[serde(with = "serde_color")]
+    pub foreground: Color,
+    #[serde(with = "serde_color")]
+    pub current_line: Color,
+}
+
+impl Default for CustomTheme {
+    fn default() -> Self {
+        Self {
+            background: Color::from_rgb(1.0, 1.0, 1.0),
+            foreground: Color::from_rgb(0.0, 0.0, 0.0),
+            current_line: Color::from_rgb(0.9, 0.9, 0.9),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EditorSettings {
+    #[serde(default = "default_font_size")]
+    pub font_size: u16,
+    #[serde(default = "default_tab_width")]
+    pub tab_width: u8,
+    #[serde(default = "default_true")]
+    pub auto_indent: bool,
+    #[serde(default)]
+    pub line_wrapping: bool,
+    #[serde(default = "default_true")]
+    pub highlight_current_line: bool,
+    #[serde(default)]
+    pub theme: EditorTheme,
+    #[serde(default)]
+    pub custom_theme: CustomTheme,
+}
+
+fn default_font_size() -> u16 {
+    14
+}
+
+fn default_tab_width() -> u8 {
+    4
+}
+
+fn default_true() -> bool {
+    true
+}
+
+impl Default for EditorSettings {
+    fn default() -> Self {
+        Self {
+            font_size: default_font_size(),
+            tab_width: default_tab_width(),
+            auto_indent: true,
+            line_wrapping: false,
+            highlight_current_line: true,
+            theme: EditorTheme::Light,
+            custom_theme: CustomTheme::default(),
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- define configurable `EditorSettings` with theme and layout options
- integrate editor settings and new themes into user preferences and UI

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a74d4430a48323a53c3604d1dc8d43