### PR TITLE
Cache lowercase palette strings to speed block search

### DIFF
--- a/desktop/src/app/actions.rs
+++ b/desktop/src/app/actions.rs
@@ -7,8 +7,8 @@ use tokio::sync::broadcast;
 
 use super::events::Message;
 use super::{AppTheme, CreateTarget, EditorMode, MulticodeApp, Screen, UserSettings, ViewMode};
-use multicode_core::{parse_blocks, BlockInfo};
-use crate::visual::palette::DEFAULT_CATEGORY;
+use crate::visual::palette::{PaletteBlock, DEFAULT_CATEGORY};
+use multicode_core::parse_blocks;
 
 impl Application for MulticodeApp {
     type Executor = iced::executor::Default;
@@ -147,18 +147,19 @@ impl Application for MulticodeApp {
     }
 }
 
-fn load_palette() -> (Vec<BlockInfo>, Vec<(String, Vec<usize>)>) {
+fn load_palette() -> (Vec<PaletteBlock>, Vec<(String, Vec<usize>)>) {
     let src = r#"
 fn add(a: i32, b: i32) -> i32 { a + b }
 fn mul(a: i32, b: i32) -> i32 { a * b }
 "#;
-    let blocks = parse_blocks(src.to_string(), "rust".into()).unwrap_or_default();
+    let blocks_raw = parse_blocks(src.to_string(), "rust".into()).unwrap_or_default();
+    let blocks: Vec<PaletteBlock> = blocks_raw.into_iter().map(PaletteBlock::new).collect();
     let mut map: BTreeMap<String, Vec<usize>> = BTreeMap::new();
     for (i, block) in blocks.iter().enumerate() {
-        if block.tags.is_empty() {
+        if block.info.tags.is_empty() {
             map.entry(DEFAULT_CATEGORY.to_string()).or_default().push(i);
         } else {
-            for tag in &block.tags {
+            for tag in &block.info.tags {
                 map.entry(tag.clone()).or_default().push(i);
             }
         }

--- a/desktop/src/app/events/handler.rs
+++ b/desktop/src/app/events/handler.rs
@@ -81,15 +81,18 @@ impl MulticodeApp {
                         self.palette_query = q;
                     }
                     PaletteMessage::StartDrag(i) => {
-                        if let Some(block) = self.palette.get(i).cloned() {
+                        if let Some(block) = self.palette.get(i).map(|b| b.info.clone()) {
                             self.palette_drag = Some(block);
                             self.show_block_palette = false;
                         }
                     }
                     PaletteMessage::ToggleFavorite(i) => {
-                        if let Some(kind) = self.palette.get(i).map(|b| b.kind.clone()) {
-                            if let Some(pos) =
-                                self.settings.block_favorites.iter().position(|k| k == &kind)
+                        if let Some(kind) = self.palette.get(i).map(|b| b.info.kind.clone()) {
+                            if let Some(pos) = self
+                                .settings
+                                .block_favorites
+                                .iter()
+                                .position(|k| k == &kind)
                             {
                                 self.settings.block_favorites.remove(pos);
                             } else {

--- a/desktop/src/app/state.rs
+++ b/desktop/src/app/state.rs
@@ -11,6 +11,7 @@ use tokio::{fs, process::Child, sync::broadcast};
 use crate::app::diff::DiffView;
 use crate::components::file_manager::ContextMenu;
 use crate::editor::{AutocompleteState, EditorSettings};
+use crate::visual::palette::PaletteBlock;
 use crate::visual::translations::Language;
 
 mod serde_color {
@@ -97,7 +98,7 @@ pub struct MulticodeApp {
     pub(super) autocomplete: Option<AutocompleteState>,
     pub(super) show_meta_panel: bool,
     pub(super) tab_drag: Option<TabDragState>,
-    pub(super) palette: Vec<BlockInfo>,
+    pub(super) palette: Vec<PaletteBlock>,
     pub(super) palette_categories: Vec<(String, Vec<usize>)>,
     pub(super) show_block_palette: bool,
     pub(super) palette_query: String,


### PR DESCRIPTION
## Summary
- cache lowercase translations/kind in `PaletteBlock`
- search against cached strings to avoid per-keystroke allocations
- build palette entries with cached fields on initialization

## Testing
- `cargo test -p desktop`
- `cargo test -p desktop bench_block_palette_search --test palette_bench -- --nocapture`

------
https://chatgpt.com/codex/tasks/task_e_68a79f82922883239ea4e0b802ccc4cb