### PR TITLE
Clarify analysis_type scope and update analysis result schema

### DIFF
--- a/docs/neira/analysis-nodes.md
+++ b/docs/neira/analysis-nodes.md
@@ -79,6 +79,8 @@ struct QualityMetrics {
 
 Поля `id` и `output` обязательны и сериализуются строками. `quality_metrics` — объект с числовыми метриками; отсутствующие показатели опускаются. `status` фиксирует состояние узла (`draft`, `active`, `deprecated`, `error`), `reasoning_chain` сохраняет этапы вывода, `links` перечисляет связанные узлы, `explanation` содержит краткое пояснение, а `uncertainty_score` отражает уровень сомнения (`0` — полная уверенность). `metadata.schema` указывает версию формата.
 
+Поле `analysis_type` относится к описанию узла и в `AnalysisResult` не сериализуется.
+
 После выполнения `analyze()` узел анализа всегда передаёт рассчитанные
 `QualityMetrics` и `uncertainty_score` в связанный `MemoryNode`, например через метод
 `push_metrics()`.

--- a/schemas/analysis-result.schema.json
+++ b/schemas/analysis-result.schema.json
@@ -30,6 +30,11 @@
       "items": { "type": "string" }
     },
     "explanation": { "type": "string" },
+    "uncertainty_score": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1
+    },
     "metadata": {
       "type": "object",
       "additionalProperties": true,


### PR DESCRIPTION
## Summary
- note that `analysis_type` applies to the node and isn't serialized in `AnalysisResult`
- include `uncertainty_score` in the `analysis-result` JSON schema

## Testing
- `npm test` *(fails: Cannot find package 'jsdom')*


------
https://chatgpt.com/codex/tasks/task_e_68acd2e57f4c8323b669d26f28a75bc9