### PR TITLE
feat: make meta insertion optional

### DIFF
--- a/docs/sync.md
+++ b/docs/sync.md
@@ -96,7 +96,7 @@ let blocks = [Block {
     anchors: vec![],
 }];
 
-let gen = CodeGenerator::new(Lang::Rust);
+let gen = CodeGenerator::new(Lang::Rust, true);
 let code = gen.generate(&metas, &blocks).unwrap();
 let formatted = format_generated_code(&code, 1, FormattingStyle::Spaces, 4);
 ```


### PR DESCRIPTION
## Summary
- allow `CodeGenerator` to skip `@VISUAL_META` injection via new `insert_meta` flag
- test code generation with and without metadata comments
- update documentation for the new constructor

## Testing
- `cargo test -p desktop`


------
https://chatgpt.com/codex/tasks/task_e_68ac4568cad08323abc2a575c7d48097