### PR TITLE
feat: add context-aware hotkey manager

### DIFF
--- a/desktop/src/app/actions.rs
+++ b/desktop/src/app/actions.rs
@@ -87,7 +87,6 @@ impl Application for MulticodeApp {
             show_create_file_confirm: false,
             show_delete_confirm: false,
             pending_action: None,
-            hotkey_capture: None,
             shortcut_capture: None,
             settings_warning: None,
             loading: false,

--- a/desktop/src/app/events/message.rs
+++ b/desktop/src/app/events/message.rs
@@ -2,9 +2,7 @@ use iced::{widget::text_editor, Event};
 use std::path::PathBuf;
 
 use crate::app::diff::DiffView;
-use crate::app::{
-    AppTheme, CreateTarget, Diagnostic, FileEntry, HotkeyField, Language, LogLevel, ViewMode,
-};
+use crate::app::{AppTheme, CreateTarget, Diagnostic, FileEntry, Language, LogLevel, ViewMode};
 use crate::editor::EditorTheme;
 use crate::visual::canvas::CanvasMessage;
 use crate::visual::palette::PaletteMessage;
@@ -115,7 +113,6 @@ pub enum Message {
     MetaLinksChanged(String),
     MetaCommentChanged(String),
     SaveMeta,
-    StartCaptureHotkey(HotkeyField),
     StartCaptureShortcut(String),
     SwitchToTextEditor,
     SwitchToVisualEditor,

--- a/desktop/src/app/mod.rs
+++ b/desktop/src/app/mod.rs
@@ -14,9 +14,8 @@ mod view;
 pub use crate::visual::translations::Language;
 pub use log_translations::{format_log, LogMessage};
 pub use state::{
-    AppTheme, CreateTarget, Diagnostic, EditorMode, EntryType, FileEntry, Hotkey, HotkeyField,
-    Hotkeys, LogEntry, LogLevel, MulticodeApp, PendingAction, Screen, Tab, TabDragState,
-    UserSettings, ViewMode,
+    AppTheme, CreateTarget, Diagnostic, EditorMode, EntryType, FileEntry, LogEntry, LogLevel,
+    MulticodeApp, PendingAction, Screen, Tab, TabDragState, UserSettings, ViewMode,
 };
 
 use iced::Application;

--- a/desktop/src/app/ui.rs
+++ b/desktop/src/app/ui.rs
@@ -15,6 +15,7 @@ use crate::app::{
     search_translations::{search_text, SearchText},
     Language, LogLevel, MulticodeApp,
 };
+use crate::search::hotkeys::HotkeyContext;
 use crate::modal::Modal;
 use crate::search::fuzzy;
 use crate::visual::canvas::{CanvasMessage, VisualCanvas};
@@ -467,8 +468,8 @@ impl MulticodeApp {
                     String::from("...")
                 } else {
                     self.settings
-                        .shortcuts
-                        .get(cmd.id)
+                        .hotkeys
+                        .binding(HotkeyContext::Global, cmd.id)
                         .map(|h| h.to_string())
                         .unwrap_or_else(|| String::from("-"))
                 };
@@ -543,7 +544,6 @@ mod tests {
             show_create_file_confirm: false,
             show_delete_confirm: false,
             pending_action: None,
-            hotkey_capture: None,
             shortcut_capture: None,
             settings_warning: None,
             loading: false,

--- a/desktop/src/app/view.rs
+++ b/desktop/src/app/view.rs
@@ -9,7 +9,8 @@ use iced::widget::{
 use iced::{alignment, theme, Element, Length};
 
 use super::events::Message;
-use super::{AppTheme, CreateTarget, HotkeyField, Language, MulticodeApp, Screen, ViewMode};
+use super::{AppTheme, CreateTarget, Language, MulticodeApp, Screen, ViewMode};
+use crate::search::hotkeys::HotkeyContext;
 use crate::editor::{CodeEditor, EditorTheme, THEME_SET};
 use crate::components::file_manager;
 
@@ -397,35 +398,53 @@ impl MulticodeApp {
             }
             Screen::Settings => {
                 let hotkeys = &self.settings.hotkeys;
-                let create_label = if self.hotkey_capture == Some(HotkeyField::CreateFile) {
+                let create_label = if self.shortcut_capture.as_deref() == Some("create_file") {
                     String::from("...")
                 } else {
-                    hotkeys.create_file.to_string()
+                    hotkeys
+                        .binding(HotkeyContext::Global, "create_file")
+                        .map(|h| h.to_string())
+                        .unwrap_or_else(|| "-".into())
                 };
-                let save_label = if self.hotkey_capture == Some(HotkeyField::SaveFile) {
+                let save_label = if self.shortcut_capture.as_deref() == Some("save_file") {
                     String::from("...")
                 } else {
-                    hotkeys.save_file.to_string()
+                    hotkeys
+                        .binding(HotkeyContext::Global, "save_file")
+                        .map(|h| h.to_string())
+                        .unwrap_or_else(|| "-".into())
                 };
-                let rename_label = if self.hotkey_capture == Some(HotkeyField::RenameFile) {
+                let rename_label = if self.shortcut_capture.as_deref() == Some("rename_file") {
                     String::from("...")
                 } else {
-                    hotkeys.rename_file.to_string()
+                    hotkeys
+                        .binding(HotkeyContext::Global, "rename_file")
+                        .map(|h| h.to_string())
+                        .unwrap_or_else(|| "-".into())
                 };
-                let delete_label = if self.hotkey_capture == Some(HotkeyField::DeleteFile) {
+                let delete_label = if self.shortcut_capture.as_deref() == Some("delete_file") {
                     String::from("...")
                 } else {
-                    hotkeys.delete_file.to_string()
+                    hotkeys
+                        .binding(HotkeyContext::Global, "delete_file")
+                        .map(|h| h.to_string())
+                        .unwrap_or_else(|| "-".into())
                 };
-                let next_diff_label = if self.hotkey_capture == Some(HotkeyField::NextDiff) {
+                let next_diff_label = if self.shortcut_capture.as_deref() == Some("next_diff") {
                     String::from("...")
                 } else {
-                    hotkeys.next_diff.to_string()
+                    hotkeys
+                        .binding(HotkeyContext::Diff, "next_diff")
+                        .map(|h| h.to_string())
+                        .unwrap_or_else(|| "-".into())
                 };
-                let prev_diff_label = if self.hotkey_capture == Some(HotkeyField::PrevDiff) {
+                let prev_diff_label = if self.shortcut_capture.as_deref() == Some("prev_diff") {
                     String::from("...")
                 } else {
-                    hotkeys.prev_diff.to_string()
+                    hotkeys
+                        .binding(HotkeyContext::Diff, "prev_diff")
+                        .map(|h| h.to_string())
+                        .unwrap_or_else(|| "-".into())
                 };
                 let syntect_themes: Vec<String> = THEME_SET.themes.keys().cloned().collect();
                 let warning: Element<_> = if let Some(w) = &self.settings_warning {
@@ -535,37 +554,37 @@ impl MulticodeApp {
                     row![
                         text("Создать файл"),
                         button(text(create_label))
-                            .on_press(Message::StartCaptureHotkey(HotkeyField::CreateFile))
+                            .on_press(Message::StartCaptureShortcut("create_file".into()))
                     ]
                     .spacing(10),
                     row![
                         text("Сохранить файл"),
                         button(text(save_label))
-                            .on_press(Message::StartCaptureHotkey(HotkeyField::SaveFile))
+                            .on_press(Message::StartCaptureShortcut("save_file".into()))
                     ]
                     .spacing(10),
                     row![
                         text("Переименовать файл"),
                         button(text(rename_label))
-                            .on_press(Message::StartCaptureHotkey(HotkeyField::RenameFile))
+                            .on_press(Message::StartCaptureShortcut("rename_file".into()))
                     ]
                     .spacing(10),
                     row![
                         text("Удалить файл"),
                         button(text(delete_label))
-                            .on_press(Message::StartCaptureHotkey(HotkeyField::DeleteFile))
+                            .on_press(Message::StartCaptureShortcut("delete_file".into()))
                     ]
                     .spacing(10),
                     row![
                         text("Следующее отличие"),
                         button(text(next_diff_label))
-                            .on_press(Message::StartCaptureHotkey(HotkeyField::NextDiff))
+                            .on_press(Message::StartCaptureShortcut("next_diff".into()))
                     ]
                     .spacing(10),
                     row![
                         text("Предыдущее отличие"),
                         button(text(prev_diff_label))
-                            .on_press(Message::StartCaptureHotkey(HotkeyField::PrevDiff))
+                            .on_press(Message::StartCaptureShortcut("prev_diff".into()))
                     ]
                     .spacing(10),
                     self.shortcuts_settings_component(),

--- a/desktop/src/search/hotkeys.rs
+++ b/desktop/src/search/hotkeys.rs
@@ -1,0 +1,232 @@
+use iced::keyboard::{Key, Modifiers};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::fmt;
+
+/// Keyboard key combination with modifiers
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct KeyCombination {
+    pub key: String,
+    pub ctrl: bool,
+    pub alt: bool,
+    pub shift: bool,
+}
+
+impl KeyCombination {
+    /// Build combination from an iced [`Key`] and [`Modifiers`]
+    pub fn from_event(key: &Key, modifiers: Modifiers) -> Option<Self> {
+        let key_str = match key {
+            Key::Character(c) => c.to_uppercase(),
+            Key::Named(named) => format!("{:?}", named),
+            _ => return None,
+        };
+        Some(Self {
+            key: key_str,
+            ctrl: modifiers.control(),
+            alt: modifiers.alt(),
+            shift: modifiers.shift(),
+        })
+    }
+
+    /// Parse string like "Ctrl+S" into a combination
+    pub fn parse(s: &str) -> Option<Self> {
+        let mut ctrl = false;
+        let mut alt = false;
+        let mut shift = false;
+        let mut key = None;
+        for part in s.split('+') {
+            let p = part.trim();
+            match p.to_lowercase().as_str() {
+                "ctrl" | "cmd" => ctrl = true,
+                "alt" => alt = true,
+                "shift" => shift = true,
+                other => key = Some(other.to_uppercase()),
+            }
+        }
+        key.map(|k| Self {
+            key: k,
+            ctrl,
+            alt,
+            shift,
+        })
+    }
+
+    /// Check if given key/modifiers match this combination
+    pub fn matches(&self, key: &Key, modifiers: Modifiers) -> bool {
+        self.ctrl == modifiers.control()
+            && self.alt == modifiers.alt()
+            && self.shift == modifiers.shift()
+            && match key {
+                Key::Character(c) => c.eq_ignore_ascii_case(&self.key),
+                Key::Named(named) => self.key.eq_ignore_ascii_case(&format!("{:?}", named)),
+                _ => false,
+            }
+    }
+}
+
+impl fmt::Display for KeyCombination {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut parts = Vec::new();
+        if self.ctrl {
+            parts.push("Ctrl".to_string());
+        }
+        if self.alt {
+            parts.push("Alt".to_string());
+        }
+        if self.shift {
+            parts.push("Shift".to_string());
+        }
+        parts.push(self.key.clone());
+        write!(f, "{}", parts.join("+"))
+    }
+}
+
+/// Context in which hotkeys operate
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum HotkeyContext {
+    Global,
+    Diff,
+}
+
+/// Manager storing bindings between commands and key combinations
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HotkeyManager {
+    #[serde(default)]
+    pub global: HashMap<String, KeyCombination>,
+    #[serde(default)]
+    pub contexts: HashMap<HotkeyContext, HashMap<String, KeyCombination>>,
+}
+
+impl HotkeyManager {
+    pub fn bind(&mut self, ctx: HotkeyContext, id: String, combo: KeyCombination) {
+        match ctx {
+            HotkeyContext::Global => {
+                self.global.insert(id, combo);
+            }
+            _ => {
+                self.contexts.entry(ctx).or_default().insert(id, combo);
+            }
+        }
+    }
+
+    pub fn binding(&self, ctx: HotkeyContext, id: &str) -> Option<&KeyCombination> {
+        match ctx {
+            HotkeyContext::Global => self.global.get(id),
+            _ => self.contexts.get(&ctx).and_then(|m| m.get(id)),
+        }
+    }
+
+    /// Resolve a command id for given key and context
+    pub fn get_command(
+        &self,
+        ctx: HotkeyContext,
+        key: &Key,
+        modifiers: Modifiers,
+    ) -> Option<&str> {
+        if let Some(map) = self.contexts.get(&ctx) {
+            for (id, combo) in map {
+                if combo.matches(key, modifiers) {
+                    return Some(id.as_str());
+                }
+            }
+        }
+        for (id, combo) in &self.global {
+            if combo.matches(key, modifiers) {
+                return Some(id.as_str());
+            }
+        }
+        None
+    }
+
+    /// Return all bindings as strings for uniqueness checks
+    pub fn all_bindings(&self) -> Vec<String> {
+        let mut list = Vec::new();
+        list.extend(self.global.values().map(|c| c.to_string()));
+        for m in self.contexts.values() {
+            list.extend(m.values().map(|c| c.to_string()));
+        }
+        list
+    }
+}
+
+impl Default for HotkeyManager {
+    fn default() -> Self {
+        use crate::app::command_palette::COMMANDS;
+        let mut hm = Self {
+            global: HashMap::new(),
+            contexts: HashMap::new(),
+        };
+        // Built-in defaults
+        hm.bind(
+            HotkeyContext::Global,
+            "create_file".into(),
+            KeyCombination::parse("Ctrl+N").unwrap(),
+        );
+        hm.bind(
+            HotkeyContext::Global,
+            "save_file".into(),
+            KeyCombination::parse("Ctrl+S").unwrap(),
+        );
+        hm.bind(
+            HotkeyContext::Global,
+            "rename_file".into(),
+            KeyCombination::parse("F2").unwrap(),
+        );
+        hm.bind(
+            HotkeyContext::Global,
+            "delete_file".into(),
+            KeyCombination::parse("Delete").unwrap(),
+        );
+        hm.bind(
+            HotkeyContext::Diff,
+            "next_diff".into(),
+            KeyCombination::parse("F8").unwrap(),
+        );
+        hm.bind(
+            HotkeyContext::Diff,
+            "prev_diff".into(),
+            KeyCombination::parse("F7").unwrap(),
+        );
+        hm.bind(
+            HotkeyContext::Global,
+            "toggle_command_palette".into(),
+            KeyCombination::parse("Ctrl+Shift+P").unwrap(),
+        );
+        // Commands from command palette
+        for cmd in COMMANDS {
+            if let Some(combo) = KeyCombination::parse(cmd.hotkey) {
+                hm.bind(HotkeyContext::Global, cmd.id.to_string(), combo);
+            }
+        }
+        hm
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn matches_in_contexts() {
+        let mut mgr = HotkeyManager::default();
+        mgr.bind(
+            HotkeyContext::Diff,
+            "special".into(),
+            KeyCombination::parse("Ctrl+N").unwrap(),
+        );
+        let key_s = Key::Character("S".into());
+        assert_eq!(
+            mgr.get_command(HotkeyContext::Global, &key_s, Modifiers::CTRL),
+            Some("save_file"),
+        );
+        let key_n = Key::Character("N".into());
+        assert_eq!(
+            mgr.get_command(HotkeyContext::Diff, &key_n, Modifiers::CTRL),
+            Some("special"),
+        );
+        assert_eq!(
+            mgr.get_command(HotkeyContext::Global, &key_n, Modifiers::CTRL),
+            Some("create_file"),
+        );
+    }
+}

--- a/desktop/src/search/mod.rs
+++ b/desktop/src/search/mod.rs
@@ -1,1 +1,2 @@
 pub mod fuzzy;
+pub mod hotkeys;


### PR DESCRIPTION
## Summary
- introduce KeyCombination and HotkeyManager with context maps
- use HotkeyManager in app state and event handling
- persist user hotkey bindings

## Testing
- `cargo test -p desktop`

------
https://chatgpt.com/codex/tasks/task_e_68aaee43a8008323b183464eb0cecc71