### PR TITLE
feat: make async manager batch delay configurable

### DIFF
--- a/desktop/src/sync/mod.rs
+++ b/desktop/src/sync/mod.rs
@@ -29,7 +29,7 @@ pub mod element_mapper;
 pub mod engine;
 
 pub use ast_parser::{ASTParser, SyntaxNode, SyntaxTree};
-pub use async_manager::AsyncManager;
+pub use async_manager::{AsyncManager, DEFAULT_BATCH_DELAY};
 pub use change_tracker::{ChangeTracker, TextDelta, VisualDelta};
 pub use code_generator::{format_generated_code, CodeGenerator, FormattingStyle};
 pub use conflict_resolver::{


### PR DESCRIPTION
## Summary
- make async manager's batch delay configurable instead of fixed 50ms
- expose `DEFAULT_BATCH_DELAY` for convenient use

## Testing
- `cargo test -p desktop` *(fails: hangs with no output)*

------
https://chatgpt.com/codex/tasks/task_e_68ad8ec2f8ac8323930fe1ac7c444f47