### PR TITLE
feat: derive palette categories from metadata

### DIFF
--- a/core/src/blocks/enrich.rs
+++ b/core/src/blocks/enrich.rs
@@ -35,6 +35,7 @@ pub fn enrich_blocks(blocks: Vec<Block>, content: &str) -> Vec<BlockInfo> {
                 x: pos.map(|m| m.x).unwrap_or(0.0),
                 y: pos.map(|m| m.y).unwrap_or(0.0),
                 ai: pos.and_then(|m| m.ai.clone()),
+                tags: pos.map(|m| m.tags.clone()).unwrap_or_default(),
                 links: pos.map(|m| m.links.clone()).unwrap_or_default(),
             }
         })

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -36,6 +36,9 @@ pub struct BlockInfo {
     pub x: f64,
     pub y: f64,
     pub ai: Option<AiNote>,
+    /// Optional tags associated with the block.
+    #[serde(default)]
+    pub tags: Vec<String>,
     #[serde(default)]
     pub links: Vec<String>,
 }

--- a/desktop/src/app/state.rs
+++ b/desktop/src/app/state.rs
@@ -98,6 +98,7 @@ pub struct MulticodeApp {
     pub(super) show_meta_panel: bool,
     pub(super) tab_drag: Option<TabDragState>,
     pub(super) palette: Vec<BlockInfo>,
+    pub(super) palette_categories: Vec<(String, Vec<usize>)>,
     pub(super) show_block_palette: bool,
     pub(super) palette_query: String,
     pub(super) palette_drag: Option<BlockInfo>,

--- a/desktop/src/app/ui.rs
+++ b/desktop/src/app/ui.rs
@@ -308,6 +308,7 @@ impl MulticodeApp {
         }
         let pal: Element<_> = BlockPalette::new(
             &self.palette,
+            &self.palette_categories,
             &self.settings.block_favorites,
             &self.palette_query,
             self.settings.language,
@@ -412,6 +413,7 @@ mod tests {
             show_meta_panel: false,
             tab_drag: None,
             palette: Vec::new(),
+            palette_categories: Vec::new(),
             show_block_palette: false,
             palette_query: String::new(),
             palette_drag: None,

--- a/legacy-backend/src/blocks/enrich.rs
+++ b/legacy-backend/src/blocks/enrich.rs
@@ -35,6 +35,7 @@ pub fn enrich_blocks(blocks: Vec<Block>, content: &str) -> Vec<BlockInfo> {
                 x: pos.map(|m| m.x).unwrap_or(0.0),
                 y: pos.map(|m| m.y).unwrap_or(0.0),
                 ai: pos.and_then(|m| m.ai.clone()),
+                tags: pos.map(|m| m.tags.clone()).unwrap_or_default(),
                 links: pos.map(|m| m.links.clone()).unwrap_or_default(),
             }
         })

--- a/legacy-backend/src/lib.rs
+++ b/legacy-backend/src/lib.rs
@@ -44,6 +44,9 @@ pub struct BlockInfo {
     pub x: f64,
     pub y: f64,
     pub ai: Option<AiNote>,
+    /// Optional tags associated with the block.
+    #[serde(default)]
+    pub tags: Vec<String>,
     #[serde(default)]
     pub links: Vec<String>,
 }


### PR DESCRIPTION
## Summary
- derive block categories from metadata tags and attach to `BlockInfo`
- compute palette category mapping on load and expose a fallback category
- render block palette using dynamic, localized categories

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a79d151c408323aa4a55da7030775c