### PR TITLE
Include data type in visual connection metadata

### DIFF
--- a/desktop/src/visual/canvas.rs
+++ b/desktop/src/visual/canvas.rs
@@ -3,6 +3,7 @@ use iced::{
     keyboard::{self, key},
     mouse, Color, Point, Rectangle, Renderer, Theme, Vector,
 };
+use serde::{Deserialize, Serialize};
 use std::cell::RefCell;
 
 use crate::visual::translations::{translate_kind, Language};
@@ -14,11 +15,18 @@ const PORT_RADIUS: f32 = 5.0;
 const ARROW_LENGTH: f32 = 10.0;
 const ARROW_WIDTH: f32 = 6.0;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum DataType {
+    Any,
     Number,
     Boolean,
     Text,
+}
+
+impl Default for DataType {
+    fn default() -> Self {
+        DataType::Any
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -186,6 +194,7 @@ impl State {
                             DataType::Number => Color::from_rgb(0.0, 0.0, 0.8),
                             DataType::Boolean => Color::from_rgb(0.0, 0.6, 0.0),
                             DataType::Text => Color::from_rgb(1.0, 0.5, 0.0),
+                            DataType::Any => Color::from_rgb(0.5, 0.5, 0.5),
                         };
                         prepared.push(PreparedConnection { start, end, color });
                     }
@@ -253,7 +262,7 @@ impl<'a> Program<CanvasMessage> for VisualCanvas<'a> {
                                         start,
                                         current: start,
                                         hover: None,
-                                        data_type: DataType::Number,
+                                        data_type: DataType::Any,
                                     });
                                     return (canvas::event::Status::Captured, None);
                                 }

--- a/desktop/src/visual/mod.rs
+++ b/desktop/src/visual/mod.rs
@@ -1,6 +1,7 @@
 pub mod blocks;
 pub mod canvas;
 pub mod palette;
+pub mod serialization;
 pub mod translations;
 
 #[cfg(test)]

--- a/desktop/src/visual/serialization.rs
+++ b/desktop/src/visual/serialization.rs
@@ -1,0 +1,56 @@
+use crate::visual::canvas::{Connection, DataType};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ConnectionMeta {
+    pub from: (usize, usize),
+    pub to: (usize, usize),
+    #[serde(default)]
+    pub data_type: DataType,
+}
+
+pub fn serialize_to_meta(connections: &[Connection]) -> Vec<ConnectionMeta> {
+    connections
+        .iter()
+        .map(|c| ConnectionMeta {
+            from: c.from,
+            to: c.to,
+            data_type: c.data_type,
+        })
+        .collect()
+}
+
+pub fn load_from_meta(meta: &[ConnectionMeta]) -> Vec<Connection> {
+    meta.iter()
+        .map(|m| Connection {
+            from: m.from,
+            to: m.to,
+            data_type: m.data_type,
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn roundtrip_preserves_type() {
+        let connections = vec![Connection {
+            from: (1, 0),
+            to: (2, 1),
+            data_type: DataType::Boolean,
+        }];
+        let meta = serialize_to_meta(&connections);
+        let restored = load_from_meta(&meta);
+        assert_eq!(restored[0].data_type, DataType::Boolean);
+    }
+
+    #[test]
+    fn missing_type_defaults_to_any() {
+        let json = "[{\"from\":[0,1],\"to\":[2,3]}]";
+        let meta: Vec<ConnectionMeta> = serde_json::from_str(json).unwrap();
+        let restored = load_from_meta(&meta);
+        assert_eq!(restored[0].data_type, DataType::Any);
+    }
+}


### PR DESCRIPTION
## Summary
- track data type for connections during serialization
- restore Connection data_type from metadata and default to Any

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68a829f9efc88323a8bf57f9f41edbeb