### PR TITLE
Add tracing for conflict resolution

### DIFF
--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -1,10 +1,10 @@
-use iced::{Sandbox, Settings};
 use desktop::ui::MainUI;
+use iced::{Sandbox, Settings};
 use tracing_subscriber::EnvFilter;
 
 pub fn main() -> iced::Result {
-    tracing_subscriber::fmt()
-        .with_env_filter(EnvFilter::from_default_env())
-        .init();
+    let filter =
+        EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("desktop=debug"));
+    tracing_subscriber::fmt().with_env_filter(filter).init();
     MainUI::run(Settings::default())
 }

--- a/desktop/src/sync/conflict_resolver.rs
+++ b/desktop/src/sync/conflict_resolver.rs
@@ -79,6 +79,14 @@ impl ConflictResolver {
             (MetaComment, Merge)
         };
 
+        match conflict_type {
+            Structural => tracing::warn!(id = %text.id, "Structural conflict detected"),
+            _ => {
+                tracing::debug!(id = %text.id, conflict_type = ?conflict_type, "Conflict detected")
+            }
+        }
+        tracing::debug!(id = %text.id, resolution = ?resolution, "Conflict resolved");
+
         resolved.version = std::cmp::max(text.version, visual.version);
         let conflict = SyncConflict {
             id: text.id.clone(),


### PR DESCRIPTION
## Summary
- add debug and warn logging to conflict resolver
- log conflict details in sync engine
- enable debug logs by default for desktop in dev

## Testing
- `cargo test -p desktop`

------
https://chatgpt.com/codex/tasks/task_e_68ac71f7ab988323bc1339242ede5e8f