### PR TITLE
Add line/column based ID lookup in sync engine

### DIFF
--- a/desktop/src/sync/element_mapper.rs
+++ b/desktop/src/sync/element_mapper.rs
@@ -87,6 +87,34 @@ impl ElementMapper {
     pub fn range_of(&self, id: &str) -> Option<Range<usize>> {
         self.id_to_range.get(id).cloned()
     }
+
+    /// Converts a zero-based `(line, column)` pair to a byte offset within the
+    /// provided source code. Returns `None` if the position is out of bounds.
+    pub fn offset_at(code: &str, line: usize, column: usize) -> Option<usize> {
+        let mut current_line = 0;
+        let mut current_col = 0;
+        for (idx, ch) in code.char_indices() {
+            if current_line == line && current_col == column {
+                return Some(idx);
+            }
+            if ch == '\n' {
+                current_line += 1;
+                current_col = 0;
+            } else {
+                current_col += 1;
+            }
+        }
+        if current_line == line && current_col == column {
+            Some(code.len())
+        } else {
+            None
+        }
+    }
+
+    /// Finds a metadata identifier for the given source position.
+    pub fn id_at_position(&self, code: &str, line: usize, column: usize) -> Option<&str> {
+        Self::offset_at(code, line, column).and_then(|offset| self.id_at(offset))
+    }
 }
 
 #[cfg(test)]

--- a/desktop/src/sync/engine.rs
+++ b/desktop/src/sync/engine.rs
@@ -177,6 +177,11 @@ impl SyncEngine {
         self.mapper.id_at(offset)
     }
 
+    /// Returns the metadata identifier at the given `(line, column)` position.
+    pub fn id_at_position(&self, line: usize, column: usize) -> Option<&str> {
+        self.mapper.id_at_position(&self.state.code, line, column)
+    }
+
     /// Returns the byte range corresponding to the given metadata identifier.
     pub fn range_of(&self, id: &str) -> Option<std::ops::Range<usize>> {
         self.mapper.range_of(id)

--- a/desktop/src/sync/engine_tests.rs
+++ b/desktop/src/sync/engine_tests.rs
@@ -116,6 +116,16 @@ fn element_mapper_maps_ids_and_ranges() {
 }
 
 #[test]
+fn id_at_position_finds_id_by_coordinates() {
+    let mut engine = SyncEngine::new(Lang::Rust);
+    let meta = make_meta("0", DEFAULT_VERSION);
+    let code = meta::upsert("fn main() {}\n", &meta);
+    let _ = engine.handle(SyncMessage::TextChanged(code, Lang::Rust));
+    assert_eq!(engine.id_at_position(0, 0), Some("0"));
+    assert_eq!(engine.id_at_position(10, 0), None);
+}
+
+#[test]
 fn conflict_resolver_applies_strategies() {
     let mut engine = SyncEngine::new(Lang::Rust);
     let mut base = make_meta("c", DEFAULT_VERSION);


### PR DESCRIPTION
## Summary
- support converting (line, column) to byte offset
- expose `id_at_position` via `SyncEngine`
- test lookup of metadata ID by coordinates

## Testing
- `cargo test -p desktop`

------
https://chatgpt.com/codex/tasks/task_e_68ac8eedeacc83238403ce3cfa0c299a