### PR TITLE
Validate query and arguments

### DIFF
--- a/scripts/utils.test.js
+++ b/scripts/utils.test.js
@@ -4,9 +4,12 @@ const fs = require('fs');
 const path = require('path');
 const { runCommand } = require('./utils');
 
-test('runCommand does not execute suspicious arguments', async () => {
+test('runCommand rejects suspicious arguments', () => {
   const tmpFile = path.join(__dirname, 'hacked.txt');
   fs.rmSync(tmpFile, { force: true });
-  await runCommand('echo', ['hello', '&&', 'touch', tmpFile], () => {});
+  assert.throws(
+    () => runCommand('echo', ['hello', '&&', 'touch', tmpFile], () => {}),
+    TypeError,
+  );
   assert.ok(!fs.existsSync(tmpFile));
 });


### PR DESCRIPTION
## Summary
- ensure Rust search functions reject empty or unsafe queries
- validate and document command arguments before spawning processes
- add tests for invalid query and argument cases

## Testing
- `node --test scripts/utils.test.js`
- `cargo test -p core`


------
https://chatgpt.com/codex/tasks/task_e_68a955af57388323b3fd353699b04928