### PR TITLE
Use IndexSet for ordered merges

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1666,6 +1666,7 @@ dependencies = [
  "criterion",
  "directories",
  "iced",
+ "indexmap 2.10.0",
  "lru",
  "once_cell",
  "pulldown-cmark",

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -21,6 +21,7 @@ lru = "0.12"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tree-sitter = "0.23"
+indexmap = "2"
 
 # app modules: state, actions, view
 


### PR DESCRIPTION
## Summary
- preserve element order when merging metadata by using `IndexSet`
- add `merge_vec` utility to add text elements first, then unique visual elements
- test that merged lists maintain expected order

## Testing
- `cargo test -p desktop --lib`


------
https://chatgpt.com/codex/tasks/task_e_68ac99b2745c8323bee4a2b7471304d1