### PR TITLE
Add tests for sync engine messaging

### DIFF
--- a/desktop/src/sync/engine_tests.rs
+++ b/desktop/src/sync/engine_tests.rs
@@ -1,0 +1,61 @@
+use super::{SyncEngine, SyncMessage};
+use multicode_core::meta::{self, VisualMeta, DEFAULT_VERSION};
+use chrono::Utc;
+use std::collections::HashMap;
+
+fn make_meta(id: &str, version: u32) -> VisualMeta {
+    VisualMeta {
+        version,
+        id: id.to_string(),
+        x: 1.0,
+        y: 2.0,
+        tags: Vec::new(),
+        links: Vec::new(),
+        anchors: Vec::new(),
+        tests: Vec::new(),
+        extends: None,
+        origin: None,
+        translations: HashMap::new(),
+        ai: None,
+        extras: None,
+        updated_at: Utc::now(),
+    }
+}
+
+#[test]
+fn text_changed_updates_state_metas() {
+    let mut engine = SyncEngine::new();
+    let meta = make_meta("test", DEFAULT_VERSION);
+    let code = meta::upsert("", &meta);
+    engine.handle(SyncMessage::TextChanged(code));
+    assert_eq!(engine.state().metas.len(), 1);
+    assert_eq!(engine.state().metas[0].id, "test");
+}
+
+#[test]
+fn visual_changed_updates_state_code() {
+    let mut engine = SyncEngine::new();
+    engine.handle(SyncMessage::TextChanged(String::new()));
+    let meta = make_meta("block", DEFAULT_VERSION);
+    let result = engine
+        .handle(SyncMessage::VisualChanged(meta.clone()))
+        .unwrap();
+    assert!(result.contains("@VISUAL_META"));
+    assert!(result.contains("\"id\":\"block\""));
+    assert_eq!(result, engine.state().code);
+    assert_eq!(engine.state().metas.len(), 1);
+    assert_eq!(engine.state().metas[0].id, "block");
+}
+
+#[test]
+fn visual_changed_zeros_version_defaults_to_constant() {
+    let mut engine = SyncEngine::new();
+    engine.handle(SyncMessage::TextChanged(String::new()));
+    let meta = make_meta("zero", 0);
+    engine.handle(SyncMessage::VisualChanged(meta));
+    assert_eq!(engine.state().metas[0].version, DEFAULT_VERSION);
+    assert!(engine
+        .state()
+        .code
+        .contains(&format!("\"version\":{}", DEFAULT_VERSION)));
+}

--- a/desktop/src/sync/mod.rs
+++ b/desktop/src/sync/mod.rs
@@ -1,3 +1,6 @@
 pub mod engine;
 
 pub use engine::{SyncEngine, SyncMessage, SyncState};
+
+#[cfg(test)]
+mod engine_tests;


### PR DESCRIPTION
## Summary
- cover SyncEngine with unit tests for text and visual update cases
- ensure DEFAULT_VERSION is set when visual metadata lacks version

## Testing
- `cargo test -p desktop --lib`

------
https://chatgpt.com/codex/tasks/task_e_68ab5adcc9348323a3ac9b1779d81fdd