### PR TITLE
Add optional preservation of visual meta formatting

### DIFF
--- a/core/src/blocks/mod.rs
+++ b/core/src/blocks/mod.rs
@@ -73,8 +73,10 @@ pub fn upsert_meta(
         Some(l) => l,
         None => {
             tracing::error!("неподдерживаемый язык: {}", lang);
-            let updated =
-                metas.clone().into_iter().fold(cleaned.clone(), |acc, m| upsert(&acc, &m));
+            let updated = metas
+                .clone()
+                .into_iter()
+                .fold(cleaned.clone(), |acc, m| upsert(&acc, &m, false));
             let mut result = HashMap::new();
             if let Some(id) = files.first() {
                 result.insert(id.clone(), updated);
@@ -83,7 +85,9 @@ pub fn upsert_meta(
                 if let Ok(src) = fs::read_to_string(fid) {
                     let metas = read_all(&src);
                     let cleaned = remove_all(&src);
-                    let updated = metas.into_iter().fold(cleaned, |acc, m| upsert(&acc, &m));
+                    let updated = metas
+                        .into_iter()
+                        .fold(cleaned, |acc, m| upsert(&acc, &m, false));
                     result.insert(fid.clone(), updated);
                 }
             }
@@ -95,7 +99,7 @@ pub fn upsert_meta(
     let current = metas
         .clone()
         .into_iter()
-        .fold(regenerated, |acc, m| upsert(&acc, &m));
+        .fold(regenerated, |acc, m| upsert(&acc, &m, false));
 
     let mut result = HashMap::new();
     if let Some(id) = files.first() {
@@ -107,7 +111,7 @@ pub fn upsert_meta(
             let metas = read_all(&src);
             let cleaned = remove_all(&src);
             let regen = regenerate_code(&cleaned, lang, &metas).unwrap_or(cleaned);
-            let updated = metas.into_iter().fold(regen, |acc, m| upsert(&acc, &m));
+            let updated = metas.into_iter().fold(regen, |acc, m| upsert(&acc, &m, false));
             result.insert(fid.clone(), updated);
         }
     }

--- a/core/tests/links.rs
+++ b/core/tests/links.rs
@@ -32,7 +32,7 @@ fn upsert_preserves_links() {
         extras: None,
         updated_at: Utc::now(),
     };
-    let updated = upsert("fn main() {}", &meta);
+    let updated = upsert("fn main() {}", &meta, false);
     assert!(updated.contains("\"links\":[\"l\"]"));
     let metas = read_all(&updated);
     assert_eq!(metas[0].links, vec!["l"]);

--- a/core/tests/tags.rs
+++ b/core/tests/tags.rs
@@ -29,7 +29,7 @@ fn upsert_preserves_tags() {
         extras: None,
         updated_at: Utc::now(),
     };
-    let updated = upsert("fn main() {}", &meta);
+    let updated = upsert("fn main() {}", &meta, false);
     assert!(updated.contains("\"tags\":[\"t\"]"));
     let metas = read_all(&updated);
     assert_eq!(metas[0].tags, vec!["t"]);

--- a/core/tests/version.rs
+++ b/core/tests/version.rs
@@ -36,7 +36,7 @@ fn upsert_preserves_version() {
         extras: None,
         updated_at: Utc::now(),
     };
-    let updated = upsert("fn main() {}", &meta);
+    let updated = upsert("fn main() {}", &meta, false);
     assert!(updated.contains("\"version\":3"));
     let metas = read_all(&updated);
     assert_eq!(metas[0].version, 3);

--- a/desktop/src/app/events/handler.rs
+++ b/desktop/src/app/events/handler.rs
@@ -493,6 +493,7 @@ impl MulticodeApp {
                 let tags_str = self.meta_tags.clone();
                 let links_str = self.meta_links.clone();
                 let comment_str = self.meta_comment.clone();
+                let preserve_formatting = self.settings.sync.preserve_meta_formatting;
                 if let Some(f) = self.current_file_mut() {
                     let mut meta = f.meta.clone().unwrap_or(VisualMeta {
                         version: DEFAULT_VERSION,
@@ -542,7 +543,7 @@ impl MulticodeApp {
                         meta.extras = Some(extras);
                     }
                     meta.updated_at = Utc::now();
-                    f.content = meta::upsert(&f.content, &meta);
+                    f.content = meta::upsert(&f.content, &meta, preserve_formatting);
                     f.editor = Content::with_text(&f.content);
                     f.meta = Some(meta);
                     f.dirty = true;
@@ -981,6 +982,7 @@ impl MulticodeApp {
             }
             Message::NewFile => Command::none(),
             Message::SaveFile => {
+                let preserve_formatting = self.settings.sync.preserve_meta_formatting;
                 if let Some(f) = self.current_file_mut() {
                     let path = f.path.clone();
                     let mut meta = f.meta.clone().unwrap_or(VisualMeta {
@@ -1000,7 +1002,7 @@ impl MulticodeApp {
                         updated_at: Utc::now(),
                     });
                     meta.updated_at = Utc::now();
-                    let content = meta::upsert(&f.content, &meta);
+                    let content = meta::upsert(&f.content, &meta, preserve_formatting);
                     f.content = content.clone();
                     f.editor = Content::with_text(&f.content);
                     f.undo_stack.clear();

--- a/desktop/src/editor/meta_integration.rs
+++ b/desktop/src/editor/meta_integration.rs
@@ -59,12 +59,12 @@ pub fn changed_meta_ids(old: &str, new: &str) -> Vec<String> {
 
 /// Insert a new visual meta comment into `content`.
 pub fn insert_meta_comment(content: &str, meta: &VisualMeta) -> String {
-    meta::upsert(content, meta)
+    meta::upsert(content, meta, false)
 }
 
 /// Update existing `@VISUAL_META` comment or insert if missing.
 pub fn update_meta_comment(content: &str, meta: &VisualMeta) -> String {
-    meta::upsert(content, meta)
+    meta::upsert(content, meta, false)
 }
 
 /// Validate JSON inside `@VISUAL_META` comments and produce diagnostics.

--- a/desktop/src/sync/ast_parser.rs
+++ b/desktop/src/sync/ast_parser.rs
@@ -82,7 +82,7 @@ mod tests {
     fn parser_links_nodes_with_meta() {
         let mut parser = ASTParser::new(Lang::Rust);
         let m = meta("0");
-        let code = multicode_core::meta::upsert("fn main() {}", &m);
+        let code = multicode_core::meta::upsert("fn main() {}", &m, false);
         let tree = parser.parse(&code, &[m]);
         assert!(tree.nodes.iter().any(
             |n| n.block.visual_id == "0" && n.meta.as_ref().map(|m| m.id.as_str()) == Some("0")

--- a/desktop/src/sync/code_generator.rs
+++ b/desktop/src/sync/code_generator.rs
@@ -93,7 +93,7 @@ impl CodeGenerator {
                 .cloned()
                 .unwrap_or_default();
             let snippet = if self.insert_meta {
-                meta::upsert(&snippet, &meta)
+                meta::upsert(&snippet, &meta, false)
             } else {
                 snippet
             };

--- a/desktop/src/sync/engine.rs
+++ b/desktop/src/sync/engine.rs
@@ -181,7 +181,8 @@ impl SyncEngine {
                         meta = resolved;
                     }
                 }
-                self.state.code = meta::upsert(&self.state.code, &meta);
+                self.state.code =
+                    meta::upsert(&self.state.code, &meta, self.preserve_meta_formatting);
                 self.state.metas.insert(meta.id.clone(), meta);
                 self.last_metas = self.state.metas.values().cloned().collect();
                 let metas = std::mem::take(&mut self.last_metas);
@@ -317,7 +318,8 @@ impl SyncEngine {
         };
 
         self.state.metas.insert(id.to_string(), resolved.clone());
-        self.state.code = meta::upsert(&self.state.code, &resolved);
+        self.state.code =
+            meta::upsert(&self.state.code, &resolved, self.preserve_meta_formatting);
 
         self.last_metas = self.state.metas.values().cloned().collect();
         let metas = std::mem::take(&mut self.last_metas);


### PR DESCRIPTION
## Summary
- support preserving indentation/suffix when updating `@VISUAL_META` comments
- forward sync setting through engine so `upsert` can keep existing formatting
- cover formatting toggle with engine tests

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68adb46396108323a3b3dd4eaa2b114e