### PR TITLE
docs: extend Neira navigation

### DIFF
--- a/docs/neira/README.md
+++ b/docs/neira/README.md
@@ -13,6 +13,12 @@
 - [Практическое руководство](practical-guide.md)
 - [Глоссарий](glossary.md)
 - [FAQ](faq.md)
+- [Загрузка обучающих данных](training.md)
+- [Развертывание Neira](deployment.md)
+- [Тестирование Neira](testing.md)
+- [Дорожная карта Neira](roadmap.md)
+- [Структура управления Нейры](governance-structure.md)
+- [Мотивация и прогресс Нейры](motivation.md)
 
 ## Оглавление
 - [Назначение](#назначение)


### PR DESCRIPTION
## Summary
- add navigation links to Neira documentation for training, deployment, testing, roadmap, governance, and motivation

## Testing
- `CI=1 npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac7324b7f88323b3cd00a2a8be75cf