### PR TITLE
Colorize connections by data type in canvas

### DIFF
--- a/desktop/src/app/ui.rs
+++ b/desktop/src/app/ui.rs
@@ -10,7 +10,7 @@ use crate::app::diff::DiffView;
 use crate::app::events::Message;
 use crate::app::{command_palette::COMMANDS, format_log, Language, LogLevel, MulticodeApp};
 use crate::modal::Modal;
-use crate::visual::canvas::{CanvasMessage, VisualCanvas};
+use crate::visual::canvas::{CanvasMessage, Connection, VisualCanvas};
 use crate::visual::palette::{BlockPalette, PaletteMessage};
 use multicode_core::BlockInfo;
 
@@ -200,9 +200,14 @@ impl MulticodeApp {
             .current_file()
             .map(|f| f.blocks.as_slice())
             .unwrap_or(&[]);
-        let canvas_widget = Canvas::new(VisualCanvas::new(blocks, self.settings.language))
-            .width(Length::Fill)
-            .height(Length::Fill);
+        let connections: &[Connection] = &[];
+        let canvas_widget = Canvas::new(VisualCanvas::new(
+            blocks,
+            connections,
+            self.settings.language,
+        ))
+        .width(Length::Fill)
+        .height(Length::Fill);
         let canvas: Element<CanvasMessage> = canvas_widget.into();
         let canvas = canvas.map(Message::CanvasEvent);
         if self.show_meta_panel {


### PR DESCRIPTION
## Summary
- colorize canvas connections based on their data type
- plumb empty connection list through UI

## Testing
- `cargo test -p desktop`
- `cargo run -p desktop` *(fails: neither WAYLAND_DISPLAY nor WAYLAND_SOCKET nor DISPLAY is set)*

------
https://chatgpt.com/codex/tasks/task_e_68a7f4744320832394648865030b1b65