### PR TITLE
Add capacity to AsyncManager and propagate send errors

### DIFF
--- a/desktop/src/sync/async_manager.rs
+++ b/desktop/src/sync/async_manager.rs
@@ -1,7 +1,7 @@
 use super::{SyncEngine, SyncMessage};
 use std::sync::{
     atomic::{AtomicBool, Ordering},
-    mpsc::{self, Receiver, Sender},
+    mpsc::{self, Receiver, SyncSender},
     Arc,
 };
 use std::thread::{self, JoinHandle};
@@ -9,6 +9,9 @@ use std::time::Duration;
 
 /// Default interval to wait for additional messages before processing a batch.
 pub const DEFAULT_BATCH_DELAY: Duration = Duration::from_millis(50);
+
+/// Default capacity for the internal sync channel.
+pub const DEFAULT_CHANNEL_CAPACITY: usize = 32;
 
 /// Manages asynchronous processing of [`SyncMessage`]s.
 ///
@@ -20,7 +23,7 @@ pub const DEFAULT_BATCH_DELAY: Duration = Duration::from_millis(50);
 ///
 /// The manager also supports pausing and resuming of message processing.
 pub struct AsyncManager {
-    tx: Option<Sender<SyncMessage>>,
+    tx: Option<SyncSender<SyncMessage>>,
     handle: Option<JoinHandle<()>>,
     paused: Arc<AtomicBool>,
 }
@@ -28,9 +31,10 @@ pub struct AsyncManager {
 impl AsyncManager {
     /// Spawns a new background worker wrapping the provided [`SyncEngine`].
     ///
-    /// Use [`DEFAULT_BATCH_DELAY`] for a reasonable default value.
-    pub fn new(engine: SyncEngine, batch_delay: Duration) -> Self {
-        let (tx, rx) = mpsc::channel();
+    /// Use [`DEFAULT_BATCH_DELAY`] for a reasonable default value and
+    /// [`DEFAULT_CHANNEL_CAPACITY`] for a typical channel size.
+    pub fn new(engine: SyncEngine, batch_delay: Duration, capacity: usize) -> Self {
+        let (tx, rx) = mpsc::sync_channel(capacity);
         let paused = Arc::new(AtomicBool::new(false));
         let worker_paused = paused.clone();
         let handle = thread::spawn(move || run_worker(engine, rx, worker_paused, batch_delay));
@@ -42,9 +46,11 @@ impl AsyncManager {
     }
 
     /// Enqueues a [`SyncMessage`] for asynchronous processing.
-    pub fn send(&self, msg: SyncMessage) {
+    pub fn send(&self, msg: SyncMessage) -> Result<(), mpsc::SendError<SyncMessage>> {
         if let Some(tx) = &self.tx {
-            let _ = tx.send(msg);
+            tx.send(msg)
+        } else {
+            Err(mpsc::SendError(msg))
         }
     }
 

--- a/desktop/src/sync/mod.rs
+++ b/desktop/src/sync/mod.rs
@@ -29,7 +29,7 @@ pub mod element_mapper;
 pub mod engine;
 
 pub use ast_parser::{ASTParser, SyntaxNode, SyntaxTree};
-pub use async_manager::{AsyncManager, DEFAULT_BATCH_DELAY};
+pub use async_manager::{AsyncManager, DEFAULT_BATCH_DELAY, DEFAULT_CHANNEL_CAPACITY};
 pub use change_tracker::{ChangeTracker, TextDelta, VisualDelta};
 pub use code_generator::{format_generated_code, CodeGenerator, FormattingStyle};
 pub use conflict_resolver::{


### PR DESCRIPTION
## Summary
- allow configuring channel capacity in `AsyncManager` using `sync_channel`
- expose `DEFAULT_CHANNEL_CAPACITY` constant and re-export it
- return `Result` from `AsyncManager::send` to handle send failures

## Testing
- `cargo test -p desktop`

------
https://chatgpt.com/codex/tasks/task_e_68ad94ac9ff0832389732976e2c053fb