### PR TITLE
Add AsyncManager tests for batching and pause/resume

### DIFF
--- a/desktop/src/sync/async_manager_tests.rs
+++ b/desktop/src/sync/async_manager_tests.rs
@@ -1,0 +1,59 @@
+use super::{AsyncManager, ResolutionPolicy, SyncEngine, SyncMessage, DEFAULT_BATCH_DELAY, DEFAULT_CHANNEL_CAPACITY};
+use multicode_core::parser::Lang;
+use std::sync::{Arc, Mutex};
+
+#[test]
+fn messages_within_delay_processed_in_one_batch() {
+    let log = Arc::new(Mutex::new(Vec::new()));
+    let engine = SyncEngine::new(Lang::Rust, ResolutionPolicy::PreferText);
+    let manager = AsyncManager::new_with_logger(
+        engine,
+        DEFAULT_BATCH_DELAY,
+        DEFAULT_CHANNEL_CAPACITY,
+        log.clone(),
+    );
+    manager
+        .send(SyncMessage::TextChanged("a".into(), Lang::Rust))
+        .unwrap();
+    manager
+        .send(SyncMessage::TextChanged("b".into(), Lang::Rust))
+        .unwrap();
+    manager
+        .send(SyncMessage::TextChanged("c".into(), Lang::Rust))
+        .unwrap();
+    std::thread::sleep(DEFAULT_BATCH_DELAY * 3);
+    manager.shutdown();
+    let batches = log.lock().unwrap();
+    assert_eq!(batches.len(), 1);
+    assert_eq!(batches[0].len(), 3);
+}
+
+#[test]
+fn pause_stops_processing_and_resume_restarts() {
+    let log = Arc::new(Mutex::new(Vec::new()));
+    let engine = SyncEngine::new(Lang::Rust, ResolutionPolicy::PreferText);
+    let manager = AsyncManager::new_with_logger(
+        engine,
+        DEFAULT_BATCH_DELAY,
+        DEFAULT_CHANNEL_CAPACITY,
+        log.clone(),
+    );
+    manager.pause();
+    manager
+        .send(SyncMessage::TextChanged("a".into(), Lang::Rust))
+        .unwrap();
+    manager
+        .send(SyncMessage::TextChanged("b".into(), Lang::Rust))
+        .unwrap();
+    std::thread::sleep(DEFAULT_BATCH_DELAY * 3);
+    {
+        let batches = log.lock().unwrap();
+        assert!(batches.is_empty());
+    }
+    manager.resume();
+    std::thread::sleep(DEFAULT_BATCH_DELAY * 3);
+    manager.shutdown();
+    let batches = log.lock().unwrap();
+    assert_eq!(batches.len(), 1);
+    assert_eq!(batches[0].len(), 2);
+}

--- a/desktop/src/sync/mod.rs
+++ b/desktop/src/sync/mod.rs
@@ -40,3 +40,5 @@ pub use engine::{SyncDiagnostics, SyncEngine, SyncMessage, SyncState};
 
 #[cfg(test)]
 mod engine_tests;
+#[cfg(test)]
+mod async_manager_tests;


### PR DESCRIPTION
## Summary
- add test-only logging helpers to AsyncManager
- cover AsyncManager batching and pause/resume behavior

## Testing
- `cargo test -p desktop`


------
https://chatgpt.com/codex/tasks/task_e_68ada55c6f308323a274d49d25cfd8a3