### PR TITLE
Add macro to define tree-sitter language parsers

### DIFF
--- a/core/src/parser/c.rs
+++ b/core/src/parser/c.rs
@@ -1,11 +1,1 @@
-use tree_sitter::{Language, Parser, Tree};
-
-pub fn language() -> Language {
-    tree_sitter_c::LANGUAGE.into()
-}
-
-pub fn parse(source: &str, old_tree: Option<&Tree>) -> Option<Tree> {
-    let mut parser = Parser::new();
-    parser.set_language(&language()).ok()?;
-    parser.parse(source, old_tree)
-}
+crate::define_lang_parser!(tree_sitter_c::LANGUAGE);

--- a/core/src/parser/c_sharp.rs
+++ b/core/src/parser/c_sharp.rs
@@ -1,11 +1,1 @@
-use tree_sitter::{Language, Parser, Tree};
-
-pub fn language() -> Language {
-    tree_sitter_c_sharp::LANGUAGE.into()
-}
-
-pub fn parse(source: &str, old_tree: Option<&Tree>) -> Option<Tree> {
-    let mut parser = Parser::new();
-    parser.set_language(&language()).ok()?;
-    parser.parse(source, old_tree)
-}
+crate::define_lang_parser!(tree_sitter_c_sharp::LANGUAGE);

--- a/core/src/parser/cpp.rs
+++ b/core/src/parser/cpp.rs
@@ -1,11 +1,1 @@
-use tree_sitter::{Language, Parser, Tree};
-
-pub fn language() -> Language {
-    tree_sitter_cpp::LANGUAGE.into()
-}
-
-pub fn parse(source: &str, old_tree: Option<&Tree>) -> Option<Tree> {
-    let mut parser = Parser::new();
-    parser.set_language(&language()).ok()?;
-    parser.parse(source, old_tree)
-}
+crate::define_lang_parser!(tree_sitter_cpp::LANGUAGE);

--- a/core/src/parser/java.rs
+++ b/core/src/parser/java.rs
@@ -1,11 +1,1 @@
-use tree_sitter::{Language, Parser, Tree};
-
-pub fn language() -> Language {
-    tree_sitter_java::LANGUAGE.into()
-}
-
-pub fn parse(source: &str, old_tree: Option<&Tree>) -> Option<Tree> {
-    let mut parser = Parser::new();
-    parser.set_language(&language()).ok()?;
-    parser.parse(source, old_tree)
-}
+crate::define_lang_parser!(tree_sitter_java::LANGUAGE);

--- a/core/src/parser/mod.rs
+++ b/core/src/parser/mod.rs
@@ -3,6 +3,23 @@ use std::fmt::{self, Display};
 use std::ops::Range;
 use tree_sitter::{Language, Node, Parser, Tree};
 
+#[macro_export]
+macro_rules! define_lang_parser {
+    ($lang:expr) => {
+        use tree_sitter::{Language, Parser, Tree};
+
+        pub fn language() -> Language {
+            $lang.into()
+        }
+
+        pub fn parse(source: &str, old_tree: Option<&Tree>) -> Option<Tree> {
+            let mut parser = Parser::new();
+            parser.set_language(&language()).ok()?;
+            parser.parse(source, old_tree)
+        }
+    };
+}
+
 pub mod css;
 pub mod go;
 pub mod html;


### PR DESCRIPTION
## Summary
- add `define_lang_parser!` macro for `language` and `parse` helpers
- refactor C, C++, Java, and C# parser modules to use the macro

## Testing
- `cargo test -p core`

------
https://chatgpt.com/codex/tasks/task_e_68ac11a64f2483239861cbbcb44fee08