### PR TITLE
Refactor search index building and lowercase handling

### DIFF
--- a/desktop/src/search/index.rs
+++ b/desktop/src/search/index.rs
@@ -16,9 +16,11 @@ impl<ID: Eq + Hash + Clone> SearchIndex<ID> {
     }
 
     /// Insert identifier for given keyword.
+    ///
+    /// The keyword is expected to be already in lowercase to avoid
+    /// repeated allocation and conversions.
     pub fn insert(&mut self, keyword: &str, id: ID) {
-        let key = keyword.to_lowercase();
-        let ids = self.map.entry(key).or_default();
+        let ids = self.map.entry(keyword.to_string()).or_default();
         if !ids.contains(&id) {
             ids.push(id);
         }


### PR DESCRIPTION
## Summary
- extract `build_command_index` and `build_block_index` to centralize index construction
- reuse index builders in state management
- avoid redundant lowercase conversions by expecting lowercase in `SearchIndex::insert`

## Testing
- `cargo test -p desktop`


------
https://chatgpt.com/codex/tasks/task_e_68ab36e555548323b4cf0b3982d9def8