### PR TITLE
feat(sync): allow manual conflict resolution

### DIFF
--- a/desktop/src/ui/main_layout/update.rs
+++ b/desktop/src/ui/main_layout/update.rs
@@ -62,13 +62,9 @@ impl MessageHandler for DefaultHandler {
             }
             MainMessage::CodeEditorMsg(action) => {
                 state.code_editor.perform(action);
-                if let Some((_code, _metas, _diag)) = state
-                    .sync_engine
-                    .handle(SyncMessage::TextChanged(
-                        state.code_editor.text().to_string(),
-                        Lang::Rust,
-                    ))
-                {
+                if let Some((_code, _metas, _diag)) = state.sync_engine.handle(
+                    SyncMessage::TextChanged(state.code_editor.text().to_string(), Lang::Rust),
+                ) {
                     state.conflicts = state.sync_engine.last_conflicts().to_vec();
                 }
             }
@@ -104,10 +100,9 @@ impl MessageHandler for DefaultHandler {
             MainMessage::ShowConflict => {
                 state.active_conflict = state.conflicts.first().cloned();
             }
-            MainMessage::ResolveConflict(id, _option) => {
-                if let Some(pos) = state.conflicts.iter().position(|c| c.id == id) {
-                    state.conflicts.remove(pos);
-                }
+            MainMessage::ResolveConflict(id, option) => {
+                state.sync_engine.apply_resolution(&id, option);
+                state.conflicts = state.sync_engine.last_conflicts().to_vec();
                 state.active_conflict = state.conflicts.first().cloned();
             }
         }


### PR DESCRIPTION
## Summary
- call apply_resolution when resolving sync conflicts
- implement resolution logic in sync engine
- add tests for manual conflict resolution

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68ad2ce82a3c8323a4c24c8b20bb3c4d