### PR TITLE
Add Spanish and German translations

### DIFF
--- a/desktop/src/app/log_translations.rs
+++ b/desktop/src/app/log_translations.rs
@@ -1,5 +1,5 @@
-use crate::visual::translations::Language;
 use super::state::{LogEntry, LogLevel};
+use crate::visual::translations::Language;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum LogMessage {
@@ -34,18 +34,10 @@ impl LogMessage {
     pub fn level(self) -> LogLevel {
         use LogMessage::*;
         match self {
-            FileError
-            | ReadError
-            | SaveError
-            | CreateError
-            | DirCreateError
-            | RenameError
-            | DeleteError
-            | SearchError
-            | ParseError
-            | GitError
-            | ExportError
-            | RunError => LogLevel::Error,
+            FileError | ReadError | SaveError | CreateError | DirCreateError | RenameError
+            | DeleteError | SearchError | ParseError | GitError | ExportError | RunError => {
+                LogLevel::Error
+            }
             _ => LogLevel::Info,
         }
     }
@@ -58,99 +50,142 @@ pub fn format_log(entry: &LogEntry, lang: Language) -> String {
         FileError => match lang {
             Language::English => format!("file error: {}", arg0(0)),
             Language::Russian => format!("ошибка файла: {}", arg0(0)),
+            Language::Spanish => format!("error de archivo: {}", arg0(0)),
+            Language::German => format!("Dateifehler: {}", arg0(0)),
         },
         ReadError => match lang {
             Language::English => format!("read error: {}", arg0(0)),
             Language::Russian => format!("ошибка чтения: {}", arg0(0)),
+            Language::Spanish => format!("error de lectura: {}", arg0(0)),
+            Language::German => format!("Lesefehler: {}", arg0(0)),
         },
         FileSaved => match lang {
             Language::English => "file saved".into(),
             Language::Russian => "файл сохранен".into(),
+            Language::Spanish => "archivo guardado".into(),
+            Language::German => "Datei gespeichert".into(),
         },
         SaveError => match lang {
             Language::English => format!("save error: {}", arg0(0)),
             Language::Russian => format!("ошибка сохранения: {}", arg0(0)),
+            Language::Spanish => format!("error al guardar: {}", arg0(0)),
+            Language::German => format!("Fehler beim Speichern: {}", arg0(0)),
         },
         FileNameMissing => match lang {
             Language::English => "filename is not set".into(),
             Language::Russian => "имя файла не задано".into(),
+            Language::Spanish => "nombre de archivo no establecido".into(),
+            Language::German => "Dateiname nicht festgelegt".into(),
         },
         FileExists => match lang {
             Language::English => format!("{} already exists", arg0(0)),
             Language::Russian => format!("{} уже существует", arg0(0)),
+            Language::Spanish => format!("{} ya existe", arg0(0)),
+            Language::German => format!("{} existiert bereits", arg0(0)),
         },
         FileCreated => match lang {
             Language::English => format!("created {}", arg0(0)),
             Language::Russian => format!("создан {}", arg0(0)),
+            Language::Spanish => format!("creado {}", arg0(0)),
+            Language::German => format!("{} erstellt", arg0(0)),
         },
         CreateError => match lang {
             Language::English => format!("create error: {}", arg0(0)),
             Language::Russian => format!("ошибка создания: {}", arg0(0)),
+            Language::Spanish => format!("error de creación: {}", arg0(0)),
+            Language::German => format!("Fehler beim Erstellen: {}", arg0(0)),
         },
         DirNameMissing => match lang {
             Language::English => "directory name not set".into(),
             Language::Russian => "имя каталога не задано".into(),
+            Language::Spanish => "nombre de directorio no establecido".into(),
+            Language::German => "Verzeichnisname nicht festgelegt".into(),
         },
         DirCreated => match lang {
             Language::English => format!("directory created {}", arg0(0)),
             Language::Russian => format!("создан каталог {}", arg0(0)),
+            Language::Spanish => format!("directorio creado {}", arg0(0)),
+            Language::German => format!("Verzeichnis {} erstellt", arg0(0)),
         },
         DirCreateError => match lang {
             Language::English => format!("directory create error: {}", arg0(0)),
             Language::Russian => format!("ошибка создания каталога: {}", arg0(0)),
+            Language::Spanish => format!("error al crear directorio: {}", arg0(0)),
+            Language::German => format!("Fehler beim Erstellen des Verzeichnisses: {}", arg0(0)),
         },
         NewNameEmpty => match lang {
             Language::English => "new name is empty".into(),
             Language::Russian => "новое имя пустое".into(),
+            Language::Spanish => "el nuevo nombre está vacío".into(),
+            Language::German => "neuer Name ist leer".into(),
         },
         Renamed => match lang {
             Language::English => format!("renamed to {}", arg0(0)),
             Language::Russian => format!("переименовано в {}", arg0(0)),
+            Language::Spanish => format!("renombrado a {}", arg0(0)),
+            Language::German => format!("umbenannt in {}", arg0(0)),
         },
         RenameError => match lang {
             Language::English => format!("rename error: {}", arg0(0)),
             Language::Russian => format!("ошибка переименования: {}", arg0(0)),
+            Language::Spanish => format!("error al renombrar: {}", arg0(0)),
+            Language::German => format!("Fehler beim Umbenennen: {}", arg0(0)),
         },
         Deleted => match lang {
             Language::English => format!("deleted {}", arg0(0)),
             Language::Russian => format!("удален {}", arg0(0)),
+            Language::Spanish => format!("eliminado {}", arg0(0)),
+            Language::German => format!("{} gelöscht", arg0(0)),
         },
         DeleteError => match lang {
             Language::English => format!("delete error: {}", arg0(0)),
             Language::Russian => format!("ошибка удаления: {}", arg0(0)),
+            Language::Spanish => format!("error al eliminar: {}", arg0(0)),
+            Language::German => format!("Fehler beim Löschen: {}", arg0(0)),
         },
         FoundItem => match lang {
             Language::English => format!("found {}", arg0(0)),
             Language::Russian => format!("найден {}", arg0(0)),
+            Language::Spanish => format!("encontrado {}", arg0(0)),
+            Language::German => format!("{} gefunden", arg0(0)),
         },
         SearchError => match lang {
             Language::English => format!("search error: {}", arg0(0)),
             Language::Russian => format!("ошибка поиска: {}", arg0(0)),
+            Language::Spanish => format!("error de búsqueda: {}", arg0(0)),
+            Language::German => format!("Fehler bei der Suche: {}", arg0(0)),
         },
         ParseError => match lang {
             Language::English => format!("parse error: {}", arg0(0)),
             Language::Russian => format!("ошибка разбора: {}", arg0(0)),
+            Language::Spanish => format!("error de análisis: {}", arg0(0)),
+            Language::German => format!("Fehler beim Parsen: {}", arg0(0)),
         },
         GitError => match lang {
             Language::English => format!("git error: {}", arg0(0)),
             Language::Russian => format!("ошибка git: {}", arg0(0)),
+            Language::Spanish => format!("error de git: {}", arg0(0)),
+            Language::German => format!("Git-Fehler: {}", arg0(0)),
         },
         ExportError => match lang {
             Language::English => format!("export error: {}", arg0(0)),
             Language::Russian => format!("ошибка экспорта: {}", arg0(0)),
+            Language::Spanish => format!("error de exportación: {}", arg0(0)),
+            Language::German => format!("Exportfehler: {}", arg0(0)),
         },
-        Command => match lang {
-            Language::English | Language::Russian => format!("$ {}", arg0(0)),
-        },
+        Command => format!("$ {}", arg0(0)),
         RunError => match lang {
             Language::English => format!("run error: {}", arg0(0)),
             Language::Russian => format!("ошибка запуска: {}", arg0(0)),
+            Language::Spanish => format!("error de ejecución: {}", arg0(0)),
+            Language::German => format!("Fehler beim Ausführen: {}", arg0(0)),
         },
         BlocksUpdated => match lang {
             Language::English => format!("blocks updated: {}", arg0(0)),
             Language::Russian => format!("обновлено блоков: {}", arg0(0)),
+            Language::Spanish => format!("bloques actualizados: {}", arg0(0)),
+            Language::German => format!("Blöcke aktualisiert: {}", arg0(0)),
         },
         Raw => arg0(0),
     }
 }
-

--- a/desktop/src/app/ui.rs
+++ b/desktop/src/app/ui.rs
@@ -8,7 +8,7 @@ use iced::{Element, Length};
 
 use crate::app::diff::DiffView;
 use crate::app::events::Message;
-use crate::app::{command_palette::COMMANDS, format_log, LogLevel, MulticodeApp};
+use crate::app::{command_palette::COMMANDS, format_log, Language, LogLevel, MulticodeApp};
 use crate::modal::Modal;
 use crate::visual::canvas::{CanvasMessage, VisualCanvas};
 use crate::visual::palette::{BlockPalette, PaletteMessage};
@@ -257,8 +257,11 @@ impl MulticodeApp {
         let clear_btn = button("Очистить").on_press(Message::RunTerminalCmd(":clear".into()));
         let stop_btn = button("Stop").on_press(Message::RunTerminalCmd(":stop".into()));
         let help_btn = button("Справка").on_press(Message::ShowTerminalHelp);
-        let translate_btn =
-            button("Перевести").on_press(Message::LanguageSelected(self.settings.language.next()));
+        let lang_pick = pick_list(
+            &Language::ALL[..],
+            Some(self.settings.language),
+            Message::LanguageSelected,
+        );
         let save_log_btn = button("Сохранить лог").on_press(Message::SaveLog);
         let level_pick = pick_list(
             &LogLevel::ALL[..],
@@ -272,7 +275,7 @@ impl MulticodeApp {
                 clear_btn,
                 stop_btn,
                 help_btn,
-                translate_btn,
+                lang_pick,
                 save_log_btn,
                 level_pick
             ]

--- a/desktop/src/visual/translations.rs
+++ b/desktop/src/visual/translations.rs
@@ -10,22 +10,33 @@ use super::blocks::{
 pub enum Language {
     English,
     Russian,
+    Spanish,
+    German,
 }
 
 impl Language {
-    pub const ALL: [Language; 2] = [Language::English, Language::Russian];
+    pub const ALL: [Language; 4] = [
+        Language::English,
+        Language::Russian,
+        Language::Spanish,
+        Language::German,
+    ];
 
     pub fn code(self) -> &'static str {
         match self {
             Language::English => "en",
             Language::Russian => "ru",
+            Language::Spanish => "es",
+            Language::German => "de",
         }
     }
 
     pub fn next(self) -> Self {
         match self {
             Language::English => Language::Russian,
-            Language::Russian => Language::English,
+            Language::Russian => Language::Spanish,
+            Language::Spanish => Language::German,
+            Language::German => Language::English,
         }
     }
 }
@@ -41,6 +52,8 @@ impl fmt::Display for Language {
         match self {
             Language::English => write!(f, "English"),
             Language::Russian => write!(f, "Русский"),
+            Language::Spanish => write!(f, "Español"),
+            Language::German => write!(f, "Deutsch"),
         }
     }
 }
@@ -59,22 +72,46 @@ impl BlockTranslation {
 
     pub fn get(&self, lang: Language) -> &'static str {
         match lang {
-            Language::English => self.en,
             Language::Russian => self.ru,
+            _ => self.en,
         }
     }
 }
 
 pub const BLOCK_TRANSLATIONS: &[BlockTranslation] = &[
     // Arithmetic
-    BlockTranslation::new(BlockType::Arithmetic(ArithmeticBlock::Add), "Add", "Сложить"),
-    BlockTranslation::new(BlockType::Arithmetic(ArithmeticBlock::Subtract), "Subtract", "Вычесть"),
-    BlockTranslation::new(BlockType::Arithmetic(ArithmeticBlock::Multiply), "Multiply", "Умножить"),
-    BlockTranslation::new(BlockType::Arithmetic(ArithmeticBlock::Divide), "Divide", "Делить"),
+    BlockTranslation::new(
+        BlockType::Arithmetic(ArithmeticBlock::Add),
+        "Add",
+        "Сложить",
+    ),
+    BlockTranslation::new(
+        BlockType::Arithmetic(ArithmeticBlock::Subtract),
+        "Subtract",
+        "Вычесть",
+    ),
+    BlockTranslation::new(
+        BlockType::Arithmetic(ArithmeticBlock::Multiply),
+        "Multiply",
+        "Умножить",
+    ),
+    BlockTranslation::new(
+        BlockType::Arithmetic(ArithmeticBlock::Divide),
+        "Divide",
+        "Делить",
+    ),
     // Conditional
     BlockTranslation::new(BlockType::Conditional(ConditionalBlock::If), "If", "Если"),
-    BlockTranslation::new(BlockType::Conditional(ConditionalBlock::ElseIf), "Else If", "Иначе если"),
-    BlockTranslation::new(BlockType::Conditional(ConditionalBlock::Else), "Else", "Иначе"),
+    BlockTranslation::new(
+        BlockType::Conditional(ConditionalBlock::ElseIf),
+        "Else If",
+        "Иначе если",
+    ),
+    BlockTranslation::new(
+        BlockType::Conditional(ConditionalBlock::Else),
+        "Else",
+        "Иначе",
+    ),
     // Loops
     BlockTranslation::new(BlockType::Loop(LoopBlock::For), "For", "Для"),
     BlockTranslation::new(BlockType::Loop(LoopBlock::While), "While", "Пока"),
@@ -83,9 +120,17 @@ pub const BLOCK_TRANSLATIONS: &[BlockTranslation] = &[
     BlockTranslation::new(BlockType::Variable(VariableBlock::Set), "Set", "Присвоить"),
     BlockTranslation::new(BlockType::Variable(VariableBlock::Get), "Get", "Получить"),
     // Functions
-    BlockTranslation::new(BlockType::Function(FunctionBlock::Define), "Define", "Определить"),
+    BlockTranslation::new(
+        BlockType::Function(FunctionBlock::Define),
+        "Define",
+        "Определить",
+    ),
     BlockTranslation::new(BlockType::Function(FunctionBlock::Call), "Call", "Вызвать"),
-    BlockTranslation::new(BlockType::Function(FunctionBlock::Return), "Return", "Возврат"),
+    BlockTranslation::new(
+        BlockType::Function(FunctionBlock::Return),
+        "Return",
+        "Возврат",
+    ),
 ];
 
 pub fn translate(block: BlockType, lang: Language) -> Option<&'static str> {


### PR DESCRIPTION
## Summary
- expand language enum with Spanish and German
- translate log messages into Spanish and German
- switch terminal language via dropdown

## Testing
- `cargo test -p desktop`


------
https://chatgpt.com/codex/tasks/task_e_68a7cd010ae883238935e14d0aa4a595