### PR TITLE
Add main UI state and message types

### DIFF
--- a/desktop/src/ui/mod.rs
+++ b/desktop/src/ui/mod.rs
@@ -1,3 +1,3 @@
 pub mod main_layout;
 
-pub use main_layout::{create_split_view, create_visual_editor_view};
+pub use main_layout::{MainMessage, MainUI};


### PR DESCRIPTION
## Summary
- Define `MainUI` struct with view mode and editor states
- Add `MainMessage` enum for switching views and editor events
- Re-export new types from `ui` module

## Testing
- `cargo test -p desktop`

------
https://chatgpt.com/codex/tasks/task_e_68a85d2eda44832398a17f5f64e364b2