### PR TITLE
Fix block favorites stored only in settings

### DIFF
--- a/desktop/src/app/actions.rs
+++ b/desktop/src/app/actions.rs
@@ -22,7 +22,6 @@ impl Application for MulticodeApp {
         }
         let (sender, _) = broadcast::channel(100);
         let fav_files = settings.favorites.clone();
-        let block_favorites = settings.block_favorites.clone();
 
         let (screen, view_mode) = if let Some(path) = settings.last_folders.first().cloned() {
             match settings.editor_mode {
@@ -84,10 +83,6 @@ impl Application for MulticodeApp {
             show_block_palette: false,
             palette_query: String::new(),
             palette_drag: None,
-
-            block_favorites,
-
-
         };
 
         let cmd = match &app.screen {

--- a/desktop/src/app/events/handler.rs
+++ b/desktop/src/app/events/handler.rs
@@ -88,13 +88,13 @@ impl MulticodeApp {
                     }
                     PaletteMessage::ToggleFavorite(i) => {
                         if let Some(kind) = self.palette.get(i).map(|b| b.kind.clone()) {
-                            if let Some(pos) = self.block_favorites.iter().position(|k| k == &kind)
+                            if let Some(pos) =
+                                self.settings.block_favorites.iter().position(|k| k == &kind)
                             {
-                                self.block_favorites.remove(pos);
+                                self.settings.block_favorites.remove(pos);
                             } else {
-                                self.block_favorites.push(kind);
+                                self.settings.block_favorites.push(kind);
                             }
-                            self.settings.block_favorites = self.block_favorites.clone();
                             return self.handle_message(Message::SaveSettings);
                         }
                     }


### PR DESCRIPTION
## Summary
- remove outdated `block_favorites` field from `MulticodeApp`
- toggle block favorites directly via `settings.block_favorites`

## Testing
- `cargo test -p desktop`


------
https://chatgpt.com/codex/tasks/task_e_68a793b5163c8323869a1ab01191bf0c