### PR TITLE
docs: expand Neira API usage

### DIFF
--- a/docs/neira/action-nodes.md
+++ b/docs/neira/action-nodes.md
@@ -58,6 +58,43 @@
 
 Дополнительные ActionNodes (работа с файлами, внешние API и т.п.) будут добавлены после MVP.
 
+### Пример HTTP/JSON/TOML вызова
+
+Запрос к API узлов действий передаётся в формате JSON.
+
+```http
+POST /action HTTP/1.1
+Host: localhost:4000
+Content-Type: application/json
+
+{
+  "id": "example.chat",
+  "action_type": "chat",
+  "prompt": "Расскажи о проекте Neira"
+}
+```
+
+Ответ:
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "id": "example.chat",
+  "status": "ok",
+  "result": "Neira — саморазвивающийся модуль..."
+}
+```
+
+Эквивалентная конфигурация в формате TOML:
+
+```toml
+id = "example.chat"
+action_type = "chat"
+prompt = "Расскажи о проекте Neira"
+```
+
 ### Реализация на правилах (ранние версии)
 
 Для первичных прототипов каждый ActionNode можно реализовать набором простых правил:

--- a/docs/neira/analysis-nodes.md
+++ b/docs/neira/analysis-nodes.md
@@ -83,6 +83,44 @@ struct QualityMetrics {
 `QualityMetrics` и `uncertainty_score` в связанный `MemoryNode`, например через метод
 `push_metrics()`.
 
+### Пример HTTP/JSON/TOML вызова
+
+Запрос к API узлов анализа принимает параметры задачи и возвращает результат с метриками качества.
+
+```http
+POST /analysis HTTP/1.1
+Host: localhost:4000
+Content-Type: application/json
+
+{
+  "id": "example.analysis",
+  "analysis_type": "summary",
+  "input": "Describe project Neira"
+}
+```
+
+Ответ:
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "id": "example.analysis",
+  "output": "Neira — саморазвивающийся модуль...",
+  "quality_metrics": { "credibility": 0.95, "recency_days": 7, "demand": 42 },
+  "status": "active"
+}
+```
+
+Эквивалент в формате TOML:
+
+```toml
+id = "example.analysis"
+analysis_type = "summary"
+input = "Describe project Neira"
+```
+
 Каждый узел должен проверять `cancel_token` перед длительными вычислениями и
 сохранять промежуточное состояние в чекпоинты, чтобы обеспечивать возобновление
 после остановки.

--- a/docs/neira/usage-example.md
+++ b/docs/neira/usage-example.md
@@ -27,3 +27,26 @@ curl -X POST http://localhost:4000/interact \
   ]
 }
 ```
+
+## Требования к окружению
+
+- Linux x86_64, 4 ядра CPU и 8 ГБ RAM.
+- Node.js 20 LTS.
+- Rust 1.75.
+
+## Запуск модулей
+
+```bash
+# установка зависимостей
+npm install
+# подготовка окружения
+npm run setup
+# запуск API сервера на http://localhost:4000
+npm run dev
+```
+
+## Маршруты API
+
+- `POST /interact` — общий вход для пользовательских запросов.
+- `POST /analysis` — выполнение конкретного `AnalysisNode`.
+- `POST /action` — запуск `ActionNode`.


### PR DESCRIPTION
## Summary
- add HTTP/JSON/TOML call examples for ActionNode and AnalysisNode
- document Neira module startup, API routes and environment needs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68acce2c490c83238e27faf6ba651244