### PR TITLE
Limit palette suggestions

### DIFF
--- a/desktop/src/visual/palette.rs
+++ b/desktop/src/visual/palette.rs
@@ -3,7 +3,7 @@ use iced::{theme, Color, Element, Length};
 use multicode_core::BlockInfo;
 
 use super::{
-    suggestions::suggest_blocks,
+    suggestions::{suggest_blocks, SUGGESTION_LIMIT},
     translations::{block_synonyms, Language},
 };
 use std::collections::HashSet;
@@ -118,7 +118,8 @@ impl<'a> BlockPalette<'a> {
         let q = self.query.trim().to_lowercase();
         let tokens: Vec<_> = q.split_whitespace().collect();
 
-        let mut suggestions = suggest_blocks(self.blocks, self.categories, self.selected);
+        let mut suggestions =
+            suggest_blocks(self.blocks, self.categories, self.selected, SUGGESTION_LIMIT);
         if !tokens.is_empty() {
             suggestions.retain(|&i| matches_block(&self.blocks[i], &tokens));
         }


### PR DESCRIPTION
## Summary
- limit palette suggestions with a configurable constant
- ensure `suggest_blocks` respects the limit
- add test for limit handling

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68aacf5bc32483238212b7160305283b