### PR TITLE
Clarify optional NodeTemplate fields and update schema

### DIFF
--- a/docs/neira/analysis-nodes.md
+++ b/docs/neira/analysis-nodes.md
@@ -148,9 +148,10 @@ struct NodeTemplate {
   "id": "example.template",
   "analysis_type": "ProgrammingSyntaxNode",
   "links": ["prog.syntax.base"],
+  "confidence_threshold": 0.8,
   "draft_content": "Initial description",
   "metadata": {
-    "schema": "1.0.0",
+    "schema": "1.1.0",
     "source": "https://example.org"
   }
 }
@@ -170,7 +171,7 @@ struct NodeTemplate {
   ],
   "uncertainty_score": 0.2,
   "metadata": {
-    "schema": "1.0.0",
+    "schema": "1.1.0",
     "source": "https://example.org"
   }
 }
@@ -183,9 +184,10 @@ id: example.template
 analysis_type: ProgrammingSyntaxNode
 links:
   - prog.syntax.base
+confidence_threshold: 0.8
 draft_content: Initial description
 metadata:
-  schema: "1.0.0"
+  schema: "1.1.0"
   source: "https://example.org"
 ```
 
@@ -202,7 +204,7 @@ reasoning_chain:
   - initial review complete
 uncertainty_score: 0.2
 metadata:
-  schema: "1.0.0"
+  schema: "1.1.0"
   source: "https://example.org"
 ```
 

--- a/docs/neira/node-template.md
+++ b/docs/neira/node-template.md
@@ -19,17 +19,18 @@
 - [Проверка](#проверка)
 
 
-Шаблон для создания узлов анализа. Все поля являются обязательными.
+Шаблон для создания узлов анализа. Обязательными являются поля `id`, `analysis_type` и `metadata`.
 
 ## Обязательные поля
 
-| Поле | Описание |
-| --- | --- |
-| `id` | Уникальный идентификатор шаблона. |
-| `analysis_type` | Тип создаваемого узла. |
-| `links` | Список связей с другими узлами. |
-| `draft_content` | Черновое содержимое узла. |
-| `metadata` | Дополнительные метаданные в формате ключ‑значение. |
+| Поле | Тип | Обязательное | Описание |
+| --- | --- | --- | --- |
+| `id` | string | да | Уникальный идентификатор шаблона. |
+| `analysis_type` | string | да | Тип создаваемого узла. |
+| `links` | array<string> | нет, по умолчанию `[]` | Список связей с другими узлами. |
+| `confidence_threshold` | number | нет | Минимальная допустимая `credibility` для принятия результата. |
+| `draft_content` | string | нет | Черновое содержимое узла. |
+| `metadata` | object | да | Дополнительные метаданные в формате ключ‑значение. Должно содержать поле `schema`. |
 
 ## Пример
 
@@ -40,9 +41,10 @@
   "id": "example.template",
   "analysis_type": "ProgrammingSyntaxNode",
   "links": ["prog.syntax.base"],
+  "confidence_threshold": 0.8,
   "draft_content": "Initial description",
   "metadata": {
-    "schema": "1.0.0",
+    "schema": "1.1.0",
     "source": "https://example.org"
   }
 }
@@ -55,9 +57,10 @@ id: example.template
 analysis_type: ProgrammingSyntaxNode
 links:
   - prog.syntax.base
+confidence_threshold: 0.8
 draft_content: Initial description
 metadata:
-  schema: "1.0.0"
+  schema: "1.1.0"
   source: "https://example.org"
 ```
 

--- a/schemas/node-template.schema.json
+++ b/schemas/node-template.schema.json
@@ -4,13 +4,19 @@
   "title": "NodeTemplate",
   "type": "object",
   "additionalProperties": false,
-  "required": ["id", "analysis_type", "links", "draft_content", "metadata"],
+  "required": ["id", "analysis_type", "metadata"],
   "properties": {
     "id": { "type": "string" },
     "analysis_type": { "type": "string" },
     "links": {
       "type": "array",
-      "items": { "type": "string" }
+      "items": { "type": "string" },
+      "default": []
+    },
+    "confidence_threshold": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1
     },
     "draft_content": { "type": "string" },
     "metadata": {


### PR DESCRIPTION
## Summary
- mark `links` and `draft_content` as optional in NodeTemplate and add `confidence_threshold`
- sync node template docs and examples across references
- adjust node-template JSON schema defaults and validation

## Testing
- `npx ajv validate -s schemas/node-template.schema.json -d /tmp/node-template.json`
- `npx ajv validate -s schemas/node-template.schema.json -d /tmp/node-template.yaml`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a883b382d48323a1e3495e7bb4b6ff