### PR TITLE
Add block translations and language switching

### DIFF
--- a/desktop/src/app/events/handler.rs
+++ b/desktop/src/app/events/handler.rs
@@ -100,6 +100,14 @@ impl MulticodeApp {
                     }
                     return Command::none();
                 }
+                if modifiers.alt() && !modifiers.control() && !modifiers.shift() {
+                    if let keyboard::Key::Character(c) = &key {
+                        if c.eq_ignore_ascii_case("l") {
+                            self.settings.language = self.settings.language.next();
+                            return Command::none();
+                        }
+                    }
+                }
                 if let Screen::Diff(_) = self.screen {
                     let hotkeys = &self.settings.hotkeys;
                     if hotkeys.next_diff.matches(&key, modifiers) {

--- a/desktop/src/app/mod.rs
+++ b/desktop/src/app/mod.rs
@@ -10,9 +10,9 @@ mod view;
 
 pub use state::{
     AppTheme, CreateTarget, Diagnostic, EditorMode, EntryType, FileEntry, Hotkey, HotkeyField,
-    Hotkeys, Language, MulticodeApp, PendingAction, Screen, Tab, TabDragState, UserSettings,
-    ViewMode,
+    Hotkeys, MulticodeApp, PendingAction, Screen, Tab, TabDragState, UserSettings, ViewMode,
 };
+pub use crate::visual::translations::Language;
 
 use iced::Application;
 use iced::Settings;

--- a/desktop/src/app/state.rs
+++ b/desktop/src/app/state.rs
@@ -11,6 +11,7 @@ use tokio::{fs, process::Child, sync::broadcast};
 use crate::app::diff::DiffView;
 use crate::components::file_manager::ContextMenu;
 use crate::editor::{AutocompleteState, EditorSettings};
+use crate::visual::translations::Language;
 
 mod serde_color {
     use iced::Color;
@@ -323,31 +324,6 @@ impl fmt::Display for AppTheme {
             AppTheme::Light => write!(f, "Light"),
             AppTheme::Dark => write!(f, "Dark"),
             AppTheme::HighContrast => write!(f, "High Contrast"),
-        }
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-pub enum Language {
-    English,
-    Russian,
-}
-
-impl Language {
-    pub const ALL: [Language; 2] = [Language::English, Language::Russian];
-}
-
-impl Default for Language {
-    fn default() -> Self {
-        Language::English
-    }
-}
-
-impl fmt::Display for Language {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Language::English => write!(f, "English"),
-            Language::Russian => write!(f, "Русский"),
         }
     }
 }

--- a/desktop/src/app/ui.rs
+++ b/desktop/src/app/ui.rs
@@ -198,7 +198,7 @@ impl MulticodeApp {
             .current_file()
             .map(|f| f.blocks.as_slice())
             .unwrap_or(&[]);
-        let canvas_widget = Canvas::new(VisualCanvas::new(blocks))
+        let canvas_widget = Canvas::new(VisualCanvas::new(blocks, self.settings.language))
             .width(Length::Fill)
             .height(Length::Fill);
         let canvas: Element<CanvasMessage> = canvas_widget.into();

--- a/desktop/src/visual/canvas.rs
+++ b/desktop/src/visual/canvas.rs
@@ -2,6 +2,7 @@ use iced::widget::canvas::{self, Event, Frame, Geometry, Path, Program, Stroke, 
 use iced::{mouse, Point, Rectangle, Renderer, Theme, Vector};
 
 use multicode_core::BlockInfo;
+use crate::visual::translations::{Language, translate_kind};
 
 pub const BLOCK_WIDTH: f32 = 120.0;
 pub const BLOCK_HEIGHT: f32 = 40.0;
@@ -16,6 +17,7 @@ pub enum CanvasMessage {
 
 pub struct VisualCanvas<'a> {
     blocks: &'a [BlockInfo],
+    language: Language,
 }
 
 pub struct State {
@@ -47,8 +49,8 @@ impl Default for State {
 }
 
 impl<'a> VisualCanvas<'a> {
-    pub fn new(blocks: &'a [BlockInfo]) -> Self {
-        Self { blocks }
+    pub fn new(blocks: &'a [BlockInfo], language: Language) -> Self {
+        Self { blocks, language }
     }
 }
 
@@ -215,8 +217,14 @@ impl<'a> Program<CanvasMessage> for VisualCanvas<'a> {
             };
             frame.fill(&rect, color);
             frame.stroke(&rect, Stroke::default());
+            let label = block
+                .translations
+                .get(self.language.code())
+                .cloned()
+                .or_else(|| translate_kind(&block.kind, self.language).map(|s| s.to_string()))
+                .unwrap_or_else(|| block.kind.clone());
             frame.fill_text(Text {
-                content: block.kind.clone(),
+                content: label,
                 position: Point::new(block.x as f32 + 5.0, block.y as f32 + 20.0),
                 color: iced::Color::BLACK,
                 ..Default::default()

--- a/desktop/src/visual/mod.rs
+++ b/desktop/src/visual/mod.rs
@@ -1,2 +1,3 @@
 pub mod blocks;
 pub mod canvas;
+pub mod translations;

--- a/desktop/src/visual/translations.rs
+++ b/desktop/src/visual/translations.rs
@@ -1,0 +1,118 @@
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+use super::blocks::{
+    ArithmeticBlock, BlockType, ConditionalBlock, FunctionBlock, LoopBlock, VariableBlock,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum Language {
+    English,
+    Russian,
+}
+
+impl Language {
+    pub const ALL: [Language; 2] = [Language::English, Language::Russian];
+
+    pub fn code(self) -> &'static str {
+        match self {
+            Language::English => "en",
+            Language::Russian => "ru",
+        }
+    }
+
+    pub fn next(self) -> Self {
+        match self {
+            Language::English => Language::Russian,
+            Language::Russian => Language::English,
+        }
+    }
+}
+
+impl Default for Language {
+    fn default() -> Self {
+        Language::English
+    }
+}
+
+impl fmt::Display for Language {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Language::English => write!(f, "English"),
+            Language::Russian => write!(f, "Русский"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BlockTranslation {
+    pub block: BlockType,
+    pub en: &'static str,
+    pub ru: &'static str,
+}
+
+impl BlockTranslation {
+    pub const fn new(block: BlockType, en: &'static str, ru: &'static str) -> Self {
+        Self { block, en, ru }
+    }
+
+    pub fn get(&self, lang: Language) -> &'static str {
+        match lang {
+            Language::English => self.en,
+            Language::Russian => self.ru,
+        }
+    }
+}
+
+pub const BLOCK_TRANSLATIONS: &[BlockTranslation] = &[
+    // Arithmetic
+    BlockTranslation::new(BlockType::Arithmetic(ArithmeticBlock::Add), "Add", "Сложить"),
+    BlockTranslation::new(BlockType::Arithmetic(ArithmeticBlock::Subtract), "Subtract", "Вычесть"),
+    BlockTranslation::new(BlockType::Arithmetic(ArithmeticBlock::Multiply), "Multiply", "Умножить"),
+    BlockTranslation::new(BlockType::Arithmetic(ArithmeticBlock::Divide), "Divide", "Делить"),
+    // Conditional
+    BlockTranslation::new(BlockType::Conditional(ConditionalBlock::If), "If", "Если"),
+    BlockTranslation::new(BlockType::Conditional(ConditionalBlock::ElseIf), "Else If", "Иначе если"),
+    BlockTranslation::new(BlockType::Conditional(ConditionalBlock::Else), "Else", "Иначе"),
+    // Loops
+    BlockTranslation::new(BlockType::Loop(LoopBlock::For), "For", "Для"),
+    BlockTranslation::new(BlockType::Loop(LoopBlock::While), "While", "Пока"),
+    BlockTranslation::new(BlockType::Loop(LoopBlock::Loop), "Loop", "Цикл"),
+    // Variables
+    BlockTranslation::new(BlockType::Variable(VariableBlock::Set), "Set", "Присвоить"),
+    BlockTranslation::new(BlockType::Variable(VariableBlock::Get), "Get", "Получить"),
+    // Functions
+    BlockTranslation::new(BlockType::Function(FunctionBlock::Define), "Define", "Определить"),
+    BlockTranslation::new(BlockType::Function(FunctionBlock::Call), "Call", "Вызвать"),
+    BlockTranslation::new(BlockType::Function(FunctionBlock::Return), "Return", "Возврат"),
+];
+
+pub fn translate(block: BlockType, lang: Language) -> Option<&'static str> {
+    BLOCK_TRANSLATIONS
+        .iter()
+        .find(|t| t.block == block)
+        .map(|t| t.get(lang))
+}
+
+pub fn translate_kind(kind: &str, lang: Language) -> Option<&'static str> {
+    let bt = match kind {
+        "Add" => BlockType::Arithmetic(ArithmeticBlock::Add),
+        "Subtract" => BlockType::Arithmetic(ArithmeticBlock::Subtract),
+        "Multiply" => BlockType::Arithmetic(ArithmeticBlock::Multiply),
+        "Divide" => BlockType::Arithmetic(ArithmeticBlock::Divide),
+        "If" | "Condition" => BlockType::Conditional(ConditionalBlock::If),
+        "ElseIf" => BlockType::Conditional(ConditionalBlock::ElseIf),
+        "Else" => BlockType::Conditional(ConditionalBlock::Else),
+        "For" => BlockType::Loop(LoopBlock::For),
+        "While" => BlockType::Loop(LoopBlock::While),
+        "Loop" => BlockType::Loop(LoopBlock::Loop),
+        "Set" => BlockType::Variable(VariableBlock::Set),
+        "Get" => BlockType::Variable(VariableBlock::Get),
+        "Function" | "Define" => BlockType::Function(FunctionBlock::Define),
+        "Call" => BlockType::Function(FunctionBlock::Call),
+        "Return" => BlockType::Function(FunctionBlock::Return),
+        _ => return None,
+    };
+    translate(bt, lang)
+}


### PR DESCRIPTION
## Summary
- add translation table for block types
- allow toggling UI language with Alt+L
- render blocks in the selected language

## Testing
- `cargo test -p core`
- `cargo test -p desktop`


------
https://chatgpt.com/codex/tasks/task_e_68a7784891ec8323a9f46d1850f39583