### PR TITLE
feat: add visual block enums and colors

### DIFF
--- a/desktop/src/visual/blocks/arithmetic.rs
+++ b/desktop/src/visual/blocks/arithmetic.rs
@@ -1,0 +1,9 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ArithmeticBlock {
+    Add,
+    Subtract,
+    Multiply,
+    Divide,
+}

--- a/desktop/src/visual/blocks/conditional.rs
+++ b/desktop/src/visual/blocks/conditional.rs
@@ -1,0 +1,8 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ConditionalBlock {
+    If,
+    ElseIf,
+    Else,
+}

--- a/desktop/src/visual/blocks/functions.rs
+++ b/desktop/src/visual/blocks/functions.rs
@@ -1,0 +1,8 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum FunctionBlock {
+    Define,
+    Call,
+    Return,
+}

--- a/desktop/src/visual/blocks/loops.rs
+++ b/desktop/src/visual/blocks/loops.rs
@@ -1,0 +1,8 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum LoopBlock {
+    For,
+    While,
+    Loop,
+}

--- a/desktop/src/visual/blocks/mod.rs
+++ b/desktop/src/visual/blocks/mod.rs
@@ -1,0 +1,43 @@
+use iced::Color;
+
+pub mod arithmetic;
+pub mod conditional;
+pub mod functions;
+pub mod loops;
+pub mod variables;
+
+pub use arithmetic::ArithmeticBlock;
+pub use conditional::ConditionalBlock;
+pub use functions::FunctionBlock;
+pub use loops::LoopBlock;
+pub use variables::VariableBlock;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BlockType {
+    Arithmetic(ArithmeticBlock),
+    Conditional(ConditionalBlock),
+    Loop(LoopBlock),
+    Variable(VariableBlock),
+    Function(FunctionBlock),
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct BlockColors {
+    pub arithmetic: Color,
+    pub conditional: Color,
+    pub loops: Color,
+    pub variables: Color,
+    pub functions: Color,
+}
+
+impl Default for BlockColors {
+    fn default() -> Self {
+        Self {
+            arithmetic: Color::from_rgb(0.9, 0.3, 0.3),
+            conditional: Color::from_rgb(0.3, 0.9, 0.3),
+            loops: Color::from_rgb(0.3, 0.3, 0.9),
+            variables: Color::from_rgb(0.9, 0.9, 0.3),
+            functions: Color::from_rgb(0.9, 0.3, 0.9),
+        }
+    }
+}

--- a/desktop/src/visual/blocks/variables.rs
+++ b/desktop/src/visual/blocks/variables.rs
@@ -1,0 +1,7 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum VariableBlock {
+    Set,
+    Get,
+}

--- a/desktop/src/visual/mod.rs
+++ b/desktop/src/visual/mod.rs
@@ -1,1 +1,2 @@
+pub mod blocks;
 pub mod canvas;


### PR DESCRIPTION
## Summary
- add visual block modules for arithmetic, conditional, loops, variables, and functions
- expose new BlockType enum and color scheme for blocks

## Testing
- `cargo test -p desktop`

------
https://chatgpt.com/codex/tasks/task_e_68a774c71f448323a8ffb5d996d0e766