### PR TITLE
Persist recent command history

### DIFF
--- a/desktop/src/app/actions.rs
+++ b/desktop/src/app/actions.rs
@@ -25,6 +25,12 @@ impl Application for MulticodeApp {
         let fav_files = settings.favorites.clone();
         let (palette, palette_categories) = load_palette();
 
+        let recent_commands: VecDeque<String> = settings.recent_commands.clone().into();
+        let mut command_counts: HashMap<String, usize> = HashMap::new();
+        for cmd in &recent_commands {
+            *command_counts.entry(cmd.clone()).or_insert(0) += 1;
+        }
+
         let view_mode = settings.last_view_mode;
         let screen = if let Some(path) = settings.last_folders.first().cloned() {
             match settings.editor_mode {
@@ -90,8 +96,8 @@ impl Application for MulticodeApp {
             show_block_palette: false,
             palette_query: String::new(),
             palette_drag: None,
-            recent_commands: VecDeque::new(),
-            command_counts: HashMap::new(),
+            recent_commands,
+            command_counts,
         };
 
         let cmd = match &app.screen {

--- a/desktop/src/app/events/handler.rs
+++ b/desktop/src/app/events/handler.rs
@@ -1807,25 +1807,28 @@ impl MulticodeApp {
                         }
                     }
                 }
-                match cmd.as_str() {
-                    "open_file" => return self.handle_message(Message::PickFile),
-                    "save_file" => return self.handle_message(Message::SaveFile),
-                    "toggle_terminal" => {
-                        return self.handle_message(Message::ToggleTerminal)
-                    }
-                    "goto_line" => return self.handle_message(Message::OpenGotoLine),
-                    "open_settings" => return self.handle_message(Message::OpenSettings),
+                self.settings.recent_commands =
+                    self.recent_commands.iter().cloned().collect();
+                let save_cmd =
+                    Command::perform(self.settings.clone().save(), |_| Message::SettingsSaved);
+                let action_cmd = match cmd.as_str() {
+                    "open_file" => self.handle_message(Message::PickFile),
+                    "save_file" => self.handle_message(Message::SaveFile),
+                    "toggle_terminal" => self.handle_message(Message::ToggleTerminal),
+                    "goto_line" => self.handle_message(Message::OpenGotoLine),
+                    "open_settings" => self.handle_message(Message::OpenSettings),
                     "switch_to_text_editor" => {
-                        return self.handle_message(Message::SwitchToTextEditor)
+                        self.handle_message(Message::SwitchToTextEditor)
                     }
                     "switch_to_visual_editor" => {
-                        return self.handle_message(Message::SwitchToVisualEditor)
+                        self.handle_message(Message::SwitchToVisualEditor)
                     }
                     "switch_to_split" => {
-                        return self.handle_message(Message::SwitchViewMode(ViewMode::Split))
+                        self.handle_message(Message::SwitchViewMode(ViewMode::Split))
                     }
                     _ => Command::none(),
-                }
+                };
+                Command::batch([save_cmd, action_cmd])
             }
             Message::ToggleDir(path) => {
                 self.selected_path = Some(path.clone());

--- a/desktop/src/app/state.rs
+++ b/desktop/src/app/state.rs
@@ -456,6 +456,8 @@ pub struct UserSettings {
     pub favorites: Vec<PathBuf>,
     #[serde(default)]
     pub block_favorites: Vec<String>,
+    #[serde(default)]
+    pub recent_commands: Vec<String>,
 }
 
 impl Default for UserSettings {
@@ -479,6 +481,7 @@ impl Default for UserSettings {
             show_markdown_preview: false,
             favorites: Vec::new(),
             block_favorites: Vec::new(),
+            recent_commands: Vec::new(),
         }
     }
 }
@@ -689,5 +692,21 @@ mod tests {
         assert_eq!(app.recent_commands.len(), 50);
         assert_eq!(app.command_counts.get("a"), Some(&45));
         assert_eq!(app.command_counts.get("b"), Some(&5));
+    }
+
+    #[test]
+    fn user_settings_serialization_roundtrip_preserves_recent_commands() {
+        let mut settings = UserSettings::default();
+        settings.recent_commands = vec!["cmd1".into(), "cmd2".into()];
+        let json = serde_json::to_string(&settings).unwrap();
+        let deserialized: UserSettings = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.recent_commands, settings.recent_commands);
+    }
+
+    #[test]
+    fn user_settings_deserialization_defaults_recent_commands() {
+        let json = "{}";
+        let settings: UserSettings = serde_json::from_str(json).unwrap();
+        assert!(settings.recent_commands.is_empty());
     }
 }


### PR DESCRIPTION
## Summary
- store recent command history in user settings
- load command history at startup
- save settings after executing a command
- test serialization and deserialization of recent command history

## Testing
- `cargo test -p desktop`

------
https://chatgpt.com/codex/tasks/task_e_68aa868181888323addcd93e77e42424