### PR TITLE
doc: document connection types

### DIFF
--- a/desktop/src/app/state.rs
+++ b/desktop/src/app/state.rs
@@ -1,4 +1,4 @@
-use crate::visual::canvas::Connection;
+use crate::visual::connections::Connection;
 use chrono::{DateTime, Utc};
 use directories::ProjectDirs;
 use iced::{widget::text_editor, Color};

--- a/desktop/src/app/ui.rs
+++ b/desktop/src/app/ui.rs
@@ -10,7 +10,8 @@ use crate::app::diff::DiffView;
 use crate::app::events::Message;
 use crate::app::{command_palette::COMMANDS, format_log, Language, LogLevel, MulticodeApp};
 use crate::modal::Modal;
-use crate::visual::canvas::{CanvasMessage, Connection, VisualCanvas};
+use crate::visual::canvas::{CanvasMessage, VisualCanvas};
+use crate::visual::connections::Connection;
 use crate::visual::palette::{BlockPalette, PaletteMessage};
 use multicode_core::BlockInfo;
 

--- a/desktop/src/visual/canvas.rs
+++ b/desktop/src/visual/canvas.rs
@@ -3,9 +3,9 @@ use iced::{
     keyboard::{self, key},
     mouse, Color, Point, Rectangle, Renderer, Theme, Vector,
 };
-use serde::{Deserialize, Serialize};
 use std::cell::RefCell;
 
+use crate::visual::connections::{Connection, DataType};
 use crate::visual::translations::{translate_kind, Language};
 use multicode_core::BlockInfo;
 
@@ -14,27 +14,6 @@ pub const BLOCK_HEIGHT: f32 = 40.0;
 const PORT_RADIUS: f32 = 5.0;
 const ARROW_LENGTH: f32 = 10.0;
 const ARROW_WIDTH: f32 = 6.0;
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-pub enum DataType {
-    Any,
-    Number,
-    Boolean,
-    Text,
-}
-
-impl Default for DataType {
-    fn default() -> Self {
-        DataType::Any
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct Connection {
-    pub from: (usize, usize),
-    pub to: (usize, usize),
-    pub data_type: DataType,
-}
 
 #[derive(Debug, Clone)]
 pub enum CanvasMessage {

--- a/desktop/src/visual/connections.rs
+++ b/desktop/src/visual/connections.rs
@@ -1,0 +1,55 @@
+use serde::{Deserialize, Serialize};
+
+/// Direction of a block port.
+///
+/// A port either receives data (`In`) or sends it (`Out`).
+///
+/// # Examples
+/// ```
+/// use desktop::visual::connections::PortType;
+/// let input = PortType::In;
+/// let output = PortType::Out;
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum PortType {
+    In,
+    Out,
+}
+
+/// The kind of data transported over a connection between blocks.
+///
+/// # Examples
+/// ```
+/// use desktop::visual::connections::DataType;
+/// let ty = DataType::Boolean;
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum DataType {
+    Any,
+    Number,
+    Boolean,
+    Text,
+}
+
+impl Default for DataType {
+    fn default() -> Self {
+        DataType::Any
+    }
+}
+
+/// Connection between two block ports.
+///
+/// Both ports are identified by `(block_index, port_index)`.
+///
+/// # Examples
+/// ```
+/// use desktop::visual::connections::{Connection, DataType};
+/// let conn = Connection { from: (0, 0), to: (1, 1), data_type: DataType::Number };
+/// assert_eq!(conn.data_type, DataType::Number);
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Connection {
+    pub from: (usize, usize),
+    pub to: (usize, usize),
+    pub data_type: DataType,
+}

--- a/desktop/src/visual/mod.rs
+++ b/desktop/src/visual/mod.rs
@@ -1,5 +1,6 @@
 pub mod blocks;
 pub mod canvas;
+pub mod connections;
 pub mod palette;
 pub mod serialization;
 pub mod translations;

--- a/desktop/src/visual/serialization.rs
+++ b/desktop/src/visual/serialization.rs
@@ -1,4 +1,4 @@
-use crate::visual::canvas::{Connection, DataType};
+use crate::visual::connections::{Connection, DataType};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
## Summary
- add `connections` module with `PortType`, `DataType`, and `Connection`
- document connection types with examples
- adjust existing modules to use the new types

## Testing
- `cargo doc --document-private-items --no-deps`


------
https://chatgpt.com/codex/tasks/task_e_68a83ec4eae483239bb186d5fe6dfeed