### PR TITLE
feat: add search benchmarks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,6 +104,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -817,6 +823,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -885,6 +897,33 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -1380,6 +1419,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1583,6 +1658,7 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "core",
+ "criterion",
  "directories",
  "iced",
  "lru",
@@ -3436,10 +3512,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -4573,6 +4669,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4951,6 +5053,34 @@ dependencies = [
  "quick-xml 0.38.2",
  "serde",
  "time",
+]
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
 ]
 
 [[package]]
@@ -7107,6 +7237,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8245,7 +8385,7 @@ dependencies = [
  "cranelift-frontend",
  "cranelift-native",
  "gimli",
- "itertools",
+ "itertools 0.14.0",
  "log",
  "object",
  "pulley-interpreter",

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -23,3 +23,8 @@ lru = "0.12"
 
 [dev-dependencies]
 tempfile = "3"
+criterion = "0.5"
+
+[[bench]]
+name = "search"
+harness = false

--- a/desktop/benches/search.rs
+++ b/desktop/benches/search.rs
@@ -1,0 +1,37 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use desktop::search::index::SearchIndex;
+
+fn naive(items: &[(usize, String)], q: &str) -> Vec<usize> {
+    items
+        .iter()
+        .filter_map(|(id, kw)| if kw == q { Some(*id) } else { None })
+        .collect()
+}
+
+fn bench_search(c: &mut Criterion) {
+    let mut idx = SearchIndex::new();
+    let mut items = Vec::new();
+    for i in 0..1000 {
+        let kw = format!("cmd{}", i);
+        idx.insert(&kw, i);
+        items.push((i, kw));
+    }
+    let query = "cmd900";
+
+    c.bench_function("naive search", |b| {
+        b.iter(|| {
+            let r = naive(&items, query);
+            assert_eq!(r, vec![900]);
+        })
+    });
+
+    c.bench_function("indexed search", |b| {
+        b.iter(|| {
+            let r = idx.search(query);
+            assert_eq!(r, vec![900]);
+        })
+    });
+}
+
+criterion_group!(benches, bench_search);
+criterion_main!(benches);

--- a/desktop/tests/search_index.rs
+++ b/desktop/tests/search_index.rs
@@ -1,35 +1,15 @@
 use desktop::search::index::SearchIndex;
-use std::time::Instant;
 
-fn naive(items: &[(usize, String)], q: &str) -> Vec<usize> {
-    items
-        .iter()
-        .filter_map(|(id, kw)| if kw == q { Some(*id) } else { None })
-        .collect()
+#[test]
+fn search_finds_existing_item() {
+    let mut idx = SearchIndex::new();
+    idx.insert("cmd900", 900);
+    assert_eq!(idx.search("cmd900"), vec![900]);
 }
 
 #[test]
-fn compare_search_speed() {
+fn search_returns_empty_for_missing_item() {
     let mut idx = SearchIndex::new();
-    let mut items = Vec::new();
-    for i in 0..1000 {
-        let kw = format!("cmd{}", i);
-        idx.insert(&kw, i);
-        items.push((i, kw));
-    }
-    let query = "cmd900";
-    let start = Instant::now();
-    for _ in 0..1000 {
-        let r = naive(&items, query);
-        assert_eq!(r, vec![900]);
-    }
-    let naive_time = start.elapsed();
-
-    let start = Instant::now();
-    for _ in 0..1000 {
-        let r = idx.search(query);
-        assert_eq!(r, vec![900]);
-    }
-    let indexed_time = start.elapsed();
-    println!("naive: {:?}, indexed: {:?}", naive_time, indexed_time);
+    idx.insert("cmd900", 900);
+    assert!(idx.search("unknown").is_empty());
 }


### PR DESCRIPTION
## Summary
- add criterion benchmark comparing naive and indexed search
- trim search tests to correctness checks
- wire up bench target in Cargo

## Testing
- `cargo test`
- `cargo bench -p desktop --no-run --profile dev`


------
https://chatgpt.com/codex/tasks/task_e_68ab46b8c7c88323a6b4c628021679f8