### PR TITLE
Persist block palette favorites in user settings

### DIFF
--- a/desktop/src/app/actions.rs
+++ b/desktop/src/app/actions.rs
@@ -82,7 +82,6 @@ impl Application for MulticodeApp {
             show_block_palette: false,
             palette_query: String::new(),
             palette_drag: None,
-            block_favorites: Vec::new(),
         };
 
         let cmd = match &app.screen {

--- a/desktop/src/app/state.rs
+++ b/desktop/src/app/state.rs
@@ -101,7 +101,6 @@ pub struct MulticodeApp {
     pub(super) show_block_palette: bool,
     pub(super) palette_query: String,
     pub(super) palette_drag: Option<BlockInfo>,
-    pub(super) block_favorites: Vec<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -383,6 +382,8 @@ pub struct UserSettings {
     pub show_markdown_preview: bool,
     #[serde(default)]
     pub favorites: Vec<PathBuf>,
+    #[serde(default)]
+    pub block_favorites: Vec<String>,
 }
 
 impl Default for UserSettings {
@@ -404,6 +405,7 @@ impl Default for UserSettings {
             show_toolbar: true,
             show_markdown_preview: false,
             favorites: Vec::new(),
+            block_favorites: Vec::new(),
         }
     }
 }

--- a/desktop/src/app/ui.rs
+++ b/desktop/src/app/ui.rs
@@ -308,7 +308,7 @@ impl MulticodeApp {
         }
         let pal: Element<_> = BlockPalette::new(
             &self.palette,
-            &self.block_favorites,
+            &self.settings.block_favorites,
             &self.palette_query,
             self.settings.language,
         )
@@ -415,7 +415,6 @@ mod tests {
             show_block_palette: false,
             palette_query: String::new(),
             palette_drag: None,
-            block_favorites: Vec::new(),
         }
     }
 


### PR DESCRIPTION
## Summary
- add `block_favorites` field to `UserSettings` for block palette persistence
- use settings-based favorites throughout the UI
- remove redundant in-memory block favorites

## Testing
- `cargo test -p desktop`


------
https://chatgpt.com/codex/tasks/task_e_68a7849e8e3483239e148e00196308ca