### PR TITLE
Add block palette favorites toggling

### DIFF
--- a/desktop/src/app/actions.rs
+++ b/desktop/src/app/actions.rs
@@ -21,6 +21,8 @@ impl Application for MulticodeApp {
             settings.add_recent_folder(path);
         }
         let (sender, _) = broadcast::channel(100);
+        let fav_files = settings.favorites.clone();
+        let block_favorites = settings.block_favorites.clone();
 
         let (screen, view_mode) = if let Some(path) = settings.last_folders.first().cloned() {
             match settings.editor_mode {
@@ -48,7 +50,7 @@ impl Application for MulticodeApp {
             create_target: CreateTarget::File,
             rename_file_name: String::new(),
             search_query: String::new(),
-            favorites: settings.favorites.clone(),
+            favorites: fav_files,
             query: String::new(),
             show_command_palette: false,
             log: Vec::new(),
@@ -82,7 +84,7 @@ impl Application for MulticodeApp {
             show_block_palette: false,
             palette_query: String::new(),
             palette_drag: None,
-            block_favorites: Vec::new(),
+            block_favorites,
         };
 
         let cmd = match &app.screen {
@@ -139,7 +141,7 @@ impl Application for MulticodeApp {
         }
     }
 
-fn view(&self) -> Element<Message> {
+    fn view(&self) -> Element<Message> {
         self.render()
     }
 }

--- a/desktop/src/app/events/handler.rs
+++ b/desktop/src/app/events/handler.rs
@@ -86,6 +86,18 @@ impl MulticodeApp {
                             self.show_block_palette = false;
                         }
                     }
+                    PaletteMessage::ToggleFavorite(i) => {
+                        if let Some(kind) = self.palette.get(i).map(|b| b.kind.clone()) {
+                            if let Some(pos) = self.block_favorites.iter().position(|k| k == &kind)
+                            {
+                                self.block_favorites.remove(pos);
+                            } else {
+                                self.block_favorites.push(kind);
+                            }
+                            self.settings.block_favorites = self.block_favorites.clone();
+                            return self.handle_message(Message::SaveSettings);
+                        }
+                    }
                     PaletteMessage::Close => {
                         self.show_block_palette = false;
                     }

--- a/desktop/src/app/state.rs
+++ b/desktop/src/app/state.rs
@@ -383,6 +383,8 @@ pub struct UserSettings {
     pub show_markdown_preview: bool,
     #[serde(default)]
     pub favorites: Vec<PathBuf>,
+    #[serde(default)]
+    pub block_favorites: Vec<String>,
 }
 
 impl Default for UserSettings {
@@ -404,6 +406,7 @@ impl Default for UserSettings {
             show_toolbar: true,
             show_markdown_preview: false,
             favorites: Vec::new(),
+            block_favorites: Vec::new(),
         }
     }
 }
@@ -472,7 +475,10 @@ impl MulticodeApp {
     }
 
     pub fn is_visual_mode(&self) -> bool {
-        matches!(self.screen, Screen::VisualEditor { .. } | Screen::Split { .. })
+        matches!(
+            self.screen,
+            Screen::VisualEditor { .. } | Screen::Split { .. }
+        )
     }
 
     /// Возвращает путь к корню проекта, если он выбран

--- a/desktop/src/visual/palette.rs
+++ b/desktop/src/visual/palette.rs
@@ -1,13 +1,14 @@
-use iced::widget::{column, scrollable, text, text_input, MouseArea};
-use iced::{Element, Length};
+use iced::widget::{column, row, scrollable, text, text_input, MouseArea};
+use iced::{theme, Color, Element, Length};
 use multicode_core::BlockInfo;
 
-use super::translations::{Language};
+use super::translations::Language;
 
 #[derive(Debug, Clone)]
 pub enum PaletteMessage {
     SearchChanged(String),
     StartDrag(usize),
+    ToggleFavorite(usize),
     Close,
 }
 
@@ -122,14 +123,25 @@ impl<'a> BlockPalette<'a> {
                 };
                 col = col.push(text(title));
                 for i in fav_blocks {
-                    let name = self
-                        .blocks[i]
+                    let name = self.blocks[i]
                         .translations
                         .get(self.language.code())
                         .cloned()
                         .unwrap_or_else(|| self.blocks[i].kind.clone());
+                    let fav = self.favorites.contains(&self.blocks[i].kind);
+                    let star = if fav { "★" } else { "☆" };
+                    let star_txt = text(star);
+                    let star_txt = if fav {
+                        star_txt.style(theme::Text::Color(Color::from_rgb(1.0, 0.8, 0.0)))
+                    } else {
+                        star_txt
+                    };
                     col = col.push(
-                        MouseArea::new(text(name)).on_press(PaletteMessage::StartDrag(i)),
+                        row![
+                            MouseArea::new(star_txt).on_press(PaletteMessage::ToggleFavorite(i)),
+                            MouseArea::new(text(name)).on_press(PaletteMessage::StartDrag(i)),
+                        ]
+                        .spacing(5),
                     );
                 }
             }
@@ -144,14 +156,25 @@ impl<'a> BlockPalette<'a> {
             if !cat_blocks.is_empty() {
                 col = col.push(text(cat.title(self.language)));
                 for i in cat_blocks {
-                    let name = self
-                        .blocks[i]
+                    let name = self.blocks[i]
                         .translations
                         .get(self.language.code())
                         .cloned()
                         .unwrap_or_else(|| self.blocks[i].kind.clone());
+                    let fav = self.favorites.contains(&self.blocks[i].kind);
+                    let star = if fav { "★" } else { "☆" };
+                    let star_txt = text(star);
+                    let star_txt = if fav {
+                        star_txt.style(theme::Text::Color(Color::from_rgb(1.0, 0.8, 0.0)))
+                    } else {
+                        star_txt
+                    };
                     col = col.push(
-                        MouseArea::new(text(name)).on_press(PaletteMessage::StartDrag(i)),
+                        row![
+                            MouseArea::new(star_txt).on_press(PaletteMessage::ToggleFavorite(i)),
+                            MouseArea::new(text(name)).on_press(PaletteMessage::StartDrag(i)),
+                        ]
+                        .spacing(5),
                     );
                 }
             }
@@ -175,4 +198,3 @@ fn matches_block(block: &BlockInfo, q: &str) -> bool {
         .unwrap_or_default();
     en.contains(q) || ru.contains(q) || block.kind.to_lowercase().contains(q)
 }
-


### PR DESCRIPTION
## Summary
- allow toggling block favorites in palette with a star button
- persist block favorites in user settings and load them at startup

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68a7896d280483239523d1c675ed70b5