### PR TITLE
docs(neira): replace TinyLlama example

### DIFF
--- a/docs/neira/deployment.md
+++ b/docs/neira/deployment.md
@@ -32,7 +32,7 @@ Neira поддерживает конфигурацию через `.env` или
 Пример файла `.env`:
 ```dotenv
 NEIRA_PORT=4000
-NEIRA_MODEL=./models/tiny-llama.bin
+NEIRA_MODEL=./models/teacher-model.bin
 NEIRA_LOG_LEVEL=info
 ```
 После изменения переменных перезапустите приложение.


### PR DESCRIPTION
## Summary
- replace TinyLlama model path example with generic placeholder
- verify no TinyLlama references remain in deployment docs

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a8e37dd1648323a45821cb89e37a0e