### PR TITLE
Implement Display for connection port and data types

### DIFF
--- a/desktop/src/visual/connections_tests.rs
+++ b/desktop/src/visual/connections_tests.rs
@@ -15,7 +15,13 @@ fn fails_on_mismatched_data() {
         (0, 0, PortType::Out, DataType::Number),
         (1, 0, PortType::In, DataType::Text),
     );
-    assert_eq!(conn, Err(ConnectionError::DataTypeMismatch));
+    assert_eq!(
+        conn,
+        Err(ConnectionError::DataTypeMismatch(
+            DataType::Number,
+            DataType::Text,
+        ))
+    );
 }
 
 #[test]
@@ -24,5 +30,8 @@ fn fails_on_wrong_port_direction() {
         (0, 0, PortType::In, DataType::Number),
         (1, 0, PortType::In, DataType::Number),
     );
-    assert_eq!(conn, Err(ConnectionError::PortMismatch));
+    assert_eq!(
+        conn,
+        Err(ConnectionError::PortMismatch(PortType::In, PortType::In))
+    );
 }


### PR DESCRIPTION
## Summary
- add `fmt::Display` for `PortType` and `DataType`
- include mismatched values in `ConnectionError` messages
- adjust tests for new error details

## Testing
- `cargo test -p desktop`


------
https://chatgpt.com/codex/tasks/task_e_68a84fd71f74832385747d5a3f5dd7aa