### PR TITLE
Add meta integration tests for meta ID changes

### DIFF
--- a/desktop/src/editor/meta_integration_tests.rs
+++ b/desktop/src/editor/meta_integration_tests.rs
@@ -1,0 +1,29 @@
+use super::meta_integration::changed_meta_ids;
+
+#[test]
+fn detects_new_meta_id() {
+    let old = "";
+    let new = "# @VISUAL_META {\"id\":\"new\",\"x\":0.0,\"y\":0.0}";
+    assert_eq!(changed_meta_ids(old, new), vec!["new".to_string()]);
+}
+
+#[test]
+fn detects_removed_meta_id() {
+    let old = "# @VISUAL_META {\"id\":\"old\",\"x\":0.0,\"y\":0.0}";
+    let new = "";
+    assert_eq!(changed_meta_ids(old, new), vec!["old".to_string()]);
+}
+
+#[test]
+fn detects_modified_meta_id() {
+    let old = "# @VISUAL_META {\"id\":\"same\",\"x\":0.0,\"y\":0.0}";
+    let new = "# @VISUAL_META {\"id\":\"same\",\"x\":1.0,\"y\":1.0}";
+    assert_eq!(changed_meta_ids(old, new), vec!["same".to_string()]);
+}
+
+#[test]
+fn does_not_duplicate_ids() {
+    let old = "";
+    let new = "# @VISUAL_META {\"id\":\"dup\",\"x\":0.0,\"y\":0.0}\n# @VISUAL_META {\"id\":\"dup\",\"x\":1.0,\"y\":1.0}";
+    assert_eq!(changed_meta_ids(old, new), vec!["dup".to_string()]);
+}

--- a/desktop/src/editor/mod.rs
+++ b/desktop/src/editor/mod.rs
@@ -11,3 +11,5 @@ pub use settings::{EditorSettings, EditorTheme, CustomTheme};
 
 #[cfg(test)]
 mod code_editor_tests;
+#[cfg(test)]
+mod meta_integration_tests;


### PR DESCRIPTION
## Summary
- add tests covering `changed_meta_ids` behavior
- ensure no duplicates and handle addition/removal/modification of meta IDs

## Testing
- `cargo test`
- `cargo test -p desktop meta_integration_tests -- --nocapture`


------
https://chatgpt.com/codex/tasks/task_e_68abff6e36788323a1405f5fb7aa7fe6