### PR TITLE
docs: clarify node identifiers in trace example

### DIFF
--- a/docs/neira/usage-example.md
+++ b/docs/neira/usage-example.md
@@ -9,6 +9,8 @@
 5. **ActionNode** — выполняет команду (генерация кода, вывод данных и т.д.).
 6. **Ответ** — результат возвращается пользователю вместе с трассировкой.
 
+Трассировка оперирует идентификаторами узлов.
+
 ```bash
 # запрос
 curl -X POST http://localhost:4000/interact \
@@ -19,9 +21,9 @@ curl -X POST http://localhost:4000/interact \
 {
   "reply": "Задачи: [\"task1\", \"task2\"]",
   "trace": [
-    {"node": "AnalysisNode/main", "status": "ok"},
-    {"node": "MemoryNode/tasks", "status": "hit"},
-    {"node": "ActionNode/list", "result": ["task1", "task2"]}
+    {"id": "AnalysisNode/main", "status": "ok"},
+    {"id": "MemoryNode/tasks", "status": "hit"},
+    {"id": "ActionNode/list", "result": ["task1", "task2"]}
   ]
 }
 ```


### PR DESCRIPTION
## Summary
- replace `node` with `id` in trace example
- note that trace items use node identifiers

## Testing
- `npm test`
- `cargo test` *(fails: The system library `glib-2.0` required by crate `glib-sys` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a88f3fddfc8323b1e16bd208b7ff91