### PR TITLE
Graceful error handling for metadata utilities

### DIFF
--- a/core/src/export.rs
+++ b/core/src/export.rs
@@ -1,7 +1,7 @@
-use once_cell::sync::Lazy;
-use regex::Regex;
-use serde::{Deserialize, Serialize};
 use crate::meta;
+use once_cell::sync::Lazy;
+use regex::{Error as RegexError, Regex};
+use serde::{Deserialize, Serialize};
 
 /// Набор визуальных метаданных, связанных с исходным файлом.
 #[derive(Debug, Serialize, Deserialize)]
@@ -28,39 +28,45 @@ pub fn deserialize_viz_document(json: &str) -> Result<VizDocument, serde_json::E
 // Регулярные выражения для разных стилей комментариев, которые могут содержать
 // маркеры `@VISUAL_META`. Каждый шаблон также поглощает завершающий перевод строки,
 // чтобы убрать всю строку из вывода.
-static PYTHON_SINGLE: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"(?m)^\s*#\s*@VISUAL_META\s*\{.*\}\s*\n?").unwrap());
+static PYTHON_SINGLE: Lazy<Result<Regex, RegexError>> =
+    Lazy::new(|| Regex::new(r"(?m)^\s*#\s*@VISUAL_META\s*\{.*\}\s*\n?"));
 
-static SLASH_SINGLE: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"(?m)^\s*//\s*@VISUAL_META\s*\{.*\}\s*\n?").unwrap());
+static SLASH_SINGLE: Lazy<Result<Regex, RegexError>> =
+    Lazy::new(|| Regex::new(r"(?m)^\s*//\s*@VISUAL_META\s*\{.*\}\s*\n?"));
 
-static C_STYLE_MULTI: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"(?ms)^\s*/\*\s*@VISUAL_META\s*\{.*?\}\s*\*/\s*\n?").unwrap());
+static C_STYLE_MULTI: Lazy<Result<Regex, RegexError>> =
+    Lazy::new(|| Regex::new(r"(?ms)^\s*/\*\s*@VISUAL_META\s*\{.*?\}\s*\*/\s*\n?"));
 
-static HTML_MULTI: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"(?ms)^\s*<!--\s*@VISUAL_META\s*\{.*?\}\s*-->\s*\n?").unwrap());
+static HTML_MULTI: Lazy<Result<Regex, RegexError>> =
+    Lazy::new(|| Regex::new(r"(?ms)^\s*<!--\s*@VISUAL_META\s*\{.*?\}\s*-->\s*\n?"));
 
 /// Удаляет из `content` все строки, содержащие комментарии `@VISUAL_META`.
 ///
 /// Поддерживаются однострочные комментарии, начинающиеся с `#` или `//`, и
 /// блочные комментарии вида `/* */` и `<!-- -->`.
-pub fn remove_meta_lines(content: &str) -> String {
+pub fn remove_meta_lines(content: &str) -> Result<String, RegexError> {
     let mut out = content.to_string();
-    for re in [&PYTHON_SINGLE, &SLASH_SINGLE, &C_STYLE_MULTI, &HTML_MULTI] {
+    for re in [
+        &*PYTHON_SINGLE,
+        &*SLASH_SINGLE,
+        &*C_STYLE_MULTI,
+        &*HTML_MULTI,
+    ] {
+        let re = re.as_ref().map_err(|e| e.clone())?;
         out = re.replace_all(&out, "").to_string();
     }
-    out
+    Ok(out)
 }
 
 /// Подготавливает исходный текст к экспорту.
 ///
 /// Если `strip_meta` равно `true`, все комментарии `@VISUAL_META` удаляются.
 /// Иначе содержимое возвращается без изменений.
-pub fn prepare_for_export(content: &str, strip_meta: bool) -> String {
+pub fn prepare_for_export(content: &str, strip_meta: bool) -> Result<String, RegexError> {
     if strip_meta {
         remove_meta_lines(content)
     } else {
-        content.to_string()
+        Ok(content.to_string())
     }
 }
 
@@ -71,8 +77,18 @@ mod tests {
     #[test]
     fn strips_python_comment() {
         let src = "# @VISUAL_META {\"id\":1}\nprint(\"hi\")\n";
-        let cleaned = remove_meta_lines(src);
+        let cleaned = remove_meta_lines(src).unwrap();
         assert!(!cleaned.contains("@VISUAL_META"));
         assert!(cleaned.contains("print"));
+    }
+
+    #[test]
+    fn serialize_empty_returns_none() {
+        assert!(serialize_viz_document("").is_none());
+    }
+
+    #[test]
+    fn deserialize_invalid_json() {
+        assert!(deserialize_viz_document("not json").is_err());
     }
 }

--- a/core/tests/export.rs
+++ b/core/tests/export.rs
@@ -4,7 +4,7 @@ use core::export::prepare_for_export;
 #[test]
 fn remove_python_meta() {
     let src = "# @VISUAL_META {\"id\":\"1\",\"x\":1.0,\"y\":2.0}\nprint(\"hi\")";
-    let cleaned = prepare_for_export(src, true);
+    let cleaned = prepare_for_export(src, true).unwrap();
     assert!(!cleaned.contains("@VISUAL_META"));
     assert!(cleaned.contains("print"));
 }
@@ -12,7 +12,7 @@ fn remove_python_meta() {
 #[test]
 fn remove_js_meta() {
     let src = "// @VISUAL_META {\"id\":\"1\",\"x\":1.0,\"y\":2.0}\nconsole.log(\"hi\");";
-    let cleaned = prepare_for_export(src, true);
+    let cleaned = prepare_for_export(src, true).unwrap();
     assert!(!cleaned.contains("@VISUAL_META"));
     assert!(cleaned.contains("console.log"));
 }
@@ -20,7 +20,7 @@ fn remove_js_meta() {
 #[test]
 fn remove_css_meta() {
     let src = "/* @VISUAL_META {\"id\":\"1\",\"x\":1.0,\"y\":2.0} */\n.selector { color: red; }";
-    let cleaned = prepare_for_export(src, true);
+    let cleaned = prepare_for_export(src, true).unwrap();
     assert!(!cleaned.contains("@VISUAL_META"));
     assert!(cleaned.contains(".selector"));
 }
@@ -28,7 +28,7 @@ fn remove_css_meta() {
 #[test]
 fn remove_html_meta() {
     let src = "<!-- @VISUAL_META {\"id\":\"1\",\"x\":1.0,\"y\":2.0} -->\n<div></div>";
-    let cleaned = prepare_for_export(src, true);
+    let cleaned = prepare_for_export(src, true).unwrap();
     assert!(!cleaned.contains("@VISUAL_META"));
     assert!(cleaned.contains("<div>"));
 }
@@ -36,7 +36,7 @@ fn remove_html_meta() {
 #[test]
 fn keep_meta_when_requested() {
     let src = "// @VISUAL_META {\"id\":\"1\",\"x\":1.0,\"y\":2.0}\nconsole.log(\"hi\");";
-    let kept = prepare_for_export(src, false);
+    let kept = prepare_for_export(src, false).unwrap();
     assert!(kept.contains("@VISUAL_META"));
     assert!(kept.contains("console.log"));
 }

--- a/core/tests/links.rs
+++ b/core/tests/links.rs
@@ -1,6 +1,6 @@
+use chrono::Utc;
 use core::meta::{read_all, upsert, VisualMeta};
 use core::search::search_links;
-use chrono::Utc;
 use std::collections::HashMap;
 use std::fs;
 use tempfile::tempdir;
@@ -47,7 +47,7 @@ fn search_finds_by_link() {
         "// @VISUAL_META {\"id\":\"1\",\"x\":0.0,\"y\":0.0,\"links\":[\"target\"]}\n",
     )
     .unwrap();
-    let res = search_links(dir.path(), "target");
+    let res = search_links(dir.path(), "target").unwrap();
     assert_eq!(res.len(), 1);
     assert_eq!(res[0].file, file);
     assert_eq!(res[0].meta.links, vec!["target"]);

--- a/desktop/src/app/events/handler.rs
+++ b/desktop/src/app/events/handler.rs
@@ -1304,7 +1304,8 @@ impl MulticodeApp {
                 let query = self.query.clone();
                 Command::perform(
                     async move {
-                        let results = search::search_metadata(Path::new(&root), &query);
+                        let results = search::search_metadata(Path::new(&root), &query)
+                            .map_err(|e| e.to_string())?;
                         Ok::<_, String>(
                             results
                                 .into_iter()


### PR DESCRIPTION
## Summary
- return `Result` from search utilities and avoid panicking on regex init
- validate export regexes and propagate errors when stripping metadata
- guard registry access and time retrieval without `unwrap` in meta module
- cover empty/invalid inputs with new tests

## Testing
- `cargo test -p core`


------
https://chatgpt.com/codex/tasks/task_e_68a882012f888323b0ec0a7eac0135c3