### PR TITLE
fix: handle multiple meta comments in line

### DIFF
--- a/desktop/src/editor/meta_integration_tests.rs
+++ b/desktop/src/editor/meta_integration_tests.rs
@@ -1,4 +1,4 @@
-use super::meta_integration::changed_meta_ids;
+use super::meta_integration::{changed_meta_ids, find_meta_comments};
 
 #[test]
 fn detects_new_meta_id() {
@@ -26,4 +26,21 @@ fn does_not_duplicate_ids() {
     let old = "";
     let new = "# @VISUAL_META {\"id\":\"dup\",\"x\":0.0,\"y\":0.0}\n# @VISUAL_META {\"id\":\"dup\",\"x\":1.0,\"y\":1.0}";
     assert_eq!(changed_meta_ids(old, new), vec!["dup".to_string()]);
+}
+
+#[test]
+fn finds_multiple_comments_per_line() {
+    let content = "# @VISUAL_META {\"id\":\"one\"} @VISUAL_META {\"id\":\"two\"}";
+    let comments = find_meta_comments(content);
+    assert_eq!(comments.len(), 2);
+    assert_eq!(comments[0].2, "{\"id\":\"one\"}");
+    assert_eq!(comments[1].2, "{\"id\":\"two\"}");
+}
+
+#[test]
+fn ignores_text_after_closing_brace() {
+    let content = "# @VISUAL_META {\"id\":\"one\"} trailing";
+    let comments = find_meta_comments(content);
+    assert_eq!(comments.len(), 1);
+    assert_eq!(comments[0].2, "{\"id\":\"one\"}");
 }


### PR DESCRIPTION
## Summary
- parse `@VISUAL_META` with non-greedy regex
- handle multiple meta comments per line
- document regex limits and add tests for edge cases

## Testing
- `cargo test -p desktop`


------
https://chatgpt.com/codex/tasks/task_e_68ac080d4ebc8323956e14e494701053