### PR TITLE
Preserve stable visual IDs across parses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1678,6 +1678,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "tree-sitter",
 ]
 
 [[package]]

--- a/core/src/blocks/mod.rs
+++ b/core/src/blocks/mod.rs
@@ -125,7 +125,7 @@ fn regenerate_code(content: &str, lang: Lang, metas: &[VisualMeta]) -> Option<St
 fn regenerate_rust(content: &str, metas: &[VisualMeta]) -> Option<String> {
     let mut file: File = syn::parse_file(content).ok()?;
     let tree = parse(content, Lang::Rust, None)?;
-    let blocks = parse_to_blocks(&tree);
+    let blocks = parse_to_blocks(&tree, None);
     let map: HashMap<_, _> = blocks
         .into_iter()
         .map(|b| (b.node_id, b.visual_id))

--- a/core/src/blocks/parsing.rs
+++ b/core/src/blocks/parsing.rs
@@ -39,5 +39,5 @@ pub fn parse(content: &str, lang: Lang) -> Option<Vec<Block>> {
         ts_parse(content, lang, None)?
     };
     update_document_tree("current".to_string(), tree.clone());
-    Some(parse_to_blocks(&tree))
+    Some(parse_to_blocks(&tree, None))
 }

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -20,6 +20,7 @@ regex = "1"
 lru = "0.12"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tree-sitter = "0.23"
 
 # app modules: state, actions, view
 


### PR DESCRIPTION
## Summary
- Cache the last tree and node ID map in `ASTParser` to reuse visual IDs
- Allow `parse_to_blocks` to accept previous ID mappings for incremental parsing
- Add regression test confirming unchanged nodes keep their `visual_id`

## Testing
- `cargo test -p desktop`


------
https://chatgpt.com/codex/tasks/task_e_68ac1bebf2bc8323a8941b18274cf2c9