### PR TITLE
test: add frequency and fuzzy search tests

### DIFF
--- a/desktop/src/search/fuzzy.rs
+++ b/desktop/src/search/fuzzy.rs
@@ -121,4 +121,21 @@ mod tests {
         let direct = similarity(a, b, 3);
         assert!((cached - direct).abs() < f32::EPSILON);
     }
+
+    #[test]
+    fn search_one_char_matches_inside() {
+        let items = vec!["ba", "cb"];
+        let results = search("a", items.iter().map(|s| *s));
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].0, "ba");
+    }
+
+    #[test]
+    fn search_two_char_matches_inside() {
+        let items = vec!["xabc", "cab", "zz"];
+        let results = search("ab", items.iter().map(|s| *s));
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0].0, "cab");
+        assert_eq!(results[1].0, "xabc");
+    }
 }


### PR DESCRIPTION
## Summary
- simulate command executions and verify command palette frequency ordering
- add fuzzy search tests for short queries containing n-gram matches inside strings

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68aa966011448323ae7407ff60275257