### PR TITLE
Ensure deterministic order in change tracker

### DIFF
--- a/desktop/src/sync/change_tracker.rs
+++ b/desktop/src/sync/change_tracker.rs
@@ -47,12 +47,20 @@ impl ChangeTracker {
     }
 
     /// Returns and clears accumulated text changes.
+    ///
+    /// The returned identifiers are sorted to ensure deterministic order.
     pub fn take_text_changes(&mut self) -> Vec<String> {
-        self.text_changes.drain().collect()
+        let mut changes: Vec<_> = self.text_changes.drain().collect();
+        changes.sort();
+        changes
     }
 
     /// Returns and clears accumulated visual changes.
+    ///
+    /// The returned identifiers are sorted to ensure deterministic order.
     pub fn take_visual_changes(&mut self) -> Vec<String> {
-        self.visual_changes.drain().collect()
+        let mut changes: Vec<_> = self.visual_changes.drain().collect();
+        changes.sort();
+        changes
     }
 }


### PR DESCRIPTION
## Summary
- sort drained change identifiers in ChangeTracker for consistent ordering

## Testing
- `cargo test -p desktop -- --nocapture` *(fails: process terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68abf4b75e008323b7a2ca52145a64d7