### PR TITLE
feat: enhance conflict dialog

### DIFF
--- a/desktop/src/ui/conflict_dialog.rs
+++ b/desktop/src/ui/conflict_dialog.rs
@@ -4,15 +4,19 @@ use iced::Element;
 
 /// Render a dialog for resolving a synchronization conflict.
 ///
-/// The dialog shows the identifier of the conflicting metadata and
-/// allows choosing which version should win.
-pub fn view(conflict: &SyncConflict) -> Element<ResolutionOption> {
+/// The dialog shows details about the conflicting metadata and allows
+/// choosing which version should win. A `Cancel` button lets the user
+/// dismiss the dialog without applying a resolution.
+pub fn view(conflict: &SyncConflict) -> Element<Option<ResolutionOption>> {
     column![
         text(format!("Conflict for {}", conflict.id)),
+        text(format!("Type: {:?}", conflict.conflict_type)),
+        text(format!("Suggested: {:?}", conflict.resolution)),
         row![
-            button("Text").on_press(ResolutionOption::Text),
-            button("Visual").on_press(ResolutionOption::Visual),
-            button("Merge").on_press(ResolutionOption::Merge),
+            button("Text").on_press(Some(ResolutionOption::Text)),
+            button("Visual").on_press(Some(ResolutionOption::Visual)),
+            button("Merge").on_press(Some(ResolutionOption::Merge)),
+            button("Cancel").on_press(None),
         ]
         .spacing(10)
     ]

--- a/desktop/src/ui/main_layout/update.rs
+++ b/desktop/src/ui/main_layout/update.rs
@@ -28,8 +28,8 @@ pub enum MainMessage {
     CanvasEvent(CanvasMessage),
     /// Show conflict resolution dialog for current conflicts.
     ShowConflict,
-    /// Resolve conflict with selected option.
-    ResolveConflict(String, ResolutionOption),
+    /// Resolve conflict with selected option. `None` closes the dialog.
+    ResolveConflict(String, Option<ResolutionOption>),
 }
 
 /// Trait allowing custom message handlers to extend behaviour.
@@ -100,10 +100,13 @@ impl MessageHandler for DefaultHandler {
             MainMessage::ShowConflict => {
                 state.active_conflict = state.conflicts.first().cloned();
             }
-            MainMessage::ResolveConflict(id, option) => {
+            MainMessage::ResolveConflict(id, Some(option)) => {
                 state.sync_engine.apply_resolution(&id, option);
                 state.conflicts = state.sync_engine.last_conflicts().to_vec();
                 state.active_conflict = state.conflicts.first().cloned();
+            }
+            MainMessage::ResolveConflict(_, None) => {
+                state.active_conflict = None;
             }
         }
     }

--- a/desktop/src/ui/main_layout/view.rs
+++ b/desktop/src/ui/main_layout/view.rs
@@ -164,7 +164,7 @@ pub fn view<'a>(state: &'a MainUI) -> Element<'a, MainMessage> {
     let mut layout = column![menu, status_row, content];
     if let Some(conflict) = &state.active_conflict {
         let dialog = conflict_dialog::view(conflict)
-            .map(|opt| MainMessage::ResolveConflict(conflict.id.clone(), opt));
+            .map(|choice| MainMessage::ResolveConflict(conflict.id.clone(), choice));
         layout = layout.push(dialog);
     }
     layout.into()


### PR DESCRIPTION
## Summary
- show conflict type and default resolution in conflict dialog
- add cancel option that closes conflict dialog
- propagate optional resolution handling into main UI logic

## Testing
- `cargo test -p desktop` *(fails: build did not complete in time)*


------
https://chatgpt.com/codex/tasks/task_e_68ad37d0c198832386986724f1d15803