### PR TITLE
Rebuild search index when settings change

### DIFF
--- a/desktop/src/app/events/handler.rs
+++ b/desktop/src/app/events/handler.rs
@@ -292,6 +292,12 @@ impl MulticodeApp {
             }
             Message::LanguageSelected(lang) => {
                 self.settings.language = lang;
+                self.rebuild_search_indices();
+                Command::none()
+            }
+            Message::ToggleSearchIndex(val) => {
+                self.settings.search.use_index = val;
+                self.rebuild_search_indices();
                 Command::none()
             }
             Message::FontSizeChanged(value) => {

--- a/desktop/src/app/events/message.rs
+++ b/desktop/src/app/events/message.rs
@@ -96,6 +96,7 @@ pub enum Message {
     ThemeSelected(AppTheme),
     SyntectThemeSelected(String),
     LanguageSelected(Language),
+    ToggleSearchIndex(bool),
     FontSizeChanged(String),
     TabWidthChanged(String),
     ToggleAutoIndent(bool),

--- a/desktop/src/app/view.rs
+++ b/desktop/src/app/view.rs
@@ -482,6 +482,12 @@ impl MulticodeApp {
                     ]
                     .spacing(10),
                     row![
+                        text("Индекс поиска"),
+                        checkbox("", self.settings.search.use_index)
+                            .on_toggle(Message::ToggleSearchIndex)
+                    ]
+                    .spacing(10),
+                    row![
                         text("Номера строк"),
                         checkbox("", self.settings.show_line_numbers)
                             .on_toggle(Message::ToggleLineNumbers)


### PR DESCRIPTION
## Summary
- rebuild command and block search indexes and clear caches
- call rebuilding when language or search indexing setting change
- add checkbox for search index in settings UI

## Testing
- `cargo test -p desktop`

------
https://chatgpt.com/codex/tasks/task_e_68ab2630fb7c8323a3002bde83ac2fb1