### PR TITLE
Return visual metadata from SyncEngine

### DIFF
--- a/desktop/src/sync/engine.rs
+++ b/desktop/src/sync/engine.rs
@@ -31,13 +31,13 @@ impl SyncEngine {
     }
 
     /// Обрабатывает входящее сообщение синхронизации.
-    /// Возвращает обновлённый текст, если он был изменён.
-    pub fn handle(&mut self, msg: SyncMessage) -> Option<String> {
+    /// Возвращает обновлённый текст и список метаданных.
+    pub fn handle(&mut self, msg: SyncMessage) -> Option<(String, Vec<VisualMeta>)> {
         match msg {
             SyncMessage::TextChanged(code) => {
                 self.state.metas = meta::read_all(&code);
                 self.state.code = code;
-                None
+                Some((self.state.code.clone(), self.state.metas.clone()))
             }
             SyncMessage::VisualChanged(mut meta) => {
                 if meta.version == 0 {
@@ -49,7 +49,7 @@ impl SyncEngine {
                 } else {
                     self.state.metas.push(meta);
                 }
-                Some(self.state.code.clone())
+                Some((self.state.code.clone(), self.state.metas.clone()))
             }
         }
     }

--- a/desktop/src/sync/engine_tests.rs
+++ b/desktop/src/sync/engine_tests.rs
@@ -23,26 +23,32 @@ fn make_meta(id: &str, version: u32) -> VisualMeta {
 }
 
 #[test]
-fn text_changed_updates_state_metas() {
+fn text_changed_returns_metas() {
     let mut engine = SyncEngine::new();
     let meta = make_meta("test", DEFAULT_VERSION);
     let code = meta::upsert("", &meta);
-    engine.handle(SyncMessage::TextChanged(code));
+    let (ret_code, metas) = engine
+        .handle(SyncMessage::TextChanged(code.clone()))
+        .unwrap();
+    assert_eq!(ret_code, code);
+    assert_eq!(metas.len(), 1);
+    assert_eq!(metas[0].id, "test");
     assert_eq!(engine.state().metas.len(), 1);
-    assert_eq!(engine.state().metas[0].id, "test");
 }
 
 #[test]
 fn visual_changed_updates_state_code() {
     let mut engine = SyncEngine::new();
-    engine.handle(SyncMessage::TextChanged(String::new()));
+    let _ = engine.handle(SyncMessage::TextChanged(String::new()));
     let meta = make_meta("block", DEFAULT_VERSION);
-    let result = engine
+    let (result, metas) = engine
         .handle(SyncMessage::VisualChanged(meta.clone()))
         .unwrap();
     assert!(result.contains("@VISUAL_META"));
     assert!(result.contains("\"id\":\"block\""));
     assert_eq!(result, engine.state().code);
+    assert_eq!(metas.len(), 1);
+    assert_eq!(metas[0].id, "block");
     assert_eq!(engine.state().metas.len(), 1);
     assert_eq!(engine.state().metas[0].id, "block");
 }
@@ -52,10 +58,10 @@ fn visual_changed_does_not_duplicate_meta() {
     let mut engine = SyncEngine::new();
     let meta = make_meta("block", DEFAULT_VERSION);
     let code = meta::upsert("", &meta);
-    engine.handle(SyncMessage::TextChanged(code));
+    let _ = engine.handle(SyncMessage::TextChanged(code));
 
     let updated = make_meta("block", DEFAULT_VERSION + 1);
-    engine.handle(SyncMessage::VisualChanged(updated));
+    let _ = engine.handle(SyncMessage::VisualChanged(updated));
 
     assert_eq!(engine.state().metas.len(), 1);
     assert_eq!(engine.state().metas[0].version, DEFAULT_VERSION + 1);
@@ -64,9 +70,9 @@ fn visual_changed_does_not_duplicate_meta() {
 #[test]
 fn visual_changed_zeros_version_defaults_to_constant() {
     let mut engine = SyncEngine::new();
-    engine.handle(SyncMessage::TextChanged(String::new()));
+    let _ = engine.handle(SyncMessage::TextChanged(String::new()));
     let meta = make_meta("zero", 0);
-    engine.handle(SyncMessage::VisualChanged(meta));
+    let _ = engine.handle(SyncMessage::VisualChanged(meta));
     assert_eq!(engine.state().metas[0].version, DEFAULT_VERSION);
     assert!(engine
         .state()


### PR DESCRIPTION
## Summary
- extend `SyncEngine::handle` to return updated code and visual metadata
- propagate metadata through event handler to refresh visual state
- add tests ensuring `handle` outputs current `VisualMeta`

## Testing
- `cargo test -p desktop sync::engine --quiet`


------
https://chatgpt.com/codex/tasks/task_e_68ab65820ad48323aee6028d0f446ff9