### PR TITLE
feat: add canvas port connections

### DIFF
--- a/desktop/src/app/events/handler.rs
+++ b/desktop/src/app/events/handler.rs
@@ -64,6 +64,12 @@ impl MulticodeApp {
                             }
                         }
                     }
+                    CanvasMessage::ConnectionCreated(conn) => {
+                        if let Some(tab) = self.current_file_mut() {
+                            tab.connections.push(conn);
+                            tab.dirty = true;
+                        }
+                    }
                     CanvasMessage::TogglePalette => {
                         self.show_block_palette = !self.show_block_palette;
                         if !self.show_block_palette {
@@ -781,6 +787,7 @@ impl MulticodeApp {
                     blame: HashMap::new(),
                     diagnostics,
                     blocks,
+                    connections: Vec::new(),
                     meta,
                     undo_stack: VecDeque::new(),
                     redo_stack: VecDeque::new(),
@@ -1008,6 +1015,7 @@ impl MulticodeApp {
                     blame: HashMap::new(),
                     diagnostics: Vec::new(),
                     blocks: Vec::new(),
+                    connections: Vec::new(),
                     meta: None,
                     undo_stack: VecDeque::new(),
                     redo_stack: VecDeque::new(),

--- a/desktop/src/app/state.rs
+++ b/desktop/src/app/state.rs
@@ -1,3 +1,4 @@
+use crate::visual::canvas::Connection;
 use chrono::{DateTime, Utc};
 use directories::ProjectDirs;
 use iced::{widget::text_editor, Color};
@@ -205,6 +206,7 @@ pub struct Tab {
     pub blame: HashMap<usize, git::BlameLine>,
     pub diagnostics: Vec<Diagnostic>,
     pub blocks: Vec<BlockInfo>,
+    pub connections: Vec<Connection>,
     pub meta: Option<VisualMeta>,
     pub undo_stack: VecDeque<String>,
     pub redo_stack: VecDeque<String>,

--- a/desktop/src/app/ui.rs
+++ b/desktop/src/app/ui.rs
@@ -200,7 +200,10 @@ impl MulticodeApp {
             .current_file()
             .map(|f| f.blocks.as_slice())
             .unwrap_or(&[]);
-        let connections: &[Connection] = &[];
+        let connections: &[Connection] = self
+            .current_file()
+            .map(|f| f.connections.as_slice())
+            .unwrap_or(&[]);
         let canvas_widget = Canvas::new(VisualCanvas::new(
             blocks,
             connections,


### PR DESCRIPTION
## Summary
- start connections from output ports
- highlight input port on hover
- create connections on mouse release

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68a803ada0308323aad87cdcda1c1830