### PR TITLE
docs: rename node_type to analysis_type in Neira docs

### DIFF
--- a/docs/neira/analysis-architecture.md
+++ b/docs/neira/analysis-architecture.md
@@ -37,7 +37,7 @@
 ```rust
 pub trait AnalysisNode {
     fn id(&self) -> &str;
-    fn node_type(&self) -> &str;
+    fn analysis_type(&self) -> &str;
     fn analyze(&self, input: &str) -> AnalysisResult;
     fn explain(&self) -> String;
 }
@@ -73,7 +73,7 @@ pub struct ComplexityNode;
 
 impl AnalysisNode for ComplexityNode {
     fn id(&self) -> &str { "analysis.complexity" }
-    fn node_type(&self) -> &str { "ComplexityNode" }
+    fn analysis_type(&self) -> &str { "ComplexityNode" }
     fn analyze(&self, input: &str) -> AnalysisResult {
         let score = compute_complexity(input);
         AnalysisResult {

--- a/docs/neira/analysis-nodes.md
+++ b/docs/neira/analysis-nodes.md
@@ -99,7 +99,7 @@ source: "https://example.org"
 | Поле | Описание |
 | --- | --- |
 | `id` | Уникальный идентификатор шаблона. |
-| `node_type` | Тип создаваемого узла. |
+| `analysis_type` | Тип создаваемого узла. |
 | `links` | Список связей с другими узлами. |
 | `draft_content` | Черновое содержимое узла. |
 | `metadata` | Дополнительные метаданные в формате ключ‑значение. |
@@ -107,7 +107,7 @@ source: "https://example.org"
 ```rust
 struct NodeTemplate {
     id: String,
-    node_type: String,
+    analysis_type: String,
     links: Vec<String>,
     draft_content: String,
     metadata: HashMap<String, String>,
@@ -119,7 +119,7 @@ struct NodeTemplate {
 | Поле NodeTemplate | Поле AnalysisNode |
 | --- | --- |
 | `id` | `id` |
-| `node_type` | `analysis_type` |
+| `analysis_type` | `analysis_type` |
 | `links` | `links` |
 | `metadata` | `metadata` |
 | `draft_content` | — |
@@ -131,7 +131,7 @@ struct NodeTemplate {
 ```json
 {
   "id": "example.template",
-  "node_type": "ProgrammingSyntaxNode",
+  "analysis_type": "ProgrammingSyntaxNode",
   "links": ["prog.syntax.base"],
   "draft_content": "Initial description",
   "metadata": {
@@ -165,7 +165,7 @@ struct NodeTemplate {
 
 ```yaml
 id: example.template
-node_type: ProgrammingSyntaxNode
+analysis_type: ProgrammingSyntaxNode
 links:
   - prog.syntax.base
 draft_content: Initial description

--- a/docs/neira/node-template.md
+++ b/docs/neira/node-template.md
@@ -26,7 +26,7 @@
 | Поле | Описание |
 | --- | --- |
 | `id` | Уникальный идентификатор шаблона. |
-| `node_type` | Тип создаваемого узла. |
+| `analysis_type` | Тип создаваемого узла. |
 | `links` | Список связей с другими узлами. |
 | `draft_content` | Черновое содержимое узла. |
 | `metadata` | Дополнительные метаданные в формате ключ‑значение. |
@@ -38,7 +38,7 @@
 ```json
 {
   "id": "example.template",
-  "node_type": "ProgrammingSyntaxNode",
+  "analysis_type": "ProgrammingSyntaxNode",
   "links": ["prog.syntax.base"],
   "draft_content": "Initial description",
   "metadata": {
@@ -52,7 +52,7 @@
 
 ```yaml
 id: example.template
-node_type: ProgrammingSyntaxNode
+analysis_type: ProgrammingSyntaxNode
 links:
   - prog.syntax.base
 draft_content: Initial description


### PR DESCRIPTION
## Summary
- rename `node_type()` method to `analysis_type()` in analysis architecture
- use `analysis_type` field in node template and analysis nodes docs

## Testing
- `CI=1 npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a85805a444832387ef7bd1a672e389