### PR TITLE
Add hotkey unbinding capability

### DIFF
--- a/desktop/src/app/events/handler.rs
+++ b/desktop/src/app/events/handler.rs
@@ -126,16 +126,26 @@ impl MulticodeApp {
                     }
                 }
                 if let Some(id) = self.shortcut_capture.take() {
-                    if let Some(hk) = KeyCombination::from_event(&key, modifiers) {
-                        let ctx = match id.as_str() {
-                            "next_diff" | "prev_diff" => HotkeyContext::Diff,
-                            _ => HotkeyContext::Global,
-                        };
-                        if !self.settings.hotkeys.bind(ctx, id, hk) {
-                            self.settings_warning =
-                                Some("Сочетания клавиш должны быть уникальными".into());
-                        } else {
+                    let ctx = match id.as_str() {
+                        "next_diff" | "prev_diff" => HotkeyContext::Diff,
+                        _ => HotkeyContext::Global,
+                    };
+                    match key {
+                        keyboard::Key::Named(keyboard::key::Named::Backspace)
+                            if !modifiers.control() && !modifiers.alt() && !modifiers.shift() =>
+                        {
+                            self.settings.hotkeys.unbind(ctx, &id);
                             self.settings_warning = None;
+                        }
+                        _ => {
+                            if let Some(hk) = KeyCombination::from_event(&key, modifiers) {
+                                if !self.settings.hotkeys.bind(ctx, id, hk) {
+                                    self.settings_warning =
+                                        Some("Сочетания клавиш должны быть уникальными".into());
+                                } else {
+                                    self.settings_warning = None;
+                                }
+                            }
                         }
                     }
                     return Command::none();


### PR DESCRIPTION
## Summary
- allow removing key bindings via `HotkeyManager::unbind`
- clear captured shortcuts with Backspace in settings
- test unbinding logic for HotkeyManager

## Testing
- `cargo test -p desktop`
- `cargo test -p desktop unbind_removes_binding`
- `cargo test -p desktop unbinding_frees_combination`


------
https://chatgpt.com/codex/tasks/task_e_68ab05395efc8323afbaa76c1adf80aa