### PR TITLE
Add customizable conflict resolution policy

### DIFF
--- a/desktop/src/app/actions.rs
+++ b/desktop/src/app/actions.rs
@@ -14,7 +14,7 @@ use super::{
     AppTheme, CreateTarget, EditorMode, Language, LogLevel, MulticodeApp, Screen, UserSettings,
 };
 use crate::search::{fuzzy, index::SearchIndex};
-use crate::sync::{ChangeTracker, SyncEngine};
+use crate::sync::{ChangeTracker, ResolutionPolicy, SyncEngine};
 use crate::visual::palette::{PaletteBlock, DEFAULT_CATEGORY};
 use crate::visual::translations::block_synonyms;
 use lru::LruCache;
@@ -169,7 +169,7 @@ impl Application for MulticodeApp {
             palette_query: String::new(),
             palette_drag: None,
             change_tracker: ChangeTracker::default(),
-            sync_engine: SyncEngine::new(Lang::Rust),
+            sync_engine: SyncEngine::new(Lang::Rust, ResolutionPolicy::PreferText),
             recent_commands,
             command_counts,
             command_trigrams,

--- a/desktop/src/app/state.rs
+++ b/desktop/src/app/state.rs
@@ -26,7 +26,7 @@ use super::log_translations::LogMessage;
 use crate::app::diff::DiffView;
 use crate::components::file_manager::ContextMenu;
 use crate::editor::{AutocompleteState, EditorSettings};
-use crate::sync::{ChangeTracker, SyncEngine};
+use crate::sync::{ChangeTracker, ResolutionPolicy, SyncEngine};
 use crate::visual::palette::PaletteBlock;
 use crate::visual::translations::Language;
 
@@ -686,7 +686,7 @@ mod tests {
             palette_query: String::new(),
             palette_drag: None,
             change_tracker: ChangeTracker::default(),
-            sync_engine: SyncEngine::new(Lang::Rust),
+            sync_engine: SyncEngine::new(Lang::Rust, ResolutionPolicy::PreferText),
             recent_commands: VecDeque::new(),
             command_counts: HashMap::new(),
             command_trigrams: HashMap::new(),

--- a/desktop/src/app/ui.rs
+++ b/desktop/src/app/ui.rs
@@ -494,7 +494,7 @@ mod tests {
     use super::super::{CreateTarget, LogLevel, MulticodeApp, Screen, UserSettings, ViewMode};
     use crate::app::command_palette::COMMANDS;
     use crate::components::file_manager::ContextMenu;
-    use crate::sync::{ChangeTracker, SyncEngine};
+    use crate::sync::{ChangeTracker, ResolutionPolicy, SyncEngine};
     use lru::LruCache;
     use multicode_core::parser::Lang;
     use std::cell::RefCell;
@@ -571,7 +571,7 @@ mod tests {
             palette_query: String::new(),
             palette_drag: None,
             change_tracker: ChangeTracker::default(),
-            sync_engine: SyncEngine::new(Lang::Rust),
+            sync_engine: SyncEngine::new(Lang::Rust, ResolutionPolicy::PreferText),
             recent_commands: VecDeque::new(),
             command_counts: HashMap::new(),
             command_trigrams: HashMap::new(),

--- a/desktop/src/sync/mod.rs
+++ b/desktop/src/sync/mod.rs
@@ -8,10 +8,10 @@
 //!
 //! # Пример
 //! ```rust
-//! use desktop::sync::{SyncEngine, SyncMessage};
+//! use desktop::sync::{ResolutionPolicy, SyncEngine, SyncMessage};
 //! use multicode_core::parser::Lang;
 //!
-//! let mut engine = SyncEngine::new(Lang::Rust);
+//! let mut engine = SyncEngine::new(Lang::Rust, ResolutionPolicy::PreferText);
 //! // текстовый редактор сообщает об изменении
 //! let (_code, _metas) = engine
 //!     .handle(SyncMessage::TextChanged("fn main() {}".into(), Lang::Rust))
@@ -30,7 +30,9 @@ pub mod engine;
 pub use ast_parser::{ASTParser, SyntaxNode, SyntaxTree};
 pub use change_tracker::{ChangeTracker, TextDelta, VisualDelta};
 pub use code_generator::{format_generated_code, CodeGenerator, FormattingStyle};
-pub use conflict_resolver::{ConflictResolver, ConflictType, ResolutionOption, SyncConflict};
+pub use conflict_resolver::{
+    ConflictResolver, ConflictType, ResolutionOption, ResolutionPolicy, SyncConflict,
+};
 pub use element_mapper::ElementMapper;
 pub use engine::{SyncEngine, SyncMessage, SyncState};
 

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -45,10 +45,10 @@ for node in tree.nodes {
 ## Пример
 
 ```rust
-use desktop::sync::{SyncEngine, SyncMessage};
+use desktop::sync::{ResolutionPolicy, SyncEngine, SyncMessage};
 use multicode_core::parser::Lang;
 
-let mut engine = SyncEngine::new(Lang::Rust);
+let mut engine = SyncEngine::new(Lang::Rust, ResolutionPolicy::PreferText);
 let (_code, metas) = engine
     .handle(SyncMessage::TextChanged("fn main() {}".into(), Lang::Rust))
     .unwrap();


### PR DESCRIPTION
## Summary
- introduce `ResolutionPolicy` to select text or visual priority
- allow `ConflictResolver::resolve` and `SyncEngine::new` to accept a `ResolutionPolicy`
- update engine and call sites to use `ResolutionPolicy::PreferText` by default

## Testing
- `cargo test` *(fails: lock file version 4 requires `-Znext-lockfile-bump`)*

------
https://chatgpt.com/codex/tasks/task_e_68aca21e8ac48323b60304bc7482b6bb