### PR TITLE
feat: add sync settings

### DIFF
--- a/desktop/src/app/actions.rs
+++ b/desktop/src/app/actions.rs
@@ -14,7 +14,7 @@ use super::{
     AppTheme, CreateTarget, EditorMode, Language, LogLevel, MulticodeApp, Screen, UserSettings,
 };
 use crate::search::{fuzzy, index::SearchIndex};
-use crate::sync::{ChangeTracker, ResolutionPolicy, SyncEngine};
+use crate::sync::{ChangeTracker, SyncEngine};
 use crate::visual::palette::{PaletteBlock, DEFAULT_CATEGORY};
 use crate::visual::translations::block_synonyms;
 use lru::LruCache;
@@ -77,6 +77,7 @@ impl Application for MulticodeApp {
         }
         let use_index = settings.search.use_index;
         let cache_size = settings.search.cache_size;
+        let sync_settings = settings.sync.clone();
         let (sender, _) = broadcast::channel(100);
         let fav_files = settings.favorites.clone();
         let (palette, palette_categories) = load_palette();
@@ -169,7 +170,7 @@ impl Application for MulticodeApp {
             palette_query: String::new(),
             palette_drag: None,
             change_tracker: ChangeTracker::default(),
-            sync_engine: SyncEngine::new(Lang::Rust, ResolutionPolicy::PreferText),
+            sync_engine: SyncEngine::new(Lang::Rust, sync_settings),
             recent_commands,
             command_counts,
             command_trigrams,

--- a/desktop/src/app/events/handler.rs
+++ b/desktop/src/app/events/handler.rs
@@ -370,6 +370,18 @@ impl MulticodeApp {
                 self.rebuild_search_indices();
                 Command::none()
             }
+            Message::ConflictResolutionModeSelected(mode) => {
+                self.settings.sync.conflict_resolution = mode;
+                self.sync_engine
+                    .update_settings(self.settings.sync.clone());
+                Command::none()
+            }
+            Message::TogglePreserveMetaFormatting(val) => {
+                self.settings.sync.preserve_meta_formatting = val;
+                self.sync_engine
+                    .update_settings(self.settings.sync.clone());
+                Command::none()
+            }
             Message::ToggleSearchIndex(val) => {
                 self.settings.search.use_index = val;
                 self.rebuild_search_indices();

--- a/desktop/src/app/events/message.rs
+++ b/desktop/src/app/events/message.rs
@@ -7,6 +7,7 @@ use crate::editor::EditorTheme;
 use crate::visual::canvas::CanvasMessage;
 use crate::visual::palette::PaletteMessage;
 use crate::sync::SyncMessage;
+use crate::sync::ConflictResolutionMode;
 use multicode_core::BlockInfo;
 
 #[derive(Debug, Clone)]
@@ -109,6 +110,8 @@ pub enum Message {
     ToggleStatusBar(bool),
     ToggleToolbar(bool),
     ToggleMarkdownPreview(bool),
+    ConflictResolutionModeSelected(ConflictResolutionMode),
+    TogglePreserveMetaFormatting(bool),
     ToggleMetaPanel,
     ShowMetaDialog,
     CloseMetaDialog,

--- a/desktop/src/app/state.rs
+++ b/desktop/src/app/state.rs
@@ -26,7 +26,7 @@ use super::log_translations::LogMessage;
 use crate::app::diff::DiffView;
 use crate::components::file_manager::ContextMenu;
 use crate::editor::{AutocompleteState, EditorSettings};
-use crate::sync::{ChangeTracker, ResolutionPolicy, SyncEngine};
+use crate::sync::{ChangeTracker, SyncEngine, SyncSettings};
 use crate::visual::palette::PaletteBlock;
 use crate::visual::translations::Language;
 
@@ -403,6 +403,8 @@ pub struct UserSettings {
     pub block_favorites: Vec<String>,
     #[serde(default)]
     pub recent_commands: Vec<String>,
+    #[serde(default)]
+    pub sync: SyncSettings,
 }
 
 impl Default for UserSettings {
@@ -427,6 +429,7 @@ impl Default for UserSettings {
             favorites: Vec::new(),
             block_favorites: Vec::new(),
             recent_commands: Vec::new(),
+            sync: SyncSettings::default(),
         }
     }
 }
@@ -686,7 +689,7 @@ mod tests {
             palette_query: String::new(),
             palette_drag: None,
             change_tracker: ChangeTracker::default(),
-            sync_engine: SyncEngine::new(Lang::Rust, ResolutionPolicy::PreferText),
+            sync_engine: SyncEngine::new(Lang::Rust, SyncSettings::default()),
             recent_commands: VecDeque::new(),
             command_counts: HashMap::new(),
             command_trigrams: HashMap::new(),

--- a/desktop/src/app/ui.rs
+++ b/desktop/src/app/ui.rs
@@ -494,7 +494,7 @@ mod tests {
     use super::super::{CreateTarget, LogLevel, MulticodeApp, Screen, UserSettings, ViewMode};
     use crate::app::command_palette::COMMANDS;
     use crate::components::file_manager::ContextMenu;
-    use crate::sync::{ChangeTracker, ResolutionPolicy, SyncEngine};
+    use crate::sync::{ChangeTracker, SyncEngine, SyncSettings};
     use lru::LruCache;
     use multicode_core::parser::Lang;
     use std::cell::RefCell;
@@ -571,7 +571,7 @@ mod tests {
             palette_query: String::new(),
             palette_drag: None,
             change_tracker: ChangeTracker::default(),
-            sync_engine: SyncEngine::new(Lang::Rust, ResolutionPolicy::PreferText),
+            sync_engine: SyncEngine::new(Lang::Rust, SyncSettings::default()),
             recent_commands: VecDeque::new(),
             command_counts: HashMap::new(),
             command_trigrams: HashMap::new(),

--- a/desktop/src/app/view.rs
+++ b/desktop/src/app/view.rs
@@ -10,6 +10,7 @@ use iced::{alignment, theme, Element, Length};
 
 use super::events::Message;
 use super::{AppTheme, CreateTarget, Language, MulticodeApp, Screen, ViewMode};
+use crate::sync::ConflictResolutionMode;
 use crate::search::hotkeys::HotkeyContext;
 use crate::editor::{CodeEditor, EditorTheme, THEME_SET};
 use crate::components::file_manager;
@@ -479,6 +480,21 @@ impl MulticodeApp {
                             Some(self.settings.language),
                             Message::LanguageSelected
                         )
+                    ]
+                    .spacing(10),
+                    row![
+                        text("Решение конфликтов"),
+                        pick_list(
+                            &ConflictResolutionMode::ALL[..],
+                            Some(self.settings.sync.conflict_resolution),
+                            Message::ConflictResolutionModeSelected
+                        )
+                    ]
+                    .spacing(10),
+                    row![
+                        text("Сохранять формат мета-комментариев"),
+                        checkbox("", self.settings.sync.preserve_meta_formatting)
+                            .on_toggle(Message::TogglePreserveMetaFormatting)
                     ]
                     .spacing(10),
                     row![

--- a/desktop/src/sync/async_manager.rs
+++ b/desktop/src/sync/async_manager.rs
@@ -26,12 +26,12 @@ pub const DEFAULT_CHANNEL_CAPACITY: usize = 32;
 /// # Example
 /// ```ignore
 /// use desktop::sync::{
-///     AsyncManager, ResolutionPolicy, SyncEngine, SyncMessage, DEFAULT_BATCH_DELAY,
+///     AsyncManager, SyncEngine, SyncMessage, SyncSettings, DEFAULT_BATCH_DELAY,
 ///     DEFAULT_CHANNEL_CAPACITY,
 /// };
 /// use multicode_core::parser::Lang;
 ///
-/// let engine = SyncEngine::new(Lang::Rust, ResolutionPolicy::PreferText);
+/// let engine = SyncEngine::new(Lang::Rust, SyncSettings::default());
 /// let manager = AsyncManager::new(engine, DEFAULT_BATCH_DELAY, DEFAULT_CHANNEL_CAPACITY);
 /// manager
 ///     .send(SyncMessage::TextChanged(String::new(), Lang::Rust))

--- a/desktop/src/sync/async_manager_tests.rs
+++ b/desktop/src/sync/async_manager_tests.rs
@@ -1,11 +1,11 @@
-use super::{AsyncManager, ResolutionPolicy, SyncEngine, SyncMessage, DEFAULT_BATCH_DELAY, DEFAULT_CHANNEL_CAPACITY};
+use super::{AsyncManager, SyncEngine, SyncMessage, SyncSettings, DEFAULT_BATCH_DELAY, DEFAULT_CHANNEL_CAPACITY};
 use multicode_core::parser::Lang;
 use std::sync::{Arc, Mutex};
 
 #[test]
 fn messages_within_delay_processed_in_one_batch() {
     let log = Arc::new(Mutex::new(Vec::new()));
-    let engine = SyncEngine::new(Lang::Rust, ResolutionPolicy::PreferText);
+    let engine = SyncEngine::new(Lang::Rust, SyncSettings::default());
     let manager = AsyncManager::new_with_logger(
         engine,
         DEFAULT_BATCH_DELAY,
@@ -31,7 +31,7 @@ fn messages_within_delay_processed_in_one_batch() {
 #[test]
 fn pause_stops_processing_and_resume_restarts() {
     let log = Arc::new(Mutex::new(Vec::new()));
-    let engine = SyncEngine::new(Lang::Rust, ResolutionPolicy::PreferText);
+    let engine = SyncEngine::new(Lang::Rust, SyncSettings::default());
     let manager = AsyncManager::new_with_logger(
         engine,
         DEFAULT_BATCH_DELAY,

--- a/desktop/src/sync/mod.rs
+++ b/desktop/src/sync/mod.rs
@@ -8,10 +8,10 @@
 //!
 //! # Пример
 //! ```rust
-//! use desktop::sync::{ResolutionPolicy, SyncDiagnostics, SyncEngine, SyncMessage};
+//! use desktop::sync::{SyncSettings, SyncDiagnostics, SyncEngine, SyncMessage};
 //! use multicode_core::parser::Lang;
 //!
-//! let mut engine = SyncEngine::new(Lang::Rust, ResolutionPolicy::PreferText);
+//! let mut engine = SyncEngine::new(Lang::Rust, SyncSettings::default());
 //! // текстовый редактор сообщает об изменении
 //! let (_code, _metas, _diag) = engine
 //!     .handle(SyncMessage::TextChanged("fn main() {}".into(), Lang::Rust))
@@ -27,6 +27,7 @@ pub mod code_generator;
 pub mod conflict_resolver;
 pub mod element_mapper;
 pub mod engine;
+pub mod settings;
 
 pub use ast_parser::{ASTParser, SyntaxNode, SyntaxTree};
 pub use async_manager::{AsyncManager, DEFAULT_BATCH_DELAY, DEFAULT_CHANNEL_CAPACITY};
@@ -37,6 +38,7 @@ pub use conflict_resolver::{
 };
 pub use element_mapper::ElementMapper;
 pub use engine::{SyncDiagnostics, SyncEngine, SyncMessage, SyncState};
+pub use settings::{ConflictResolutionMode, SyncSettings};
 
 #[cfg(test)]
 mod engine_tests;

--- a/desktop/src/sync/settings.rs
+++ b/desktop/src/sync/settings.rs
@@ -1,0 +1,74 @@
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+use super::conflict_resolver::ResolutionPolicy;
+
+fn default_conflict_mode() -> ConflictResolutionMode {
+    ConflictResolutionMode::PreferText
+}
+
+fn default_true() -> bool {
+    true
+}
+
+/// Available strategies for resolving conflicts between text and visual metadata.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ConflictResolutionMode {
+    /// Prefer textual representation when conflicts arise.
+    PreferText,
+    /// Prefer visual representation when conflicts arise.
+    PreferVisual,
+}
+
+impl ConflictResolutionMode {
+    /// All variants for use in user interfaces.
+    pub const ALL: [ConflictResolutionMode; 2] = [
+        ConflictResolutionMode::PreferText,
+        ConflictResolutionMode::PreferVisual,
+    ];
+}
+
+impl Default for ConflictResolutionMode {
+    fn default() -> Self {
+        default_conflict_mode()
+    }
+}
+
+impl fmt::Display for ConflictResolutionMode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ConflictResolutionMode::PreferText => write!(f, "Текст"),
+            ConflictResolutionMode::PreferVisual => write!(f, "Визуально"),
+        }
+    }
+}
+
+impl From<ConflictResolutionMode> for ResolutionPolicy {
+    fn from(mode: ConflictResolutionMode) -> Self {
+        match mode {
+            ConflictResolutionMode::PreferText => ResolutionPolicy::PreferText,
+            ConflictResolutionMode::PreferVisual => ResolutionPolicy::PreferVisual,
+        }
+    }
+}
+
+/// Synchronization settings affecting conflict resolution behaviour.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SyncSettings {
+    /// Strategy used to resolve conflicts between text and visual metadata.
+    #[serde(default = "default_conflict_mode")]
+    pub conflict_resolution: ConflictResolutionMode,
+    /// Preserve formatting of existing meta comments when updating code.
+    #[serde(default = "default_true")]
+    pub preserve_meta_formatting: bool,
+}
+
+impl Default for SyncSettings {
+    fn default() -> Self {
+        Self {
+            conflict_resolution: default_conflict_mode(),
+            preserve_meta_formatting: default_true(),
+        }
+    }
+}

--- a/desktop/src/ui/main_layout/state.rs
+++ b/desktop/src/ui/main_layout/state.rs
@@ -1,7 +1,7 @@
 use super::view::{self, ModeView};
 use super::update::MainMessage;
 use crate::app::ViewMode;
-use crate::sync::{ResolutionPolicy, SyncConflict, SyncEngine};
+use crate::sync::{SyncConflict, SyncEngine, SyncSettings};
 use crate::visual::connections::Connection;
 use crate::visual::translations::Language;
 use iced::widget::text_editor;
@@ -54,7 +54,7 @@ impl Default for MainUI {
             language: Language::default(),
             show_palette: true,
             view_modes: view::default_modes(),
-            sync_engine: SyncEngine::new(Lang::Rust, ResolutionPolicy::PreferText),
+            sync_engine: SyncEngine::new(Lang::Rust, SyncSettings::default()),
             conflicts: Vec::new(),
             active_conflict: None,
         }


### PR DESCRIPTION
## Summary
- add synchronization settings and conflict resolution mode
- store sync settings in application state and update sync engine
- expose UI controls to modify sync behaviour

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68adad6c73a88323aac993879b4fba91