### PR TITLE
Add validation and errors for visual block connections

### DIFF
--- a/desktop/src/visual/connections.rs
+++ b/desktop/src/visual/connections.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use std::fmt;
 
 /// Direction of a block port.
 ///
@@ -37,6 +38,26 @@ impl Default for DataType {
     }
 }
 
+/// Errors that can occur when creating a [`Connection`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConnectionError {
+    /// The ports have incompatible directions.
+    PortMismatch,
+    /// The ports carry incompatible data types.
+    DataTypeMismatch,
+}
+
+impl fmt::Display for ConnectionError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ConnectionError::PortMismatch => write!(f, "incompatible port types"),
+            ConnectionError::DataTypeMismatch => write!(f, "data type mismatch"),
+        }
+    }
+}
+
+impl std::error::Error for ConnectionError {}
+
 /// Connection between two block ports.
 ///
 /// Both ports are identified by `(block_index, port_index)`.
@@ -52,4 +73,35 @@ pub struct Connection {
     pub from: (usize, usize),
     pub to: (usize, usize),
     pub data_type: DataType,
+}
+
+impl Connection {
+    /// Create a new [`Connection`] between two ports.
+    ///
+    /// `from` and `to` are tuples containing `(block_index, port_index, port_type, data_type)`.
+    /// Returns an error if the ports have incompatible directions or data types.
+    pub fn new(
+        from: (usize, usize, PortType, DataType),
+        to: (usize, usize, PortType, DataType),
+    ) -> Result<Self, ConnectionError> {
+        if from.2 != PortType::Out || to.2 != PortType::In {
+            return Err(ConnectionError::PortMismatch);
+        }
+
+        let data_type = if from.3 == to.3 {
+            from.3
+        } else if from.3 == DataType::Any {
+            to.3
+        } else if to.3 == DataType::Any {
+            from.3
+        } else {
+            return Err(ConnectionError::DataTypeMismatch);
+        };
+
+        Ok(Connection {
+            from: (from.0, from.1),
+            to: (to.0, to.1),
+            data_type,
+        })
+    }
 }

--- a/desktop/src/visual/connections_tests.rs
+++ b/desktop/src/visual/connections_tests.rs
@@ -1,53 +1,28 @@
-#[derive(Debug, PartialEq)]
-enum PortDirection {
-    In,
-    Out,
-}
-
-#[derive(Debug, PartialEq)]
-enum DataType {
-    Integer,
-    Text,
-}
-
-#[derive(Debug)]
-struct Port {
-    direction: PortDirection,
-    data: DataType,
-}
-
-fn can_connect(from: &Port, to: &Port) -> Result<(), &'static str> {
-    match (&from.direction, &to.direction) {
-        (PortDirection::Out, PortDirection::In) => {
-            if from.data == to.data {
-                Ok(())
-            } else {
-                Err("data type mismatch")
-            }
-        }
-        (PortDirection::Out, PortDirection::Out) | (PortDirection::In, PortDirection::In) |
-        (PortDirection::In, PortDirection::Out) => Err("incompatible ports"),
-    }
-}
+use super::connections::{Connection, ConnectionError, DataType, PortType};
 
 #[test]
 fn connects_matching_ports() {
-    let from = Port { direction: PortDirection::Out, data: DataType::Integer };
-    let to = Port { direction: PortDirection::In, data: DataType::Integer };
-    assert!(can_connect(&from, &to).is_ok());
+    let conn = Connection::new(
+        (0, 0, PortType::Out, DataType::Number),
+        (1, 0, PortType::In, DataType::Number),
+    );
+    assert!(conn.is_ok());
 }
 
 #[test]
 fn fails_on_mismatched_data() {
-    let from = Port { direction: PortDirection::Out, data: DataType::Integer };
-    let to = Port { direction: PortDirection::In, data: DataType::Text };
-    assert!(can_connect(&from, &to).is_err());
+    let conn = Connection::new(
+        (0, 0, PortType::Out, DataType::Number),
+        (1, 0, PortType::In, DataType::Text),
+    );
+    assert_eq!(conn, Err(ConnectionError::DataTypeMismatch));
 }
 
 #[test]
 fn fails_on_wrong_port_direction() {
-    let from = Port { direction: PortDirection::In, data: DataType::Integer };
-    let to = Port { direction: PortDirection::In, data: DataType::Integer };
-    assert!(can_connect(&from, &to).is_err());
+    let conn = Connection::new(
+        (0, 0, PortType::In, DataType::Number),
+        (1, 0, PortType::In, DataType::Number),
+    );
+    assert_eq!(conn, Err(ConnectionError::PortMismatch));
 }
-


### PR DESCRIPTION
## Summary
- introduce `ConnectionError` for port and datatype mismatches
- return `Result` from `Connection::new` and validate port types and data
- add tests for valid and invalid connection scenarios

## Testing
- `cargo test -p desktop`


------
https://chatgpt.com/codex/tasks/task_e_68a846c9cf94832384ecddea79a6b248