### PR TITLE
feat(ui): add sync conflict dialog and indicators

### DIFF
--- a/desktop/src/ui/conflict_dialog.rs
+++ b/desktop/src/ui/conflict_dialog.rs
@@ -1,0 +1,21 @@
+use crate::sync::{ResolutionOption, SyncConflict};
+use iced::widget::{button, column, row, text};
+use iced::Element;
+
+/// Render a dialog for resolving a synchronization conflict.
+///
+/// The dialog shows the identifier of the conflicting metadata and
+/// allows choosing which version should win.
+pub fn view(conflict: &SyncConflict) -> Element<ResolutionOption> {
+    column![
+        text(format!("Conflict for {}", conflict.id)),
+        row![
+            button("Text").on_press(ResolutionOption::Text),
+            button("Visual").on_press(ResolutionOption::Visual),
+            button("Merge").on_press(ResolutionOption::Merge),
+        ]
+        .spacing(10)
+    ]
+    .spacing(10)
+    .into()
+}

--- a/desktop/src/ui/main_layout/state.rs
+++ b/desktop/src/ui/main_layout/state.rs
@@ -1,10 +1,12 @@
 use super::view::{self, ModeView};
 use super::update::MainMessage;
 use crate::app::ViewMode;
+use crate::sync::{ResolutionPolicy, SyncConflict, SyncEngine};
 use crate::visual::connections::Connection;
 use crate::visual::translations::Language;
 use iced::widget::text_editor;
 use iced::Element;
+use multicode_core::parser::Lang;
 use multicode_core::BlockInfo;
 
 /// Main user interface state containing current view mode and editor states.
@@ -26,7 +28,13 @@ pub struct MainUI {
     /// Whether the block palette is visible.
     pub show_palette: bool,
     /// Registered view mode renderers allowing easy extension.
-    pub view_modes: Vec<Box<dyn ModeView>>, 
+    pub view_modes: Vec<Box<dyn ModeView>>,
+    /// Engine keeping text and visual representations in sync.
+    pub sync_engine: SyncEngine,
+    /// Conflicts detected during synchronization.
+    pub conflicts: Vec<SyncConflict>,
+    /// Currently visible conflict dialog.
+    pub active_conflict: Option<SyncConflict>,
 }
 
 #[derive(Clone)]
@@ -46,6 +54,9 @@ impl Default for MainUI {
             language: Language::default(),
             show_palette: true,
             view_modes: view::default_modes(),
+            sync_engine: SyncEngine::new(Lang::Rust, ResolutionPolicy::PreferText),
+            conflicts: Vec::new(),
+            active_conflict: None,
         }
     }
 }

--- a/desktop/src/ui/mod.rs
+++ b/desktop/src/ui/mod.rs
@@ -1,3 +1,5 @@
 pub mod main_layout;
+pub mod conflict_dialog;
+pub mod sync_indicators;
 
 pub use main_layout::{MainMessage, MainUI};

--- a/desktop/src/ui/sync_indicators.rs
+++ b/desktop/src/ui/sync_indicators.rs
@@ -1,0 +1,29 @@
+use crate::sync::SyncEngine;
+
+/// Return a human readable synchronization status.
+pub fn status_text(engine: &SyncEngine) -> String {
+    let conflicts = engine.last_conflicts();
+    if conflicts.is_empty() {
+        "Synced".into()
+    } else {
+        format!("Conflicts: {}", conflicts.len())
+    }
+}
+
+/// Collect ranges in the source code corresponding to current conflicts.
+pub fn conflict_ranges(engine: &SyncEngine) -> Vec<std::ops::Range<usize>> {
+    engine
+        .last_conflicts()
+        .iter()
+        .filter_map(|c| engine.range_of(&c.id))
+        .collect()
+}
+
+/// Lines containing conflicts in the current source code.
+pub fn conflict_lines(engine: &SyncEngine) -> Vec<usize> {
+    let code = engine.state().code.as_str();
+    conflict_ranges(engine)
+        .into_iter()
+        .map(|range| code[..range.start].lines().count())
+        .collect()
+}


### PR DESCRIPTION
## Summary
- track conflicts inside SyncEngine
- display sync status and highlight conflict lines
- provide dialog to resolve text vs visual conflicts

## Testing
- `cargo test -p desktop`


------
https://chatgpt.com/codex/tasks/task_e_68ad23c0cc748323835f633c52ad703c