### PR TITLE
Track and sync meta changes after file save

### DIFF
--- a/desktop/src/sync/engine.rs
+++ b/desktop/src/sync/engine.rs
@@ -44,6 +44,10 @@ pub enum SyncMessage {
 #[derive(Debug, Default)]
 pub struct SyncEngine {
     state: SyncState,
+    /// Последние обработанные идентификаторы метаданных из текстового редактора.
+    last_text_ids: Vec<String>,
+    /// Последние обработанные идентификаторы метаданных из визуального редактора.
+    last_visual_ids: Vec<String>,
 }
 
 impl SyncEngine {
@@ -79,5 +83,24 @@ impl SyncEngine {
     /// Возвращает текущее состояние синхронизации.
     pub fn state(&self) -> &SyncState {
         &self.state
+    }
+
+    /// Принимает идентификаторы метаданных, изменения которых необходимо
+    /// синхронизировать. В текущей реализации идентификаторы лишь сохраняются
+    /// во внутреннем состоянии, что позволяет тестам проверять факт передачи
+    /// данных.
+    pub fn process_changes(&mut self, text_ids: Vec<String>, visual_ids: Vec<String>) {
+        self.last_text_ids = text_ids;
+        self.last_visual_ids = visual_ids;
+    }
+
+    /// Возвращает последние обработанные идентификаторы из текстового редактора.
+    pub fn last_text_changes(&self) -> &[String] {
+        &self.last_text_ids
+    }
+
+    /// Возвращает последние обработанные идентификаторы из визуального редактора.
+    pub fn last_visual_changes(&self) -> &[String] {
+        &self.last_visual_ids
     }
 }

--- a/desktop/src/sync/engine_tests.rs
+++ b/desktop/src/sync/engine_tests.rs
@@ -79,3 +79,14 @@ fn visual_changed_zeros_version_defaults_to_constant() {
         .code
         .contains(&format!("\"version\":{}", DEFAULT_VERSION)));
 }
+
+#[test]
+fn process_changes_stores_ids() {
+    let mut engine = SyncEngine::new();
+    engine.process_changes(vec!["t1".into()], vec!["v1".into(), "v2".into()]);
+    assert_eq!(engine.last_text_changes(), &["t1".to_string()]);
+    assert_eq!(
+        engine.last_visual_changes(),
+        &["v1".to_string(), "v2".to_string()]
+    );
+}


### PR DESCRIPTION
## Summary
- capture text and visual meta changes on file save
- allow `SyncEngine` to record processed meta ids
- log synced meta IDs and test change handling

## Testing
- `cargo test -p desktop`


------
https://chatgpt.com/codex/tasks/task_e_68ac02c9864483238b646b88fcee530f