### PR TITLE
Include diagnostics in sync engine handle

### DIFF
--- a/desktop/src/app/events/handler.rs
+++ b/desktop/src/app/events/handler.rs
@@ -82,7 +82,7 @@ impl MulticodeApp {
                             };
                             if let Some(meta) = meta {
                                 let delta = delta_from_meta(&meta);
-                                if let Some((code, _)) =
+                                if let Some((code, _, _)) =
                                     self.sync_engine.handle(SyncMessage::VisualChanged(meta))
                                 {
                                     if let Some(tab) = self.tabs.get_mut(i) {
@@ -105,7 +105,7 @@ impl MulticodeApp {
                                     tab.blocks.push(block);
                                     tab.dirty = true;
                                 }
-                                if let Some((code, _)) =
+                                if let Some((code, _, _)) =
                                     self.sync_engine.handle(SyncMessage::VisualChanged(meta))
                                 {
                                     if let Some(tab) = self.tabs.get_mut(i) {
@@ -169,7 +169,7 @@ impl MulticodeApp {
                 Command::none()
             }
             Message::Sync(msg) => {
-                if let Some((code, metas)) = self.sync_engine.handle(msg) {
+                if let Some((code, metas, _)) = self.sync_engine.handle(msg) {
                     if let Some(tab) = self.current_file_mut() {
                         tab.content = code;
                         tab.editor = Content::with_text(&tab.content);
@@ -890,10 +890,12 @@ impl MulticodeApp {
                                 meta_ids: changed_ids,
                             });
                         }
-                        if let Some((_, metas)) = self.sync_engine.handle(SyncMessage::TextChanged(
-                            f.content.clone(),
-                            detect_lang(&f.path).unwrap_or(Lang::Rust),
-                        )) {
+                        if let Some((_, metas, _)) =
+                            self.sync_engine.handle(SyncMessage::TextChanged(
+                                f.content.clone(),
+                                detect_lang(&f.path).unwrap_or(Lang::Rust),
+                            ))
+                        {
                             for block in &mut f.blocks {
                                 if let Some(meta) = metas.iter().find(|m| m.id == block.visual_id) {
                                     block.x = meta.x;

--- a/desktop/src/sync/mod.rs
+++ b/desktop/src/sync/mod.rs
@@ -8,12 +8,12 @@
 //!
 //! # Пример
 //! ```rust
-//! use desktop::sync::{ResolutionPolicy, SyncEngine, SyncMessage};
+//! use desktop::sync::{ResolutionPolicy, SyncDiagnostics, SyncEngine, SyncMessage};
 //! use multicode_core::parser::Lang;
 //!
 //! let mut engine = SyncEngine::new(Lang::Rust, ResolutionPolicy::PreferText);
 //! // текстовый редактор сообщает об изменении
-//! let (_code, _metas) = engine
+//! let (_code, _metas, _diag) = engine
 //!     .handle(SyncMessage::TextChanged("fn main() {}".into(), Lang::Rust))
 //!     .unwrap();
 //! ```
@@ -34,7 +34,7 @@ pub use conflict_resolver::{
     ConflictResolver, ConflictType, ResolutionOption, ResolutionPolicy, SyncConflict,
 };
 pub use element_mapper::ElementMapper;
-pub use engine::{SyncEngine, SyncMessage, SyncState};
+pub use engine::{SyncDiagnostics, SyncEngine, SyncMessage, SyncState};
 
 #[cfg(test)]
 mod engine_tests;

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -55,8 +55,10 @@ for node in tree.nodes {
   кода;
 - `unmapped_code` — участки кода без метаданных.
 
-Эти списки доступны через одноимённые методы `SyncEngine` и могут использоваться
-для диагностики несоответствий между текстом и визуальным представлением.
+Эти списки возвращаются в структуре `SyncDiagnostics`, которую выдаёт `handle`,
+а также доступны через одноимённые методы `SyncEngine` и могут
+использоваться для диагностики несоответствий между текстом и визуальным
+представлением.
 
 ## Разрешение конфликтов
 
@@ -81,31 +83,33 @@ for node in tree.nodes {
 ### Пример: расхождение версий
 
 ```rust
-use desktop::sync::{ResolutionPolicy, SyncEngine, SyncMessage};
+use desktop::sync::{ResolutionPolicy, SyncDiagnostics, SyncEngine, SyncMessage};
 use multicode_core::parser::Lang;
 
 let mut engine = SyncEngine::new(Lang::Rust, ResolutionPolicy::PreferText);
 let code = r#"// @VISUAL_META {\"id\":\"1\",\"x\":0.0,\"y\":0.0}\nfn main() {}"#;
-let (_code, mut metas) =
-    engine.handle(SyncMessage::TextChanged(code.into(), Lang::Rust)).unwrap();
+let (_code, mut metas, _diag) =
+    engine
+        .handle(SyncMessage::TextChanged(code.into(), Lang::Rust))
+        .unwrap();
 
 // визуальный редактор переместил блок и увеличил версию
 let mut meta = metas.pop().unwrap();
 meta.version += 1;
 meta.x = 10.0;
 
-let (_code, _metas) = engine.handle(SyncMessage::VisualChanged(meta)).unwrap();
+let (_code, _metas, _diag) = engine.handle(SyncMessage::VisualChanged(meta)).unwrap();
 // координаты будут взяты из визуального представления
 ```
 
 ## Пример
 
 ```rust
-use desktop::sync::{ResolutionPolicy, SyncEngine, SyncMessage};
+use desktop::sync::{ResolutionPolicy, SyncDiagnostics, SyncEngine, SyncMessage};
 use multicode_core::parser::Lang;
 
 let mut engine = SyncEngine::new(Lang::Rust, ResolutionPolicy::PreferText);
-let (_code, metas) = engine
+let (_code, metas, _diag) = engine
     .handle(SyncMessage::TextChanged("fn main() {}".into(), Lang::Rust))
     .unwrap();
 // передать metas визуальному редактору


### PR DESCRIPTION
## Summary
- add `SyncDiagnostics` with orphaned block and unmapped code info
- return diagnostics from `SyncEngine::handle`
- update engine callers, docs and tests for new diagnostics

## Testing
- `cargo test --workspace` *(fails: The system library `glib-2.0` required by crate `glib-sys` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68acbae2359c8323bd79f63aa82418ab