### PR TITLE
Close block palette on outside click or escape

### DIFF
--- a/desktop/src/app/events/handler.rs
+++ b/desktop/src/app/events/handler.rs
@@ -100,6 +100,7 @@ impl MulticodeApp {
                     }
                     PaletteMessage::Close => {
                         self.show_block_palette = false;
+                        self.palette_query.clear();
                     }
                 }
                 Command::none()
@@ -109,6 +110,11 @@ impl MulticodeApp {
                 modifiers,
                 ..
             })) => {
+                if self.show_block_palette {
+                    if let keyboard::Key::Named(keyboard::key::Named::Escape) = key {
+                        return self.handle_message(Message::PaletteEvent(PaletteMessage::Close));
+                    }
+                }
                 if let Some(id) = self.shortcut_capture.take() {
                     let key_str = match key {
                         keyboard::Key::Character(c) => c.to_string().to_uppercase(),

--- a/desktop/src/visual/palette.rs
+++ b/desktop/src/visual/palette.rs
@@ -181,7 +181,11 @@ impl<'a> BlockPalette<'a> {
         }
 
         let list = scrollable(col.spacing(5)).height(Length::Fixed(300.0));
-        column![search, list].spacing(10).into()
+        let content = column![search, list].spacing(10);
+
+        MouseArea::new(content)
+            .on_press(PaletteMessage::Close)
+            .into()
     }
 }
 


### PR DESCRIPTION
## Summary
- close block palette when clicking outside via MouseArea overlay
- close block palette with Escape key and reset search query

## Testing
- `cargo test -p desktop`

------
https://chatgpt.com/codex/tasks/task_e_68a79938d0908323a67a726531c6b488