### PR TITLE
Add cross-platform hotkeys for command palette

### DIFF
--- a/desktop/src/app/command_palette.rs
+++ b/desktop/src/app/command_palette.rs
@@ -70,7 +70,7 @@ pub const COMMANDS: &[CommandItem] = &[
         description_en: "Switch to text editor",
         description_ru: "Переключиться в текстовый редактор",
         category: CommandCategory::View,
-        hotkey: "",
+        hotkey: "Ctrl+1",
     },
     CommandItem {
         id: "switch_to_visual_editor",
@@ -79,7 +79,7 @@ pub const COMMANDS: &[CommandItem] = &[
         description_en: "Switch to visual editor",
         description_ru: "Переключиться в визуальный редактор",
         category: CommandCategory::View,
-        hotkey: "",
+        hotkey: "Ctrl+2",
     },
     CommandItem {
         id: "switch_to_split",
@@ -88,14 +88,14 @@ pub const COMMANDS: &[CommandItem] = &[
         description_en: "Switch to split view",
         description_ru: "Переключиться в режим разделения",
         category: CommandCategory::View,
-        hotkey: "",
+        hotkey: "Ctrl+3",
     },
 ];
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::app::command_translations::command_name;
+    use crate::app::command_translations::{command_hotkey, command_name};
     use crate::app::Language;
 
     #[test]
@@ -117,5 +117,27 @@ mod tests {
         assert!(filtered.iter().any(|c| c.id == "switch_to_text_editor"));
         assert!(filtered.iter().any(|c| c.id == "switch_to_visual_editor"));
         assert!(filtered.iter().any(|c| c.id == "switch_to_split"));
+    }
+
+    #[test]
+    fn all_commands_have_hotkeys() {
+        assert!(COMMANDS.iter().all(|c| !c.hotkey.is_empty()));
+    }
+
+    #[test]
+    fn hotkeys_are_translated() {
+        let cmd = COMMANDS.iter().find(|c| c.id == "toggle_terminal").unwrap();
+        #[cfg(target_os = "macos")]
+        let prefix = "Cmd+";
+        #[cfg(not(target_os = "macos"))]
+        let prefix = "Ctrl+";
+        assert_eq!(
+            command_hotkey(cmd, Language::English),
+            format!("{}{}", prefix, "`")
+        );
+        assert_eq!(
+            command_hotkey(cmd, Language::Russian),
+            format!("{}Ё", prefix)
+        );
     }
 }

--- a/desktop/src/app/command_translations.rs
+++ b/desktop/src/app/command_translations.rs
@@ -14,3 +14,89 @@ pub fn command_description(cmd: &CommandItem, lang: Language) -> &'static str {
         _ => cmd.description_en,
     }
 }
+
+pub fn command_hotkey(cmd: &CommandItem, lang: Language) -> String {
+    format_hotkey(cmd.hotkey, lang)
+}
+
+fn format_hotkey(raw: &str, lang: Language) -> String {
+    raw.split('+')
+        .map(|part| translate_part(part, lang))
+        .collect::<Vec<_>>()
+        .join("+")
+}
+
+fn translate_part(part: &str, lang: Language) -> String {
+    match part {
+        "Ctrl" => ctrl_label(),
+        "Alt" => alt_label(),
+        "Shift" => "Shift".into(),
+        key => translate_key(key, lang),
+    }
+}
+
+fn ctrl_label() -> String {
+    #[cfg(target_os = "macos")]
+    {
+        "Cmd".into()
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        "Ctrl".into()
+    }
+}
+
+fn alt_label() -> String {
+    #[cfg(target_os = "macos")]
+    {
+        "Option".into()
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        "Alt".into()
+    }
+}
+
+fn translate_key(key: &str, lang: Language) -> String {
+    if lang != Language::Russian {
+        return key.to_string();
+    }
+    match key {
+        "`" => "Ё".into(),
+        "," => "Б".into(),
+        "." => "Ю".into(),
+        ";" => "Ж".into(),
+        "'" => "Э".into(),
+        "[" => "Х".into(),
+        "]" => "Ъ".into(),
+        _ => match key.to_ascii_uppercase().as_str() {
+            "Q" => "Й".into(),
+            "W" => "Ц".into(),
+            "E" => "У".into(),
+            "R" => "К".into(),
+            "T" => "Е".into(),
+            "Y" => "Н".into(),
+            "U" => "Г".into(),
+            "I" => "Ш".into(),
+            "O" => "Щ".into(),
+            "P" => "З".into(),
+            "A" => "Ф".into(),
+            "S" => "Ы".into(),
+            "D" => "В".into(),
+            "F" => "А".into(),
+            "G" => "П".into(),
+            "H" => "Р".into(),
+            "J" => "О".into(),
+            "K" => "Л".into(),
+            "L" => "Д".into(),
+            "Z" => "Я".into(),
+            "X" => "Ч".into(),
+            "C" => "С".into(),
+            "V" => "М".into(),
+            "B" => "И".into(),
+            "N" => "Т".into(),
+            "M" => "Ь".into(),
+            _ => key.to_string(),
+        },
+    }
+}


### PR DESCRIPTION
## Summary
- assign hotkeys to all command palette actions
- format hotkeys based on platform and keyboard layout
- show command hotkeys in the command palette UI with tests verifying them

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a9a8aa070c8323b14cd8480ecec1f7