### PR TITLE
Allow specifying language for sync engine

### DIFF
--- a/desktop/src/app/actions.rs
+++ b/desktop/src/app/actions.rs
@@ -19,6 +19,7 @@ use crate::visual::palette::{PaletteBlock, DEFAULT_CATEGORY};
 use crate::visual::translations::block_synonyms;
 use lru::LruCache;
 use multicode_core::parse_blocks;
+use multicode_core::parser::Lang;
 
 pub(super) fn build_command_index() -> SearchIndex<&'static str> {
     let mut index = SearchIndex::new();
@@ -168,7 +169,7 @@ impl Application for MulticodeApp {
             palette_query: String::new(),
             palette_drag: None,
             change_tracker: ChangeTracker::default(),
-            sync_engine: SyncEngine::new(),
+            sync_engine: SyncEngine::new(Lang::Rust),
             recent_commands,
             command_counts,
             command_trigrams,

--- a/desktop/src/app/events/handler.rs
+++ b/desktop/src/app/events/handler.rs
@@ -890,10 +890,10 @@ impl MulticodeApp {
                                 meta_ids: changed_ids,
                             });
                         }
-                        if let Some((_, metas)) = self
-                            .sync_engine
-                            .handle(SyncMessage::TextChanged(f.content.clone()))
-                        {
+                        if let Some((_, metas)) = self.sync_engine.handle(SyncMessage::TextChanged(
+                            f.content.clone(),
+                            detect_lang(&f.path).unwrap_or(Lang::Rust),
+                        )) {
                             for block in &mut f.blocks {
                                 if let Some(meta) = metas.iter().find(|m| m.id == block.visual_id) {
                                     block.x = meta.x;

--- a/desktop/src/app/state.rs
+++ b/desktop/src/app/state.rs
@@ -624,6 +624,7 @@ mod tests {
     use crate::app::events::Message;
     use crate::search::hotkeys::KeyCombination;
     use lru::LruCache;
+    use multicode_core::parser::Lang;
     use std::cell::RefCell;
     use std::collections::{HashMap, HashSet, VecDeque};
     use std::num::NonZeroUsize;
@@ -685,7 +686,7 @@ mod tests {
             palette_query: String::new(),
             palette_drag: None,
             change_tracker: ChangeTracker::default(),
-            sync_engine: SyncEngine::new(),
+            sync_engine: SyncEngine::new(Lang::Rust),
             recent_commands: VecDeque::new(),
             command_counts: HashMap::new(),
             command_trigrams: HashMap::new(),

--- a/desktop/src/app/ui.rs
+++ b/desktop/src/app/ui.rs
@@ -496,6 +496,7 @@ mod tests {
     use crate::components::file_manager::ContextMenu;
     use crate::sync::{ChangeTracker, SyncEngine};
     use lru::LruCache;
+    use multicode_core::parser::Lang;
     use std::cell::RefCell;
     use std::collections::{HashMap, HashSet, VecDeque};
     use std::num::NonZeroUsize;
@@ -570,7 +571,7 @@ mod tests {
             palette_query: String::new(),
             palette_drag: None,
             change_tracker: ChangeTracker::default(),
-            sync_engine: SyncEngine::new(),
+            sync_engine: SyncEngine::new(Lang::Rust),
             recent_commands: VecDeque::new(),
             command_counts: HashMap::new(),
             command_trigrams: HashMap::new(),

--- a/desktop/src/sync/engine_tests.rs
+++ b/desktop/src/sync/engine_tests.rs
@@ -1,6 +1,7 @@
 use super::{SyncEngine, SyncMessage};
 use chrono::Utc;
 use multicode_core::meta::{self, VisualMeta, DEFAULT_VERSION};
+use multicode_core::parser::Lang;
 use std::collections::HashMap;
 
 fn make_meta(id: &str, version: u32) -> VisualMeta {
@@ -24,11 +25,11 @@ fn make_meta(id: &str, version: u32) -> VisualMeta {
 
 #[test]
 fn text_changed_returns_metas() {
-    let mut engine = SyncEngine::new();
+    let mut engine = SyncEngine::new(Lang::Rust);
     let meta = make_meta("test", DEFAULT_VERSION);
     let code = meta::upsert("", &meta);
     let (ret_code, metas) = engine
-        .handle(SyncMessage::TextChanged(code.clone()))
+        .handle(SyncMessage::TextChanged(code.clone(), Lang::Rust))
         .unwrap();
     assert_eq!(ret_code, code);
     assert_eq!(metas.len(), 1);
@@ -38,8 +39,8 @@ fn text_changed_returns_metas() {
 
 #[test]
 fn visual_changed_updates_state_code() {
-    let mut engine = SyncEngine::new();
-    let _ = engine.handle(SyncMessage::TextChanged(String::new()));
+    let mut engine = SyncEngine::new(Lang::Rust);
+    let _ = engine.handle(SyncMessage::TextChanged(String::new(), Lang::Rust));
     let meta = make_meta("block", DEFAULT_VERSION);
     let (result, metas) = engine
         .handle(SyncMessage::VisualChanged(meta.clone()))
@@ -55,10 +56,10 @@ fn visual_changed_updates_state_code() {
 
 #[test]
 fn visual_changed_does_not_duplicate_meta() {
-    let mut engine = SyncEngine::new();
+    let mut engine = SyncEngine::new(Lang::Rust);
     let meta = make_meta("block", DEFAULT_VERSION);
     let code = meta::upsert("", &meta);
-    let _ = engine.handle(SyncMessage::TextChanged(code));
+    let _ = engine.handle(SyncMessage::TextChanged(code, Lang::Rust));
 
     let updated = make_meta("block", DEFAULT_VERSION + 1);
     let _ = engine.handle(SyncMessage::VisualChanged(updated));
@@ -69,8 +70,8 @@ fn visual_changed_does_not_duplicate_meta() {
 
 #[test]
 fn visual_changed_zeros_version_defaults_to_constant() {
-    let mut engine = SyncEngine::new();
-    let _ = engine.handle(SyncMessage::TextChanged(String::new()));
+    let mut engine = SyncEngine::new(Lang::Rust);
+    let _ = engine.handle(SyncMessage::TextChanged(String::new(), Lang::Rust));
     let meta = make_meta("zero", 0);
     let _ = engine.handle(SyncMessage::VisualChanged(meta));
     assert_eq!(engine.state().metas[0].version, DEFAULT_VERSION);
@@ -82,7 +83,7 @@ fn visual_changed_zeros_version_defaults_to_constant() {
 
 #[test]
 fn process_changes_stores_ids() {
-    let mut engine = SyncEngine::new();
+    let mut engine = SyncEngine::new(Lang::Rust);
     engine.process_changes(vec!["t1".into()], vec!["v1".into(), "v2".into()]);
     assert_eq!(engine.last_text_changes(), &["t1".to_string()]);
     assert_eq!(
@@ -93,7 +94,7 @@ fn process_changes_stores_ids() {
 
 #[test]
 fn text_changed_updates_syntax_tree() {
-    let mut engine = SyncEngine::new();
-    let _ = engine.handle(SyncMessage::TextChanged("fn main() {}".into()));
+    let mut engine = SyncEngine::new(Lang::Rust);
+    let _ = engine.handle(SyncMessage::TextChanged("fn main() {}".into(), Lang::Rust));
     assert!(!engine.state().syntax.nodes.is_empty());
 }

--- a/desktop/src/sync/mod.rs
+++ b/desktop/src/sync/mod.rs
@@ -9,23 +9,24 @@
 //! # Пример
 //! ```rust
 //! use desktop::sync::{SyncEngine, SyncMessage};
+//! use multicode_core::parser::Lang;
 //!
-//! let mut engine = SyncEngine::new();
+//! let mut engine = SyncEngine::new(Lang::Rust);
 //! // текстовый редактор сообщает об изменении
 //! let (_code, _metas) = engine
-//!     .handle(SyncMessage::TextChanged("fn main() {}".into()))
+//!     .handle(SyncMessage::TextChanged("fn main() {}".into(), Lang::Rust))
 //!     .unwrap();
 //! ```
 //!
 //! Более подробное описание потоков данных приведено в `docs/sync.md`.
 
+pub mod ast_parser;
 pub mod change_tracker;
 pub mod engine;
-pub mod ast_parser;
 
+pub use ast_parser::{ASTParser, SyntaxNode, SyntaxTree};
 pub use change_tracker::{ChangeTracker, TextDelta, VisualDelta};
 pub use engine::{SyncEngine, SyncMessage, SyncState};
-pub use ast_parser::{ASTParser, SyntaxTree, SyntaxNode};
 
 #[cfg(test)]
 mod engine_tests;

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -4,9 +4,9 @@
 
 ## Потоки данных
 
-1. **Изменение текста**  
-   Текстовый редактор отправляет `SyncMessage::TextChanged` с новым содержимым.  
-   `SyncEngine` извлекает метаданные и возвращает их вместе с обновлённым кодом.  
+1. **Изменение текста**
+   Текстовый редактор отправляет `SyncMessage::TextChanged` с новым содержимым и языком.
+   `SyncEngine` извлекает метаданные и возвращает их вместе с обновлённым кодом.
    Визуальный редактор использует метаданные для обновления схемы.
 
 2. **Изменение блок-схемы**  
@@ -18,10 +18,11 @@
 
 ```rust
 use desktop::sync::{SyncEngine, SyncMessage};
+use multicode_core::parser::Lang;
 
-let mut engine = SyncEngine::new();
+let mut engine = SyncEngine::new(Lang::Rust);
 let (_code, metas) = engine
-    .handle(SyncMessage::TextChanged("fn main() {}".into()))
+    .handle(SyncMessage::TextChanged("fn main() {}".into(), Lang::Rust))
     .unwrap();
 // передать metas визуальному редактору
 ```


### PR DESCRIPTION
## Summary
- pass language to `SyncEngine::new` and `SyncMessage::TextChanged`
- allow language switching during sync
- update docs and tests for new API

## Testing
- `cargo test -p desktop`

------
https://chatgpt.com/codex/tasks/task_e_68ac163801188323beb46e72d547fd31