### PR TITLE
Add parser examples for multiple languages and AST parser tests

### DIFF
--- a/core/src/parser/mod.rs
+++ b/core/src/parser/mod.rs
@@ -21,14 +21,14 @@ macro_rules! define_lang_parser {
     };
 }
 
+pub mod c;
+pub mod c_sharp;
+pub mod cpp;
 pub mod css;
 pub mod go;
 pub mod html;
-pub mod javascript;
-pub mod c;
-pub mod cpp;
 pub mod java;
-pub mod c_sharp;
+pub mod javascript;
 pub mod python;
 pub mod rust;
 pub mod typescript;
@@ -140,7 +140,12 @@ pub struct Block {
 pub fn parse_to_blocks(tree: &Tree, prev: Option<&HashMap<u32, String>>) -> Vec<Block> {
     let mut blocks = Vec::new();
     let mut counter: u64 = prev
-        .and_then(|m| m.values().filter_map(|v| v.parse::<u64>().ok()).max().map(|m| m + 1))
+        .and_then(|m| {
+            m.values()
+                .filter_map(|v| v.parse::<u64>().ok())
+                .max()
+                .map(|m| m + 1)
+        })
         .unwrap_or(0);
 
     fn map_kind(kind: &str) -> String {
@@ -219,97 +224,4 @@ pub fn parse_to_blocks(tree: &Tree, prev: Option<&HashMap<u32, String>>) -> Vec<
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use std::collections::HashSet;
-
-    #[test]
-    fn lang_display_and_from_str() {
-        let cases = [
-            (Lang::Rust, "rust"),
-            (Lang::Python, "python"),
-            (Lang::JavaScript, "javascript"),
-            (Lang::Css, "css"),
-            (Lang::Html, "html"),
-            (Lang::Go, "go"),
-            (Lang::TypeScript, "typescript"),
-            (Lang::C, "c"),
-            (Lang::Cpp, "cpp"),
-            (Lang::Java, "java"),
-            (Lang::CSharp, "csharp"),
-        ];
-        for (lang, name) in cases {
-            assert_eq!(lang.to_string(), name);
-            assert_eq!(name.parse::<Lang>().ok(), Some(lang));
-        }
-    }
-
-    #[test]
-    fn parse_sources_into_blocks() {
-        let cases = [
-            (Lang::Rust, "fn main() { println!(\"hi\"); }"),
-            (Lang::Python, "def main():\n    print('hi')"),
-            (Lang::JavaScript, "function main() { console.log('hi'); }"),
-            (Lang::Css, "body { color: red; }"),
-            (Lang::Html, "<html></html>"),
-            (Lang::Go, "package main\nfunc main() { println(\"hi\") }"),
-            (
-                Lang::TypeScript,
-                "function main(): void { console.log('hi'); }",
-            ),
-            (Lang::C, "int main() { return 0; }"),
-            (Lang::Cpp, "int main() { return 0; }"),
-            (Lang::Java, "class Main { public static void main(String[] args) { } }"),
-            (Lang::CSharp, "class Program { static void Main(string[] args) { } }"),
-        ];
-
-        for (lang, source) in cases {
-            let tree = parse(source, lang, None).expect("не удалось разобрать");
-            let blocks = parse_to_blocks(&tree, None);
-            assert!(!blocks.is_empty());
-            let mut unique = HashSet::new();
-            for block in &blocks {
-                assert!(unique.insert(block.node_id));
-                assert!(!block.visual_id.is_empty());
-            }
-        }
-    }
-
-    #[test]
-    fn parse_expression_into_ops_and_variables() {
-        let src = "a + b * c";
-        let tree = parse(src, Lang::Python, None).expect("не удалось разобрать");
-        let blocks = parse_to_blocks(&tree, None);
-        let mut found = 0;
-        for b in &blocks {
-            match b.kind.as_str() {
-                "Op/+" => {
-                    assert_eq!(b.anchors, vec![(2, 3)]);
-                    found += 1;
-                }
-                "Op/*" => {
-                    assert_eq!(b.anchors, vec![(6, 7)]);
-                    found += 1;
-                }
-                "Variable/Get" => {
-                    if b.anchors == vec![(0, 1)]
-                        || b.anchors == vec![(4, 5)]
-                        || b.anchors == vec![(8, 9)]
-                    {
-                        found += 1;
-                    }
-                }
-                _ => {}
-            }
-        }
-        assert_eq!(found, 5);
-    }
-
-    #[test]
-    fn parse_ternary_expression_into_op() {
-        let src = "a ? b : c";
-        let tree = parse(src, Lang::JavaScript, None).expect("не удалось разобрать");
-        let blocks = parse_to_blocks(&tree, None);
-        assert!(blocks.iter().any(|b| b.kind == "Op/Ternary"));
-    }
-}
+mod tests;

--- a/core/src/parser/tests/mod.rs
+++ b/core/src/parser/tests/mod.rs
@@ -1,0 +1,132 @@
+use super::*;
+use std::collections::HashSet;
+
+#[test]
+fn lang_display_and_from_str() {
+    let cases = [
+        (Lang::Rust, "rust"),
+        (Lang::Python, "python"),
+        (Lang::JavaScript, "javascript"),
+        (Lang::Css, "css"),
+        (Lang::Html, "html"),
+        (Lang::Go, "go"),
+        (Lang::TypeScript, "typescript"),
+        (Lang::C, "c"),
+        (Lang::Cpp, "cpp"),
+        (Lang::Java, "java"),
+        (Lang::CSharp, "csharp"),
+    ];
+    for (lang, name) in cases {
+        assert_eq!(lang.to_string(), name);
+        assert_eq!(name.parse::<Lang>().ok(), Some(lang));
+    }
+}
+
+#[test]
+fn parse_sources_into_blocks() {
+    let cases = [
+        (Lang::Rust, "fn main() { println!(\"hi\"); }"),
+        (Lang::Python, "def main():\n    print('hi')"),
+        (Lang::JavaScript, "function main() { console.log('hi'); }"),
+        (Lang::Css, "body { color: red; }"),
+        (Lang::Html, "<html></html>"),
+        (Lang::Go, "package main\nfunc main() { println(\"hi\") }"),
+        (
+            Lang::TypeScript,
+            "function main(): void { console.log('hi'); }",
+        ),
+        (Lang::C, "int main() { return 0; }"),
+        (Lang::Cpp, "int main() { return 0; }"),
+        (
+            Lang::Java,
+            "class Main { public static void main(String[] args) { } }",
+        ),
+        (
+            Lang::CSharp,
+            "class Program { static void Main(string[] args) { } }",
+        ),
+    ];
+
+    for (lang, source) in cases {
+        let tree = parse(source, lang, None).expect("не удалось разобрать");
+        let blocks = parse_to_blocks(&tree, None);
+        assert!(!blocks.is_empty());
+        let mut unique = HashSet::new();
+        for block in &blocks {
+            assert!(unique.insert(block.node_id));
+            assert!(!block.visual_id.is_empty());
+        }
+    }
+}
+
+#[test]
+fn parse_expression_into_ops_and_variables() {
+    let src = "a + b * c";
+    let tree = parse(src, Lang::Python, None).expect("не удалось разобрать");
+    let blocks = parse_to_blocks(&tree, None);
+    let mut found = 0;
+    for b in &blocks {
+        match b.kind.as_str() {
+            "Op/+" => {
+                assert_eq!(b.anchors, vec![(2, 3)]);
+                found += 1;
+            }
+            "Op/*" => {
+                assert_eq!(b.anchors, vec![(6, 7)]);
+                found += 1;
+            }
+            "Variable/Get" => {
+                if b.anchors == vec![(0, 1)]
+                    || b.anchors == vec![(4, 5)]
+                    || b.anchors == vec![(8, 9)]
+                {
+                    found += 1;
+                }
+            }
+            _ => {}
+        }
+    }
+    assert_eq!(found, 5);
+}
+
+#[test]
+fn parse_ternary_expression_into_op() {
+    let src = "a ? b : c";
+    let tree = parse(src, Lang::JavaScript, None).expect("не удалось разобрать");
+    let blocks = parse_to_blocks(&tree, None);
+    assert!(blocks.iter().any(|b| b.kind == "Op/Ternary"));
+}
+
+fn assert_example(lang: Lang, source: &str) {
+    let tree = parse(source, lang, None).expect("не удалось разобрать");
+    assert!(tree.root_node().child_count() > 0);
+    let blocks = parse_to_blocks(&tree, None);
+    assert!(!blocks.is_empty());
+    assert!(blocks.iter().all(|b| !b.visual_id.is_empty()));
+}
+
+#[test]
+fn c_example_has_visual_ids() {
+    assert_example(Lang::C, "int main() { return 0; }");
+}
+
+#[test]
+fn cpp_example_has_visual_ids() {
+    assert_example(Lang::Cpp, "int main() { return 0; }");
+}
+
+#[test]
+fn java_example_has_visual_ids() {
+    assert_example(
+        Lang::Java,
+        "class Main { public static void main(String[] args) {} }",
+    );
+}
+
+#[test]
+fn csharp_example_has_visual_ids() {
+    assert_example(
+        Lang::CSharp,
+        "class Program { static void Main(string[] args) { } }",
+    );
+}

--- a/desktop/src/sync/ast_parser.rs
+++ b/desktop/src/sync/ast_parser.rs
@@ -1,6 +1,6 @@
-use std::collections::HashMap;
-use multicode_core::parser::{self, Block, Lang};
 use multicode_core::meta::VisualMeta;
+use multicode_core::parser::{self, Block, Lang};
+use std::collections::HashMap;
 use tree_sitter::Tree;
 
 #[derive(Debug, Clone)]
@@ -84,10 +84,9 @@ mod tests {
         let m = meta("0");
         let code = multicode_core::meta::upsert("fn main() {}", &m);
         let tree = parser.parse(&code, &[m]);
-        assert!(tree
-            .nodes
-            .iter()
-            .any(|n| n.block.visual_id == "0" && n.meta.as_ref().map(|m| m.id.as_str()) == Some("0")));
+        assert!(tree.nodes.iter().any(
+            |n| n.block.visual_id == "0" && n.meta.as_ref().map(|m| m.id.as_str()) == Some("0")
+        ));
     }
 
     #[test]
@@ -111,5 +110,38 @@ mod tests {
             }
         }
         assert!(count > 0);
+    }
+
+    fn assert_tree_has_visual_ids(lang: Lang, code: &str) {
+        let mut parser = ASTParser::new(lang);
+        let tree = parser.parse(code, &[]);
+        assert!(!tree.nodes.is_empty());
+        assert!(tree.nodes.iter().all(|n| !n.block.visual_id.is_empty()));
+    }
+
+    #[test]
+    fn parses_c_code_with_visual_ids() {
+        assert_tree_has_visual_ids(Lang::C, "int main() { return 0; }");
+    }
+
+    #[test]
+    fn parses_cpp_code_with_visual_ids() {
+        assert_tree_has_visual_ids(Lang::Cpp, "int main() { return 0; }");
+    }
+
+    #[test]
+    fn parses_java_code_with_visual_ids() {
+        assert_tree_has_visual_ids(
+            Lang::Java,
+            "class Main { public static void main(String[] args) {} }",
+        );
+    }
+
+    #[test]
+    fn parses_csharp_code_with_visual_ids() {
+        assert_tree_has_visual_ids(
+            Lang::CSharp,
+            "class Program { static void Main(string[] args) { } }",
+        );
     }
 }


### PR DESCRIPTION
## Summary
- add dedicated parser tests for C, C++, Java, and C# ensuring parse and parse_to_blocks return nodes with visual IDs
- add ASTParser tests in desktop crate to verify SyntaxTree generation for those languages

## Testing
- `cargo test -p core`
- `cargo test -p desktop`


------
https://chatgpt.com/codex/tasks/task_e_68ac24f49c4883239132c834a92a762a