### PR TITLE
chore: harden command execution

### DIFF
--- a/scripts/run-tests.js
+++ b/scripts/run-tests.js
@@ -9,10 +9,11 @@ async function main() {
     return;
   }
   for (const cmd of cmds) {
+    const [command, ...args] = cmd.split(/\s+/);
     const spinner = createSpinner(`Running ${cmd}`);
     spinner.start();
     try {
-      await runCommand(cmd, [], log, { env: process.env });
+      await runCommand(command, args, log, { env: process.env });
       spinner.succeed(`Passed ${cmd}`);
     } catch (err) {
       spinner.fail(`Failed ${cmd}`);

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -34,8 +34,11 @@ function createLogger(name) {
 }
 
 function runCommand(cmd, args = [], log = console.log, options = {}) {
+  if (!Array.isArray(args)) {
+    throw new TypeError('args must be an array');
+  }
   return new Promise((resolve, reject) => {
-    const child = spawn(cmd, args, { shell: true, ...options });
+    const child = spawn(cmd, args, { shell: false, ...options });
     child.stdout.on('data', (data) => log(data.toString().trim()));
     child.stderr.on('data', (data) => log(data.toString().trim()));
     child.on('close', (code) => {

--- a/scripts/utils.test.js
+++ b/scripts/utils.test.js
@@ -1,0 +1,12 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+const { runCommand } = require('./utils');
+
+test('runCommand does not execute suspicious arguments', async () => {
+  const tmpFile = path.join(__dirname, 'hacked.txt');
+  fs.rmSync(tmpFile, { force: true });
+  await runCommand('echo', ['hello', '&&', 'touch', tmpFile], () => {});
+  assert.ok(!fs.existsSync(tmpFile));
+});


### PR DESCRIPTION
## Summary
- avoid shell invocation in helper spawn
- split test commands into program + args
- verify runCommand resists shell injection

## Testing
- `node --test scripts/utils.test.js`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a8922b6ce08323b1c6b7ca86cac064