### PR TITLE
Optimize meta sync on visual updates

### DIFF
--- a/desktop/src/sync/engine.rs
+++ b/desktop/src/sync/engine.rs
@@ -44,7 +44,11 @@ impl SyncEngine {
                     meta.version = DEFAULT_VERSION;
                 }
                 self.state.code = meta::upsert(&self.state.code, &meta);
-                self.state.metas = meta::read_all(&self.state.code);
+                if let Some(existing) = self.state.metas.iter_mut().find(|m| m.id == meta.id) {
+                    *existing = meta;
+                } else {
+                    self.state.metas.push(meta);
+                }
                 Some(self.state.code.clone())
             }
         }

--- a/desktop/src/sync/engine_tests.rs
+++ b/desktop/src/sync/engine_tests.rs
@@ -1,6 +1,6 @@
 use super::{SyncEngine, SyncMessage};
-use multicode_core::meta::{self, VisualMeta, DEFAULT_VERSION};
 use chrono::Utc;
+use multicode_core::meta::{self, VisualMeta, DEFAULT_VERSION};
 use std::collections::HashMap;
 
 fn make_meta(id: &str, version: u32) -> VisualMeta {
@@ -45,6 +45,20 @@ fn visual_changed_updates_state_code() {
     assert_eq!(result, engine.state().code);
     assert_eq!(engine.state().metas.len(), 1);
     assert_eq!(engine.state().metas[0].id, "block");
+}
+
+#[test]
+fn visual_changed_does_not_duplicate_meta() {
+    let mut engine = SyncEngine::new();
+    let meta = make_meta("block", DEFAULT_VERSION);
+    let code = meta::upsert("", &meta);
+    engine.handle(SyncMessage::TextChanged(code));
+
+    let updated = make_meta("block", DEFAULT_VERSION + 1);
+    engine.handle(SyncMessage::VisualChanged(updated));
+
+    assert_eq!(engine.state().metas.len(), 1);
+    assert_eq!(engine.state().metas[0].version, DEFAULT_VERSION + 1);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- avoid full meta reread after visual changes by updating the in-memory list directly
- add regression test to ensure meta count remains stable when updating an existing meta

## Testing
- `cargo test -p desktop`

------
https://chatgpt.com/codex/tasks/task_e_68ab6263b29c832389d69e7b5435ae73