### PR TITLE
Add hotkey contexts for editor and settings screens

### DIFF
--- a/desktop/src/app/state.rs
+++ b/desktop/src/app/state.rs
@@ -477,6 +477,9 @@ impl MulticodeApp {
     pub fn hotkey_context(&self) -> HotkeyContext {
         match self.screen {
             Screen::Diff(_) => HotkeyContext::Diff,
+            Screen::TextEditor { .. } => HotkeyContext::TextEditor,
+            Screen::VisualEditor { .. } | Screen::Split { .. } => HotkeyContext::VisualEditor,
+            Screen::Settings => HotkeyContext::Settings,
             _ => HotkeyContext::Global,
         }
     }
@@ -650,4 +653,21 @@ mod tests {
             Some(&diff_combo)
         );
     }
+
+#[test]
+fn hotkey_context_per_screen() {
+    use crate::app::diff::DiffView;
+    let mut app = build_app();
+    assert_eq!(app.hotkey_context(), HotkeyContext::Global);
+    app.screen = Screen::TextEditor { root: std::path::PathBuf::new() };
+    assert_eq!(app.hotkey_context(), HotkeyContext::TextEditor);
+    app.screen = Screen::VisualEditor { root: std::path::PathBuf::new() };
+    assert_eq!(app.hotkey_context(), HotkeyContext::VisualEditor);
+    app.screen = Screen::Split { root: std::path::PathBuf::new() };
+    assert_eq!(app.hotkey_context(), HotkeyContext::VisualEditor);
+    app.screen = Screen::Settings;
+    assert_eq!(app.hotkey_context(), HotkeyContext::Settings);
+    app.screen = Screen::Diff(DiffView::new(String::new(), String::new(), false));
+    assert_eq!(app.hotkey_context(), HotkeyContext::Diff);
+}
 }

--- a/desktop/src/search/hotkeys.rs
+++ b/desktop/src/search/hotkeys.rs
@@ -91,6 +91,9 @@ impl fmt::Display for KeyCombination {
 pub enum HotkeyContext {
     Global,
     Diff,
+    TextEditor,
+    VisualEditor,
+    Settings,
 }
 
 /// Manager storing bindings between commands and key combinations
@@ -222,6 +225,21 @@ impl Default for HotkeyManager {
             "toggle_command_palette".into(),
             KeyCombination::parse("Ctrl+Shift+P").unwrap(),
         );
+        hm.bind(
+            HotkeyContext::TextEditor,
+            "text_editor_special".into(),
+            KeyCombination::parse("Ctrl+Alt+T").unwrap(),
+        );
+        hm.bind(
+            HotkeyContext::VisualEditor,
+            "visual_editor_special".into(),
+            KeyCombination::parse("Ctrl+Alt+V").unwrap(),
+        );
+        hm.bind(
+            HotkeyContext::Settings,
+            "settings_special".into(),
+            KeyCombination::parse("Ctrl+Alt+S").unwrap(),
+        );
         // Commands from command palette
         for cmd in COMMANDS {
             if let Some(combo) = KeyCombination::parse(cmd.hotkey) {
@@ -261,6 +279,32 @@ mod tests {
                 Modifiers::CTRL | Modifiers::ALT
             ),
             Some("special"),
+        );
+        let key_t = Key::Character("T".into());
+        assert_eq!(
+            mgr.get_command(
+                HotkeyContext::TextEditor,
+                &key_t,
+                Modifiers::CTRL | Modifiers::ALT
+            ),
+            Some("text_editor_special"),
+        );
+        let key_v = Key::Character("V".into());
+        assert_eq!(
+            mgr.get_command(
+                HotkeyContext::VisualEditor,
+                &key_v,
+                Modifiers::CTRL | Modifiers::ALT
+            ),
+            Some("visual_editor_special"),
+        );
+        assert_eq!(
+            mgr.get_command(
+                HotkeyContext::Settings,
+                &key_s,
+                Modifiers::CTRL | Modifiers::ALT
+            ),
+            Some("settings_special"),
         );
     }
 


### PR DESCRIPTION
## Summary
- extend hotkey contexts with text editor, visual editor, and settings variants
- map `MulticodeApp` screens to new hotkey contexts
- add default bindings and tests for context-specific hotkeys

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68ab14a5459883239ebbb32cc724aa18