### PR TITLE
feat: add interactive visual canvas

### DIFF
--- a/desktop/src/app/events/message.rs
+++ b/desktop/src/app/events/message.rs
@@ -3,8 +3,9 @@ use std::path::PathBuf;
 
 use crate::app::diff::DiffView;
 use crate::app::{AppTheme, CreateTarget, Diagnostic, FileEntry, HotkeyField, Language, ViewMode};
-use multicode_core::BlockInfo;
 use crate::editor::EditorTheme;
+use crate::visual::canvas::CanvasMessage;
+use multicode_core::BlockInfo;
 
 #[derive(Debug, Clone)]
 pub enum Message {
@@ -131,4 +132,5 @@ pub enum Message {
     NavigateDown,
     NavigateInto,
     NavigateBack,
+    CanvasEvent(CanvasMessage),
 }

--- a/desktop/src/app/ui.rs
+++ b/desktop/src/app/ui.rs
@@ -1,3 +1,4 @@
+use iced::widget::canvas::Canvas;
 use iced::widget::svg::{Handle, Svg};
 use iced::widget::{
     button, checkbox, column, container, row, scrollable, text, text_input, MouseArea, Space,
@@ -8,6 +9,8 @@ use crate::app::diff::DiffView;
 use crate::app::events::Message;
 use crate::app::{command_palette::COMMANDS, MulticodeApp};
 use crate::modal::Modal;
+use crate::visual::canvas::{CanvasMessage, VisualCanvas};
+use multicode_core::BlockInfo;
 
 const OPEN_ICON: &[u8] = include_bytes!("../../assets/open.svg");
 const SAVE_ICON: &[u8] = include_bytes!("../../assets/save.svg");
@@ -191,20 +194,24 @@ impl MulticodeApp {
     }
 
     pub fn visual_editor_component(&self) -> Element<Message> {
-        let editor = container(text("visual editor stub"))
+        let blocks: &[BlockInfo] = self
+            .current_file()
+            .map(|f| f.blocks.as_slice())
+            .unwrap_or(&[]);
+        let canvas_widget = Canvas::new(VisualCanvas::new(blocks))
             .width(Length::Fill)
-            .height(Length::Fill)
-            .center_x()
-            .center_y();
+            .height(Length::Fill);
+        let canvas: Element<CanvasMessage> = canvas_widget.into();
+        let canvas = canvas.map(Message::CanvasEvent);
         if self.show_meta_panel {
             row![
-                editor.width(Length::FillPortion(3)),
+                container(canvas).width(Length::FillPortion(3)),
                 self.meta_panel_component()
             ]
             .spacing(5)
             .into()
         } else {
-            editor.into()
+            canvas
         }
     }
 

--- a/desktop/src/lib.rs
+++ b/desktop/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod app;
 pub mod components;
-pub mod modal;
 pub mod editor;
+pub mod modal;
+pub mod visual;

--- a/desktop/src/visual/canvas.rs
+++ b/desktop/src/visual/canvas.rs
@@ -1,0 +1,228 @@
+use iced::widget::canvas::{self, Event, Frame, Geometry, Path, Program, Stroke, Text};
+use iced::{mouse, Point, Rectangle, Renderer, Theme, Vector};
+
+use multicode_core::BlockInfo;
+
+pub const BLOCK_WIDTH: f32 = 120.0;
+pub const BLOCK_HEIGHT: f32 = 40.0;
+
+#[derive(Debug, Clone)]
+pub enum CanvasMessage {
+    Pan { delta: Vector },
+    Zoom { factor: f32, center: Point },
+    BlockSelected(Option<usize>),
+    BlockDragged { index: usize, position: Point },
+}
+
+pub struct VisualCanvas<'a> {
+    blocks: &'a [BlockInfo],
+}
+
+pub struct State {
+    offset: Vector,
+    scale: f32,
+    selected: Option<usize>,
+    drag: Option<Drag>,
+    panning: bool,
+    last_cursor: Point,
+}
+
+#[derive(Debug, Clone)]
+struct Drag {
+    index: usize,
+    grab: Vector,
+}
+
+impl Default for State {
+    fn default() -> Self {
+        Self {
+            offset: Vector::new(0.0, 0.0),
+            scale: 1.0,
+            selected: None,
+            drag: None,
+            panning: false,
+            last_cursor: Point::ORIGIN,
+        }
+    }
+}
+
+impl<'a> VisualCanvas<'a> {
+    pub fn new(blocks: &'a [BlockInfo]) -> Self {
+        Self { blocks }
+    }
+}
+
+fn contains(block: &BlockInfo, pos: Point) -> bool {
+    pos.x >= block.x as f32
+        && pos.x <= block.x as f32 + BLOCK_WIDTH
+        && pos.y >= block.y as f32
+        && pos.y <= block.y as f32 + BLOCK_HEIGHT
+}
+
+impl<'a> Program<CanvasMessage> for VisualCanvas<'a> {
+    type State = State;
+
+    fn update(
+        &self,
+        state: &mut Self::State,
+        event: Event,
+        bounds: Rectangle,
+        cursor: mouse::Cursor,
+    ) -> (canvas::event::Status, Option<CanvasMessage>) {
+        match event {
+            Event::Mouse(mouse::Event::WheelScrolled { delta }) => {
+                if let Some(pos) = cursor.position_in(bounds) {
+                    let y = match delta {
+                        mouse::ScrollDelta::Lines { y, .. } => y,
+                        mouse::ScrollDelta::Pixels { y, .. } => y / 120.0,
+                    };
+                    let factor = if y > 0.0 { 1.1 } else { 0.9 };
+                    state.scale = (state.scale * factor).clamp(0.1, 4.0);
+                    return (
+                        canvas::event::Status::Captured,
+                        Some(CanvasMessage::Zoom {
+                            factor: state.scale,
+                            center: pos,
+                        }),
+                    );
+                }
+            }
+            Event::Mouse(mouse::Event::ButtonPressed(button)) => {
+                if let Some(pos) = cursor.position_in(bounds) {
+                    match button {
+                        mouse::Button::Left => {
+                            let canvas_pos = Point::new(
+                                (pos.x - state.offset.x) / state.scale,
+                                (pos.y - state.offset.y) / state.scale,
+                            );
+                            if let Some((idx, block)) = self
+                                .blocks
+                                .iter()
+                                .enumerate()
+                                .find(|(_, b)| contains(b, canvas_pos))
+                            {
+                                state.selected = Some(idx);
+                                let grab = Vector::new(
+                                    canvas_pos.x - block.x as f32,
+                                    canvas_pos.y - block.y as f32,
+                                );
+                                state.drag = Some(Drag { index: idx, grab });
+                                return (
+                                    canvas::event::Status::Captured,
+                                    Some(CanvasMessage::BlockSelected(Some(idx))),
+                                );
+                            } else {
+                                state.selected = None;
+                                state.drag = None;
+                                return (
+                                    canvas::event::Status::Captured,
+                                    Some(CanvasMessage::BlockSelected(None)),
+                                );
+                            }
+                        }
+                        mouse::Button::Right => {
+                            state.panning = true;
+                            state.last_cursor = pos;
+                            return (canvas::event::Status::Captured, None);
+                        }
+                        _ => {}
+                    }
+                }
+            }
+            Event::Mouse(mouse::Event::ButtonReleased(button)) => match button {
+                mouse::Button::Left => {
+                    if let Some(drag) = state.drag.take() {
+                        if let Some(pos) = cursor.position_in(bounds) {
+                            let canvas_pos = Point::new(
+                                (pos.x - state.offset.x) / state.scale,
+                                (pos.y - state.offset.y) / state.scale,
+                            );
+                            let new_pos =
+                                Point::new(canvas_pos.x - drag.grab.x, canvas_pos.y - drag.grab.y);
+                            return (
+                                canvas::event::Status::Captured,
+                                Some(CanvasMessage::BlockDragged {
+                                    index: drag.index,
+                                    position: new_pos,
+                                }),
+                            );
+                        }
+                    }
+                }
+                mouse::Button::Right => {
+                    if state.panning {
+                        state.panning = false;
+                        return (canvas::event::Status::Captured, None);
+                    }
+                }
+                _ => {}
+            },
+            Event::Mouse(mouse::Event::CursorMoved { .. }) => {
+                if let Some(pos) = cursor.position_in(bounds) {
+                    if state.panning {
+                        let delta = pos - state.last_cursor;
+                        state.last_cursor = pos;
+                        state.offset = state.offset + delta;
+                        return (
+                            canvas::event::Status::Captured,
+                            Some(CanvasMessage::Pan { delta }),
+                        );
+                    }
+                    if let Some(drag) = state.drag.as_ref() {
+                        let canvas_pos = Point::new(
+                            (pos.x - state.offset.x) / state.scale,
+                            (pos.y - state.offset.y) / state.scale,
+                        );
+                        let new_pos =
+                            Point::new(canvas_pos.x - drag.grab.x, canvas_pos.y - drag.grab.y);
+                        return (
+                            canvas::event::Status::Captured,
+                            Some(CanvasMessage::BlockDragged {
+                                index: drag.index,
+                                position: new_pos,
+                            }),
+                        );
+                    }
+                }
+            }
+            _ => {}
+        }
+        (canvas::event::Status::Ignored, None)
+    }
+
+    fn draw(
+        &self,
+        state: &Self::State,
+        renderer: &Renderer,
+        _theme: &Theme,
+        bounds: Rectangle,
+        _cursor: mouse::Cursor,
+    ) -> Vec<Geometry> {
+        let mut frame = Frame::new(renderer, bounds.size());
+
+        frame.translate(state.offset);
+        frame.scale(state.scale);
+
+        for (i, block) in self.blocks.iter().enumerate() {
+            let rect = Path::rectangle(
+                Point::new(block.x as f32, block.y as f32),
+                iced::Size::new(BLOCK_WIDTH, BLOCK_HEIGHT),
+            );
+            let color = if state.selected == Some(i) {
+                iced::Color::from_rgb(0.8, 0.3, 0.3)
+            } else {
+                iced::Color::from_rgb(0.3, 0.3, 0.7)
+            };
+            frame.fill(&rect, color);
+            frame.stroke(&rect, Stroke::default());
+            frame.fill_text(Text {
+                content: block.kind.clone(),
+                position: Point::new(block.x as f32 + 5.0, block.y as f32 + 20.0),
+                color: iced::Color::BLACK,
+                ..Default::default()
+            });
+        }
+
+        vec![frame.into_geometry()]
+    }
+}

--- a/desktop/src/visual/mod.rs
+++ b/desktop/src/visual/mod.rs
@@ -1,0 +1,1 @@
+pub mod canvas;


### PR DESCRIPTION
## Summary
- add VisualCanvas with pan, zoom, select, and drag support
- wire VisualCanvas into MainUI and event system

## Testing
- `cargo test -p desktop`

------
https://chatgpt.com/codex/tasks/task_e_68a76ddbad00832381795b1c89d133c1