### PR TITLE
docs: add node and analysis schemas

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,7 +73,8 @@ npm run dev
 JSON‑схемы хранятся в каталоге `schemas/`. В конвейере CI они валидируются командой:
 
 ```bash
-npx ajv validate
+npx ajv validate -s schemas/node-template.schema.json -d node-template.json
+npx ajv validate -s schemas/analysis-node.schema.json -d analysis-node.json
 ```
 
 Запускайте эту проверку локально при изменении схем, чтобы убедиться в корректности.

--- a/docs/neira/analysis-nodes.md
+++ b/docs/neira/analysis-nodes.md
@@ -72,7 +72,7 @@ struct QualityMetrics {
 ```
 - **Метаданные:**
 ```yaml
-schema: "1.0"
+schema: "1.0.0"
 source: "https://example.org"
 ```
 ````
@@ -139,7 +139,7 @@ struct NodeTemplate {
   "links": ["prog.syntax.base"],
   "draft_content": "Initial description",
   "metadata": {
-    "schema": "1.0",
+    "schema": "1.0.0",
     "source": "https://example.org"
   }
 }
@@ -159,7 +159,7 @@ struct NodeTemplate {
   ],
   "uncertainty_score": 0.2,
   "metadata": {
-    "schema": "1.0",
+    "schema": "1.0.0",
     "source": "https://example.org"
   }
 }
@@ -174,7 +174,7 @@ links:
   - prog.syntax.base
 draft_content: Initial description
 metadata:
-  schema: "1.0"
+  schema: "1.0.0"
   source: "https://example.org"
 ```
 
@@ -191,11 +191,11 @@ reasoning_chain:
   - initial review complete
 uncertainty_score: 0.2
 metadata:
-  schema: "1.0"
+  schema: "1.0.0"
   source: "https://example.org"
 ```
 
-**Проверка перед ревью:** сохраните шаблон в файл и проверьте его с помощью JSON Schema, например командой `npx ajv validate -s node-template.schema.json -d node-template.json`. Для YAML используйте `npx ajv validate -s node-template.schema.json -d node-template.yaml` или `yamllint` для проверки синтаксиса.
+**Проверка перед ревью:** сохраните шаблон в файл и проверьте его с помощью JSON Schema, например командой `npx ajv validate -s ../../schemas/node-template.schema.json -d node-template.json`. Для YAML используйте `npx ajv validate -s ../../schemas/node-template.schema.json -d node-template.yaml` или `yamllint` для проверки синтаксиса.
 
 ## 1. Базовый интерфейс узла
 - **Интерфейс:** `AnalysisNode`
@@ -217,7 +217,7 @@ reasoning_chain:           # опционально, шаги рассужден
   - string
 uncertainty_score: number  # 0..1, опционально
 metadata:                  # опционально
-  schema: "1.0"            # версия схемы
+  schema: "1.0.0"            # версия схемы
 ```
 
 Версионирование определяется полем `metadata.schema` и следует [Semantic Versioning](https://semver.org/). `MAJOR` меняется при несовместимых изменениях, `MINOR` — при добавлении опциональных полей, `PATCH` — при исправлении описаний.
@@ -244,7 +244,7 @@ metadata:                  # опционально
   ],
   "uncertainty_score": 0.05,
   "metadata": {
-    "schema": "1.0",
+    "schema": "1.0.0",
     "language": "Python",
     "example": "for i in range(10): print(i)"
   }
@@ -323,7 +323,7 @@ stateDiagram-v2
   ],
   "uncertainty_score": 0.16,
   "metadata": {
-    "schema": "1.0",
+    "schema": "1.0.0",
     "language": "Python"
   }
 }
@@ -343,7 +343,7 @@ reasoning_chain:
   - validated loop bounds
 uncertainty_score: 0.16
 metadata:
-  schema: "1.0"
+  schema: "1.0.0"
   language: Python
 ```
 
@@ -769,4 +769,8 @@ metadata:
 
 ## Схемы
 
-JSON‑схемы расположены в каталоге [../../schemas](../../schemas). При несовместимых изменениях повышайте версию: `1.0.0` → `1.1.0`.
+JSON‑схемы расположены в каталоге [../../schemas](../../schemas):
+- [node-template.schema.json](../../schemas/node-template.schema.json)
+- [analysis-node.schema.json](../../schemas/analysis-node.schema.json)
+
+При несовместимых изменениях повышайте версию: `1.0.0` → `1.1.0`.

--- a/docs/neira/node-template.md
+++ b/docs/neira/node-template.md
@@ -42,7 +42,7 @@
   "links": ["prog.syntax.base"],
   "draft_content": "Initial description",
   "metadata": {
-    "schema": "1.0",
+    "schema": "1.0.0",
     "source": "https://example.org"
   }
 }
@@ -57,7 +57,7 @@ links:
   - prog.syntax.base
 draft_content: Initial description
 metadata:
-  schema: "1.0"
+  schema: "1.0.0"
   source: "https://example.org"
 ```
 
@@ -66,10 +66,10 @@ metadata:
 Файл можно проверить с помощью JSON Schema. Сохраните шаблон в файл и выполните:
 
 ```bash
-npx ajv validate -s node-template.schema.json -d node-template.json
-npx ajv validate -s node-template.schema.json -d node-template.yaml
+npx ajv validate -s ../../schemas/node-template.schema.json -d node-template.json
+npx ajv validate -s ../../schemas/node-template.schema.json -d node-template.yaml
 ```
 
 ## Схемы
 
-JSON‑схемы расположены в каталоге [../../schemas](../../schemas). При несовместимых изменениях повышайте версию: `1.0.0` → `1.1.0`.
+JSON‑схемы расположены в каталоге [../../schemas](../../schemas). Схема для NodeTemplate: [../../schemas/node-template.schema.json](../../schemas/node-template.schema.json). При несовместимых изменениях повышайте версию: `1.0.0` → `1.1.0`.

--- a/docs/neira/roadmap.md
+++ b/docs/neira/roadmap.md
@@ -103,7 +103,11 @@
 
 ## Схемы
 
-JSON‑схемы расположены в каталоге [../../schemas](../../schemas). При несовместимых изменениях повышайте версию: `1.0.0` → `1.1.0`.
+JSON‑схемы расположены в каталоге [../../schemas](../../schemas):
+- [node-template.schema.json](../../schemas/node-template.schema.json)
+- [analysis-node.schema.json](../../schemas/analysis-node.schema.json)
+
+При несовместимых изменениях повышайте версию: `1.0.0` → `1.1.0`.
 
 ## План отката
 

--- a/schemas/analysis-node.schema.json
+++ b/schemas/analysis-node.schema.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://multicode.dev/schemas/analysis-node.schema.json",
+  "title": "AnalysisNode",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["id", "output"],
+  "properties": {
+    "id": { "type": "string" },
+    "output": { "type": "string" },
+    "quality_metrics": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "credibility": { "type": "number", "minimum": 0, "maximum": 1 },
+        "recency_days": { "type": "integer", "minimum": 0 },
+        "demand": { "type": "integer", "minimum": 0 }
+      }
+    }
+  }
+}

--- a/schemas/node-template.schema.json
+++ b/schemas/node-template.schema.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://multicode.dev/schemas/node-template.schema.json",
+  "title": "NodeTemplate",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["id", "analysis_type", "links", "draft_content", "metadata"],
+  "properties": {
+    "id": { "type": "string" },
+    "analysis_type": { "type": "string" },
+    "links": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "draft_content": { "type": "string" },
+    "metadata": {
+      "type": "object",
+      "required": ["schema"],
+      "additionalProperties": { "type": "string" },
+      "properties": {
+        "schema": { "type": "string" }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add JSON schemas for `NodeTemplate` and `AnalysisNode`
- document schema validation in contributing guide
- update Neira documentation links and version markers

## Testing
- `npx ajv-cli compile -s schemas/node-template.schema.json`
- `npx ajv-cli compile -s schemas/analysis-node.schema.json`
- `npx ajv-cli validate -s schemas/node-template.schema.json -d /tmp/node-template.json`
- `npx ajv-cli validate -s schemas/analysis-node.schema.json -d /tmp/analysis-node.json`
- `npm test` *(fails: Cannot find package 'jsdom')*


------
https://chatgpt.com/codex/tasks/task_e_68a86a01ab94832398511821e9561af2