### PR TITLE
Use translation functions for search panel

### DIFF
--- a/desktop/src/app/mod.rs
+++ b/desktop/src/app/mod.rs
@@ -4,6 +4,7 @@ pub mod diff;
 pub mod events;
 pub mod io;
 pub mod log_translations;
+pub mod search_translations;
 pub mod ui;
 
 mod actions;

--- a/desktop/src/app/search_translations.rs
+++ b/desktop/src/app/search_translations.rs
@@ -1,0 +1,67 @@
+use super::Language;
+
+#[derive(Debug, Clone, Copy)]
+pub enum SearchText {
+    FindPlaceholder,
+    FindButton,
+    ReplacePlaceholder,
+    ReplaceButton,
+    ReplaceAllButton,
+}
+
+pub fn search_text(key: SearchText, lang: Language) -> &'static str {
+    use Language::*;
+    match key {
+        SearchText::FindPlaceholder => match lang {
+            English => "find",
+            Russian => "найти",
+            _ => "find",
+        },
+        SearchText::FindButton => match lang {
+            English => "Find",
+            Russian => "Найти",
+            _ => "Find",
+        },
+        SearchText::ReplacePlaceholder => match lang {
+            English => "replace with",
+            Russian => "заменить на",
+            _ => "replace with",
+        },
+        SearchText::ReplaceButton => match lang {
+            English => "Replace",
+            Russian => "Заменить",
+            _ => "Replace",
+        },
+        SearchText::ReplaceAllButton => match lang {
+            English => "Replace All",
+            Russian => "Заменить все",
+            _ => "Replace All",
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{search_text, SearchText};
+    use crate::app::Language;
+
+    #[test]
+    fn search_text_is_translated() {
+        assert_eq!(
+            search_text(SearchText::FindButton, Language::English),
+            "Find"
+        );
+        assert_eq!(
+            search_text(SearchText::FindButton, Language::Russian),
+            "Найти"
+        );
+        assert_eq!(
+            search_text(SearchText::ReplaceAllButton, Language::English),
+            "Replace All"
+        );
+        assert_eq!(
+            search_text(SearchText::ReplaceAllButton, Language::Russian),
+            "Заменить все"
+        );
+    }
+}

--- a/desktop/src/app/ui.rs
+++ b/desktop/src/app/ui.rs
@@ -11,7 +11,9 @@ use crate::app::events::Message;
 use crate::app::{
     command_palette::COMMANDS,
     command_translations::{command_description, command_hotkey, command_name},
-    format_log, Language, LogLevel, MulticodeApp,
+    format_log,
+    search_translations::{search_text, SearchText},
+    Language, LogLevel, MulticodeApp,
 };
 use crate::modal::Modal;
 use crate::search::fuzzy;
@@ -32,13 +34,30 @@ impl MulticodeApp {
             return Space::with_height(Length::Shrink).into();
         }
         row![
-            text_input("найти", &self.search_term).on_input(Message::SearchTermChanged),
-            button("Найти").on_press(Message::Find),
+            text_input(
+                search_text(SearchText::FindPlaceholder, self.settings.language),
+                &self.search_term,
+            )
+            .on_input(Message::SearchTermChanged),
+            button(search_text(SearchText::FindButton, self.settings.language))
+                .on_press(Message::Find),
             button("←").on_press(Message::FindPrev),
             button("→").on_press(Message::FindNext),
-            text_input("заменить на", &self.replace_term).on_input(Message::ReplaceTermChanged),
-            button("Заменить").on_press(Message::Replace),
-            button("Заменить все").on_press(Message::ReplaceAll),
+            text_input(
+                search_text(SearchText::ReplacePlaceholder, self.settings.language),
+                &self.replace_term,
+            )
+            .on_input(Message::ReplaceTermChanged),
+            button(search_text(
+                SearchText::ReplaceButton,
+                self.settings.language
+            ))
+            .on_press(Message::Replace),
+            button(search_text(
+                SearchText::ReplaceAllButton,
+                self.settings.language
+            ))
+            .on_press(Message::ReplaceAll),
             button("×").on_press(Message::ToggleSearchPanel),
         ]
         .spacing(5)


### PR DESCRIPTION
## Summary
- replace hardcoded search/replace labels with language-aware translations
- add search translation module with tests

## Testing
- ⚠️ `cargo test -p desktop` *(timed out during compilation)*

------
https://chatgpt.com/codex/tasks/task_e_68a9d4f9aae48323826cde3792c9eff7