### PR TITLE
Handle unhandled rejections in Node scripts

### DIFF
--- a/scripts/check-env.js
+++ b/scripts/check-env.js
@@ -1,4 +1,8 @@
 #!/usr/bin/env node
+process.on('unhandledRejection', (err) => {
+  console.error(err && err.stack ? err.stack : err);
+  process.exit(1);
+});
 const { execSync } = require('child_process');
 
 const isLinux = process.platform === 'linux';

--- a/scripts/check-gdk.js
+++ b/scripts/check-gdk.js
@@ -1,4 +1,8 @@
 #!/usr/bin/env node
+process.on('unhandledRejection', (err) => {
+  console.error(err && err.stack ? err.stack : err);
+  process.exit(1);
+});
 const { execSync } = require('child_process');
 
 const isLinux = process.platform === 'linux';

--- a/scripts/check-scripts.js
+++ b/scripts/check-scripts.js
@@ -1,4 +1,8 @@
 #!/usr/bin/env node
+process.on('unhandledRejection', (err) => {
+  console.error(err && err.stack ? err.stack : err);
+  process.exit(1);
+});
 const { execSync } = require('child_process');
 const fs = require('fs');
 const path = require('path');

--- a/scripts/run-tests.js
+++ b/scripts/run-tests.js
@@ -1,4 +1,8 @@
 #!/usr/bin/env node
+process.on('unhandledRejection', (err) => {
+  console.error(err && err.stack ? err.stack : err);
+  process.exit(1);
+});
 const { createLogger, runCommand, createSpinner } = require('./utils');
 
 async function main() {

--- a/scripts/setup.js
+++ b/scripts/setup.js
@@ -1,4 +1,8 @@
 #!/usr/bin/env node
+process.on('unhandledRejection', (err) => {
+  console.error(err && err.stack ? err.stack : err);
+  process.exit(1);
+});
 const fs = require('fs');
 const fsp = fs.promises;
 const path = require('path');

--- a/scripts/unhandled.test.js
+++ b/scripts/unhandled.test.js
@@ -1,0 +1,17 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { spawnSync } = require('child_process');
+
+test('unhandled rejection exits with code 1', () => {
+  const code = `
+    process.on('unhandledRejection', (err) => {
+      console.error(err && err.stack ? err.stack : err);
+      process.exit(1);
+    });
+    Promise.reject(new Error('boom'));
+  `;
+  const result = spawnSync(process.execPath, ['-e', code], { encoding: 'utf8' });
+  assert.equal(result.status, 1);
+  const output = result.stderr + result.stdout;
+  assert.ok(output.includes('boom'));
+});


### PR DESCRIPTION
## Summary
- add global `unhandledRejection` handlers to Node scripts to log errors and exit with code 1
- test unhandled promise rejections

## Testing
- `node --test scripts/utils.test.js scripts/unhandled.test.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a965b896c08323a84aa8a221940cda