### PR TITLE
feat: add port positions

### DIFF
--- a/core/src/blocks/enrich.rs
+++ b/core/src/blocks/enrich.rs
@@ -34,6 +34,7 @@ pub fn enrich_blocks(blocks: Vec<Block>, content: &str) -> Vec<BlockInfo> {
                 anchors: b.anchors.clone(),
                 x: pos.map(|m| m.x).unwrap_or(0.0),
                 y: pos.map(|m| m.y).unwrap_or(0.0),
+                ports: Vec::new(),
                 ai: pos.and_then(|m| m.ai.clone()),
                 tags: pos.map(|m| m.tags.clone()).unwrap_or_default(),
                 links: pos.map(|m| m.links.clone()).unwrap_or_default(),

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -22,6 +22,13 @@ use std::collections::HashMap;
 use std::sync::Mutex;
 use tree_sitter::Tree;
 
+/// Порт блока на холсте.
+#[derive(Clone, Serialize, Deserialize, Debug)]
+pub struct Port {
+    pub x: f64,
+    pub y: f64,
+}
+
 /// Информация о блоке, дополненная визуальными метаданными.
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct BlockInfo {
@@ -35,6 +42,8 @@ pub struct BlockInfo {
     pub anchors: Vec<(usize, usize)>,
     pub x: f64,
     pub y: f64,
+    #[serde(default)]
+    pub ports: Vec<Port>,
     pub ai: Option<AiNote>,
     /// Optional tags associated with the block.
     #[serde(default)]

--- a/desktop/src/visual/canvas.rs
+++ b/desktop/src/visual/canvas.rs
@@ -30,8 +30,8 @@ pub enum DataType {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Connection {
-    pub from: usize,
-    pub to: usize,
+    pub from: (usize, usize),
+    pub to: (usize, usize),
     pub data_type: DataType,
 }
 
@@ -107,21 +107,28 @@ impl State {
         if *last_blocks != current_blocks || *last_connections != connections {
             let mut prepared = Vec::new();
             for c in connections {
-                if let (Some(from), Some(to)) = (blocks.get(c.from), blocks.get(c.to)) {
-                    let start = Point::new(
-                        from.x as f32 + BLOCK_WIDTH / 2.0,
-                        from.y as f32 + BLOCK_HEIGHT / 2.0,
-                    );
-                    let end = Point::new(
-                        to.x as f32 + BLOCK_WIDTH / 2.0,
-                        to.y as f32 + BLOCK_HEIGHT / 2.0,
-                    );
-                    let color = match c.data_type {
-                        DataType::Number => Color::from_rgb(0.0, 0.0, 0.8),
-                        DataType::Boolean => Color::from_rgb(0.0, 0.6, 0.0),
-                        DataType::Text => Color::from_rgb(1.0, 0.5, 0.0),
-                    };
-                    prepared.push(PreparedConnection { start, end, color });
+                if let (Some(from_block), Some(to_block)) =
+                    (blocks.get(c.from.0), blocks.get(c.to.0))
+                {
+                    if let (Some(from_port), Some(to_port)) = (
+                        from_block.ports.get(c.from.1),
+                        to_block.ports.get(c.to.1),
+                    ) {
+                        let start = Point::new(
+                            (from_block.x + from_port.x) as f32,
+                            (from_block.y + from_port.y) as f32,
+                        );
+                        let end = Point::new(
+                            (to_block.x + to_port.x) as f32,
+                            (to_block.y + to_port.y) as f32,
+                        );
+                        let color = match c.data_type {
+                            DataType::Number => Color::from_rgb(0.0, 0.0, 0.8),
+                            DataType::Boolean => Color::from_rgb(0.0, 0.6, 0.0),
+                            DataType::Text => Color::from_rgb(1.0, 0.5, 0.0),
+                        };
+                        prepared.push(PreparedConnection { start, end, color });
+                    }
                 }
             }
             *self.connections.borrow_mut() = prepared;

--- a/desktop/src/visual/palette.rs
+++ b/desktop/src/visual/palette.rs
@@ -226,6 +226,7 @@ mod tests {
             anchors: vec![],
             x: 0.0,
             y: 0.0,
+            ports: vec![],
             ai: None,
             tags: vec![],
             links: vec![],

--- a/legacy-backend/src/blocks/enrich.rs
+++ b/legacy-backend/src/blocks/enrich.rs
@@ -34,6 +34,7 @@ pub fn enrich_blocks(blocks: Vec<Block>, content: &str) -> Vec<BlockInfo> {
                 anchors: b.anchors.clone(),
                 x: pos.map(|m| m.x).unwrap_or(0.0),
                 y: pos.map(|m| m.y).unwrap_or(0.0),
+                ports: Vec::new(),
                 ai: pos.and_then(|m| m.ai.clone()),
                 tags: pos.map(|m| m.tags.clone()).unwrap_or_default(),
                 links: pos.map(|m| m.links.clone()).unwrap_or_default(),

--- a/legacy-backend/src/lib.rs
+++ b/legacy-backend/src/lib.rs
@@ -32,6 +32,13 @@ static BLOCK_CACHE: Lazy<Mutex<HashMap<String, (String, Vec<BlockInfo>)>>> =
     Lazy::new(|| Mutex::new(HashMap::new()));
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
+/// Порт блока на холсте.
+pub struct Port {
+    pub x: f64,
+    pub y: f64,
+}
+
+#[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct BlockInfo {
     pub visual_id: String,
     #[serde(default)]
@@ -43,6 +50,8 @@ pub struct BlockInfo {
     pub anchors: Vec<(usize, usize)>,
     pub x: f64,
     pub y: f64,
+    #[serde(default)]
+    pub ports: Vec<Port>,
     pub ai: Option<AiNote>,
     /// Optional tags associated with the block.
     #[serde(default)]


### PR DESCRIPTION
## Summary
- add Port struct and ports list to BlockInfo to track port coordinates
- adjust Connection to reference ports by index and render lines at port locations
- initialize empty port data in block enrichment and palette

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68a8006084288323b71e2ca4b1de2310