### PR TITLE
Add structured translatable logging with language toggle

### DIFF
--- a/desktop/src/app/log_translations.rs
+++ b/desktop/src/app/log_translations.rs
@@ -1,0 +1,156 @@
+use crate::visual::translations::Language;
+use super::state::{LogEntry, LogLevel};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum LogMessage {
+    FileError,
+    ReadError,
+    FileSaved,
+    SaveError,
+    FileNameMissing,
+    FileExists,
+    FileCreated,
+    CreateError,
+    DirNameMissing,
+    DirCreated,
+    DirCreateError,
+    NewNameEmpty,
+    Renamed,
+    RenameError,
+    Deleted,
+    DeleteError,
+    FoundItem,
+    SearchError,
+    ParseError,
+    GitError,
+    ExportError,
+    Command,
+    RunError,
+    BlocksUpdated,
+    Raw,
+}
+
+impl LogMessage {
+    pub fn level(self) -> LogLevel {
+        use LogMessage::*;
+        match self {
+            FileError
+            | ReadError
+            | SaveError
+            | CreateError
+            | DirCreateError
+            | RenameError
+            | DeleteError
+            | SearchError
+            | ParseError
+            | GitError
+            | ExportError
+            | RunError => LogLevel::Error,
+            _ => LogLevel::Info,
+        }
+    }
+}
+
+pub fn format_log(entry: &LogEntry, lang: Language) -> String {
+    use LogMessage::*;
+    let arg0 = |idx: usize| entry.args.get(idx).cloned().unwrap_or_default();
+    match entry.message_key {
+        FileError => match lang {
+            Language::English => format!("file error: {}", arg0(0)),
+            Language::Russian => format!("ошибка файла: {}", arg0(0)),
+        },
+        ReadError => match lang {
+            Language::English => format!("read error: {}", arg0(0)),
+            Language::Russian => format!("ошибка чтения: {}", arg0(0)),
+        },
+        FileSaved => match lang {
+            Language::English => "file saved".into(),
+            Language::Russian => "файл сохранен".into(),
+        },
+        SaveError => match lang {
+            Language::English => format!("save error: {}", arg0(0)),
+            Language::Russian => format!("ошибка сохранения: {}", arg0(0)),
+        },
+        FileNameMissing => match lang {
+            Language::English => "filename is not set".into(),
+            Language::Russian => "имя файла не задано".into(),
+        },
+        FileExists => match lang {
+            Language::English => format!("{} already exists", arg0(0)),
+            Language::Russian => format!("{} уже существует", arg0(0)),
+        },
+        FileCreated => match lang {
+            Language::English => format!("created {}", arg0(0)),
+            Language::Russian => format!("создан {}", arg0(0)),
+        },
+        CreateError => match lang {
+            Language::English => format!("create error: {}", arg0(0)),
+            Language::Russian => format!("ошибка создания: {}", arg0(0)),
+        },
+        DirNameMissing => match lang {
+            Language::English => "directory name not set".into(),
+            Language::Russian => "имя каталога не задано".into(),
+        },
+        DirCreated => match lang {
+            Language::English => format!("directory created {}", arg0(0)),
+            Language::Russian => format!("создан каталог {}", arg0(0)),
+        },
+        DirCreateError => match lang {
+            Language::English => format!("directory create error: {}", arg0(0)),
+            Language::Russian => format!("ошибка создания каталога: {}", arg0(0)),
+        },
+        NewNameEmpty => match lang {
+            Language::English => "new name is empty".into(),
+            Language::Russian => "новое имя пустое".into(),
+        },
+        Renamed => match lang {
+            Language::English => format!("renamed to {}", arg0(0)),
+            Language::Russian => format!("переименовано в {}", arg0(0)),
+        },
+        RenameError => match lang {
+            Language::English => format!("rename error: {}", arg0(0)),
+            Language::Russian => format!("ошибка переименования: {}", arg0(0)),
+        },
+        Deleted => match lang {
+            Language::English => format!("deleted {}", arg0(0)),
+            Language::Russian => format!("удален {}", arg0(0)),
+        },
+        DeleteError => match lang {
+            Language::English => format!("delete error: {}", arg0(0)),
+            Language::Russian => format!("ошибка удаления: {}", arg0(0)),
+        },
+        FoundItem => match lang {
+            Language::English => format!("found {}", arg0(0)),
+            Language::Russian => format!("найден {}", arg0(0)),
+        },
+        SearchError => match lang {
+            Language::English => format!("search error: {}", arg0(0)),
+            Language::Russian => format!("ошибка поиска: {}", arg0(0)),
+        },
+        ParseError => match lang {
+            Language::English => format!("parse error: {}", arg0(0)),
+            Language::Russian => format!("ошибка разбора: {}", arg0(0)),
+        },
+        GitError => match lang {
+            Language::English => format!("git error: {}", arg0(0)),
+            Language::Russian => format!("ошибка git: {}", arg0(0)),
+        },
+        ExportError => match lang {
+            Language::English => format!("export error: {}", arg0(0)),
+            Language::Russian => format!("ошибка экспорта: {}", arg0(0)),
+        },
+        Command => match lang {
+            Language::English | Language::Russian => format!("$ {}", arg0(0)),
+        },
+        RunError => match lang {
+            Language::English => format!("run error: {}", arg0(0)),
+            Language::Russian => format!("ошибка запуска: {}", arg0(0)),
+        },
+        BlocksUpdated => match lang {
+            Language::English => format!("blocks updated: {}", arg0(0)),
+            Language::Russian => format!("обновлено блоков: {}", arg0(0)),
+        },
+        Raw => arg0(0),
+    }
+}
+

--- a/desktop/src/app/mod.rs
+++ b/desktop/src/app/mod.rs
@@ -3,6 +3,7 @@ pub mod diff;
 pub mod events;
 pub mod io;
 pub mod ui;
+pub mod log_translations;
 
 mod actions;
 mod state;
@@ -10,8 +11,10 @@ mod view;
 
 pub use state::{
     AppTheme, CreateTarget, Diagnostic, EditorMode, EntryType, FileEntry, Hotkey, HotkeyField,
-    Hotkeys, MulticodeApp, PendingAction, Screen, Tab, TabDragState, UserSettings, ViewMode,
+    Hotkeys, LogEntry, LogLevel, MulticodeApp, PendingAction, Screen, Tab, TabDragState,
+    UserSettings, ViewMode,
 };
+pub use log_translations::{format_log, LogMessage};
 pub use crate::visual::translations::Language;
 
 use iced::Application;

--- a/desktop/src/app/state.rs
+++ b/desktop/src/app/state.rs
@@ -13,6 +13,7 @@ use crate::components::file_manager::ContextMenu;
 use crate::editor::{AutocompleteState, EditorSettings};
 use crate::visual::palette::PaletteBlock;
 use crate::visual::translations::Language;
+use super::log_translations::LogMessage;
 
 mod serde_color {
     use iced::Color;
@@ -31,6 +32,38 @@ mod serde_color {
     {
         let [r, g, b] = <[f32; 3]>::deserialize(deserializer)?;
         Ok(Color::from_rgb(r, g, b))
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LogLevel {
+    Info,
+    Error,
+}
+
+#[derive(Debug, Clone)]
+pub struct LogEntry {
+    pub level: LogLevel,
+    pub message_key: LogMessage,
+    pub args: Vec<String>,
+}
+
+impl LogEntry {
+    pub fn new(message_key: LogMessage, args: Vec<String>) -> Self {
+        let level = message_key.level();
+        Self {
+            level,
+            message_key,
+            args,
+        }
+    }
+
+    pub fn raw(message: String) -> Self {
+        Self {
+            level: LogLevel::Info,
+            message_key: LogMessage::Raw,
+            args: vec![message],
+        }
     }
 }
 
@@ -66,7 +99,7 @@ pub struct MulticodeApp {
     pub(super) favorites: Vec<PathBuf>,
     pub(super) query: String,
     pub(super) show_command_palette: bool,
-    pub(super) log: Vec<String>,
+    pub(super) log: Vec<LogEntry>,
     /// результаты поиска по проекту
     pub(super) project_search_results: Vec<(PathBuf, usize, String)>,
     /// строка для перехода после открытия файла

--- a/desktop/src/app/ui.rs
+++ b/desktop/src/app/ui.rs
@@ -7,7 +7,7 @@ use iced::{Element, Length};
 
 use crate::app::diff::DiffView;
 use crate::app::events::Message;
-use crate::app::{command_palette::COMMANDS, MulticodeApp};
+use crate::app::{command_palette::COMMANDS, format_log, MulticodeApp};
 use crate::modal::Modal;
 use crate::visual::canvas::{CanvasMessage, VisualCanvas};
 use crate::visual::palette::{BlockPalette, PaletteMessage};
@@ -245,8 +245,7 @@ impl MulticodeApp {
         let output = scrollable(column(
             self.log
                 .iter()
-                .cloned()
-                .map(|l| text(l).into())
+                .map(|e| text(format_log(e, self.settings.language)).into())
                 .collect::<Vec<Element<Message>>>(),
         ))
         .height(Length::Fixed(150.0));
@@ -256,9 +255,11 @@ impl MulticodeApp {
         let clear_btn = button("Очистить").on_press(Message::RunTerminalCmd(":clear".into()));
         let stop_btn = button("Stop").on_press(Message::RunTerminalCmd(":stop".into()));
         let help_btn = button("Справка").on_press(Message::ShowTerminalHelp);
+        let translate_btn = button("Перевести")
+            .on_press(Message::LanguageSelected(self.settings.language.next()));
         column![
             output,
-            row![input, clear_btn, stop_btn, help_btn].spacing(5)
+            row![input, clear_btn, stop_btn, help_btn, translate_btn].spacing(5)
         ]
         .spacing(5)
         .into()


### PR DESCRIPTION
## Summary
- introduce `LogEntry` and `LogMessage` for structured logging
- translate log output based on selected `Language`
- add UI control to switch log language on the fly

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a7b40d41f08323af3f07f0a50deb1d