### PR TITLE
Support variable n-gram fuzzy search

### DIFF
--- a/desktop/src/app/ui.rs
+++ b/desktop/src/app/ui.rs
@@ -359,7 +359,8 @@ impl MulticodeApp {
                 let score = if self.query.is_empty() {
                     0.0
                 } else {
-                    fuzzy::similarity(&self.query, &name)
+                    let n = self.query.chars().count().min(3).max(1);
+                    fuzzy::similarity(&self.query, &name, n)
                 };
                 (cmd, name, desc, score)
             })


### PR DESCRIPTION
## Summary
- allow fuzzy search to compute similarity using 1-3 length n-grams
- handle short queries in command palette
- test single- and double-character fuzzy search

## Testing
- `cargo test -p desktop --lib fuzzy::tests`

------
https://chatgpt.com/codex/tasks/task_e_68aa1aa5df0083238bc81af748539490