### PR TITLE
Track recent command usage and limit command history

### DIFF
--- a/desktop/src/app/actions.rs
+++ b/desktop/src/app/actions.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 use std::path::PathBuf;
 
 use iced::futures::stream;
@@ -90,7 +90,8 @@ impl Application for MulticodeApp {
             show_block_palette: false,
             palette_query: String::new(),
             palette_drag: None,
-            recent_commands: Vec::new(),
+            recent_commands: VecDeque::new(),
+            command_counts: HashMap::new(),
         };
 
         let cmd = match &app.screen {

--- a/desktop/src/app/events/handler.rs
+++ b/desktop/src/app/events/handler.rs
@@ -1795,7 +1795,18 @@ impl MulticodeApp {
             }
             Message::ExecuteCommand(cmd) => {
                 self.show_command_palette = false;
-                self.recent_commands.push(cmd.clone());
+                self.recent_commands.push_back(cmd.clone());
+                *self.command_counts.entry(cmd.clone()).or_insert(0) += 1;
+                if self.recent_commands.len() > 50 {
+                    if let Some(old) = self.recent_commands.pop_front() {
+                        if let Some(count) = self.command_counts.get_mut(&old) {
+                            *count -= 1;
+                            if *count == 0 {
+                                self.command_counts.remove(&old);
+                            }
+                        }
+                    }
+                }
                 match cmd.as_str() {
                     "open_file" => return self.handle_message(Message::PickFile),
                     "save_file" => return self.handle_message(Message::SaveFile),

--- a/desktop/src/app/ui.rs
+++ b/desktop/src/app/ui.rs
@@ -21,7 +21,6 @@ use crate::visual::canvas::{CanvasMessage, VisualCanvas};
 use crate::visual::connections::Connection;
 use crate::visual::palette::{BlockPalette, PaletteMessage};
 use multicode_core::BlockInfo;
-use std::collections::HashMap;
 
 const OPEN_ICON: &[u8] = include_bytes!("../../assets/open.svg");
 const SAVE_ICON: &[u8] = include_bytes!("../../assets/save.svg");
@@ -347,10 +346,7 @@ impl MulticodeApp {
             "command"
         };
         let query_input = text_input(placeholder, &self.query).on_input(Message::QueryChanged);
-        let mut freq: HashMap<&str, usize> = HashMap::new();
-        for cmd in &self.recent_commands {
-            *freq.entry(cmd.as_str()).or_insert(0) += 1;
-        }
+        let freq = &self.command_counts;
         let mut items: Vec<_> = COMMANDS
             .iter()
             .map(|cmd| {
@@ -479,7 +475,7 @@ impl MulticodeApp {
 mod tests {
     use super::super::{CreateTarget, LogLevel, MulticodeApp, Screen, UserSettings, ViewMode};
     use crate::components::file_manager::ContextMenu;
-    use std::collections::HashSet;
+    use std::collections::{HashMap, HashSet, VecDeque};
     use std::path::PathBuf;
     use tokio::sync::broadcast;
 
@@ -550,7 +546,8 @@ mod tests {
             show_block_palette: false,
             palette_query: String::new(),
             palette_drag: None,
-            recent_commands: Vec::new(),
+            recent_commands: VecDeque::new(),
+            command_counts: HashMap::new(),
         }
     }
 


### PR DESCRIPTION
## Summary
- replace command history list with `VecDeque` and add command usage counters
- enforce 50-entry limit while updating counts
- use stored counts to rank commands in palette and expand tests

## Testing
- `cargo test -p desktop`


------
https://chatgpt.com/codex/tasks/task_e_68aa2e2a45d8832394f76b1b6cfc8e0f