### PR TITLE
feat: add block suggestions and tag search

### DIFF
--- a/desktop/src/app/ui.rs
+++ b/desktop/src/app/ui.rs
@@ -449,6 +449,7 @@ impl MulticodeApp {
             &self.palette_categories,
             &self.settings.block_favorites,
             &self.palette_query,
+            None,
             self.settings.language,
         )
         .view()
@@ -486,8 +487,8 @@ impl MulticodeApp {
 #[cfg(test)]
 mod tests {
     use super::super::{CreateTarget, LogLevel, MulticodeApp, Screen, UserSettings, ViewMode};
-    use crate::components::file_manager::ContextMenu;
     use crate::app::command_palette::COMMANDS;
+    use crate::components::file_manager::ContextMenu;
     use std::collections::{HashMap, HashSet, VecDeque};
     use std::path::PathBuf;
     use tokio::sync::broadcast;

--- a/desktop/src/visual/mod.rs
+++ b/desktop/src/visual/mod.rs
@@ -4,6 +4,7 @@ pub mod connection_draw;
 pub mod connections;
 pub mod palette;
 pub mod serialization;
+pub mod suggestions;
 pub mod translations;
 
 #[cfg(test)]

--- a/desktop/src/visual/suggestions.rs
+++ b/desktop/src/visual/suggestions.rs
@@ -1,0 +1,67 @@
+use super::palette::{PaletteBlock, DEFAULT_CATEGORY};
+
+/// Suggest block indices based on the selected block and categories.
+pub fn suggest_blocks(
+    blocks: &[PaletteBlock],
+    categories: &[(String, Vec<usize>)],
+    selected: Option<&str>,
+) -> Vec<usize> {
+    if let Some(kind) = selected {
+        for (_, indices) in categories.iter() {
+            if indices.iter().any(|&i| blocks[i].info.kind == kind) {
+                return indices
+                    .iter()
+                    .filter(|&&i| blocks[i].info.kind != kind)
+                    .copied()
+                    .collect();
+            }
+        }
+    }
+    categories
+        .iter()
+        .find(|(cat, _)| cat == DEFAULT_CATEGORY)
+        .or_else(|| categories.first())
+        .map(|(_, indices)| indices.clone())
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use multicode_core::BlockInfo;
+    use std::collections::HashMap;
+
+    fn make_block(kind: &str) -> PaletteBlock {
+        let mut translations = HashMap::new();
+        translations.insert("en".to_string(), kind.to_string());
+        PaletteBlock::new(BlockInfo {
+            visual_id: String::new(),
+            node_id: None,
+            kind: kind.to_string(),
+            translations,
+            range: (0, 0),
+            anchors: vec![],
+            x: 0.0,
+            y: 0.0,
+            ports: vec![],
+            ai: None,
+            tags: vec![],
+            links: vec![],
+        })
+    }
+
+    #[test]
+    fn suggests_from_same_category_excluding_selected() {
+        let blocks = vec![
+            make_block("Add"),
+            make_block("Subtract"),
+            make_block("Loop"),
+        ];
+        let categories = vec![
+            ("Arithmetic".to_string(), vec![0, 1]),
+            ("Loops".to_string(), vec![2]),
+        ];
+        let res = suggest_blocks(&blocks, &categories, Some("Add"));
+        assert_eq!(res, vec![1]);
+    }
+}

--- a/desktop/src/visual/translations.rs
+++ b/desktop/src/visual/translations.rs
@@ -161,3 +161,16 @@ pub fn translate_kind(kind: &str, lang: Language) -> Option<&'static str> {
     };
     translate(bt, lang)
 }
+
+pub const BLOCK_SYNONYMS: &[(&str, &[&str])] = &[
+    ("Add", &["plus", "sum", "сложить", "прибавить"]),
+    ("Subtract", &["minus", "difference", "вычесть", "минус"]),
+    ("Loop", &["repeat", "повтор", "цикл"]),
+];
+
+pub fn block_synonyms(kind: &str) -> Option<&'static [&'static str]> {
+    BLOCK_SYNONYMS
+        .iter()
+        .find(|(k, _)| *k == kind)
+        .map(|(_, v)| *v)
+}


### PR DESCRIPTION
## Summary
- extend palette blocks with tags and synonyms-aware filtering
- add suggestion system to propose related blocks based on selection
- display suggestions separately in palette UI and cover with tests

## Testing
- `cargo test -p desktop --quiet` *(fails: command timed out, partial build)*

------
https://chatgpt.com/codex/tasks/task_e_68aa9afe3e5483239bc89b810093828e