### PR TITLE
Optimize highlighting and history management

### DIFF
--- a/desktop/src/app/events/message.rs
+++ b/desktop/src/app/events/message.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 
 use crate::app::diff::DiffView;
 use crate::app::{AppTheme, CreateTarget, Diagnostic, FileEntry, HotkeyField, Language, ViewMode};
+use multicode_core::BlockInfo;
 use crate::editor::EditorTheme;
 
 #[derive(Debug, Clone)]
@@ -20,6 +21,7 @@ pub enum Message {
     FileContentEdited(text_editor::Action),
     Undo,
     Redo,
+    AnalysisReady(PathBuf, u64, Vec<BlockInfo>, Vec<Diagnostic>),
     SearchTermChanged(String),
     ReplaceTermChanged(String),
     Find,

--- a/desktop/src/app/state.rs
+++ b/desktop/src/app/state.rs
@@ -2,7 +2,7 @@ use directories::ProjectDirs;
 use iced::{widget::text_editor, Color};
 use multicode_core::{git, meta::VisualMeta, BlockInfo};
 use serde::{Deserialize, Serialize};
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::fmt;
 use std::ops::Range;
 use std::path::PathBuf;
@@ -145,8 +145,9 @@ pub struct Tab {
     pub diagnostics: Vec<Diagnostic>,
     pub blocks: Vec<BlockInfo>,
     pub meta: Option<VisualMeta>,
-    pub undo_stack: Vec<String>,
-    pub redo_stack: Vec<String>,
+    pub undo_stack: VecDeque<String>,
+    pub redo_stack: VecDeque<String>,
+    pub analysis_version: u64,
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
## Summary
- cache syntax highlighting results to process only requested lines
- debounce expensive file analysis after edits
- cap undo/redo history to prevent unbounded memory use

## Testing
- `npm test`
- `npm run test:canvas`


------
https://chatgpt.com/codex/tasks/task_e_68a75b713d308323a63d4c31c1186a55