### PR TITLE
Use translations for conflict resolution modes

### DIFF
--- a/desktop/src/app/mod.rs
+++ b/desktop/src/app/mod.rs
@@ -5,6 +5,7 @@ pub mod events;
 pub mod io;
 pub mod log_translations;
 pub mod search_translations;
+pub mod settings_translations;
 pub mod ui;
 
 mod actions;

--- a/desktop/src/app/settings_translations.rs
+++ b/desktop/src/app/settings_translations.rs
@@ -1,0 +1,50 @@
+use super::Language;
+
+#[derive(Debug, Clone, Copy)]
+pub enum SettingsText {
+    ConflictResolutionLabel,
+    ConflictModePreferText,
+    ConflictModePreferVisual,
+}
+
+pub fn settings_text(key: SettingsText, lang: Language) -> &'static str {
+    use Language::*;
+    match key {
+        SettingsText::ConflictResolutionLabel => match lang {
+            English => "Conflict resolution",
+            Russian => "Решение конфликтов",
+            Spanish => "Resolución de conflictos",
+            German => "Konfliktlösung",
+        },
+        SettingsText::ConflictModePreferText => match lang {
+            English => "Prefer Text",
+            Russian => "Текст",
+            Spanish => "Preferir texto",
+            German => "Text bevorzugen",
+        },
+        SettingsText::ConflictModePreferVisual => match lang {
+            English => "Prefer Visual",
+            Russian => "Визуально",
+            Spanish => "Preferir visual",
+            German => "Visuell bevorzugen",
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{settings_text, SettingsText};
+    use crate::app::Language;
+
+    #[test]
+    fn settings_text_is_translated() {
+        assert_eq!(
+            settings_text(SettingsText::ConflictModePreferText, Language::English),
+            "Prefer Text"
+        );
+        assert_eq!(
+            settings_text(SettingsText::ConflictModePreferVisual, Language::Russian),
+            "Визуально"
+        );
+    }
+}

--- a/desktop/src/app/view.rs
+++ b/desktop/src/app/view.rs
@@ -9,7 +9,7 @@ use iced::widget::{
 use iced::{alignment, theme, Element, Length};
 
 use super::events::Message;
-use super::{AppTheme, CreateTarget, Language, MulticodeApp, Screen, ViewMode};
+use super::{settings_translations::{settings_text, SettingsText}, AppTheme, CreateTarget, Language, MulticodeApp, Screen, ViewMode};
 use crate::sync::ConflictResolutionMode;
 use crate::search::hotkeys::HotkeyContext;
 use crate::editor::{CodeEditor, EditorTheme, THEME_SET};
@@ -482,15 +482,29 @@ impl MulticodeApp {
                         )
                     ]
                     .spacing(10),
-                    row![
-                        text("Решение конфликтов"),
-                        pick_list(
-                            &ConflictResolutionMode::ALL[..],
-                            Some(self.settings.sync.conflict_resolution),
-                            Message::ConflictResolutionModeSelected
-                        )
-                    ]
-                    .spacing(10),
+                    {
+                        let lang = self.settings.language;
+                        let label = settings_text(SettingsText::ConflictResolutionLabel, lang);
+                        let prefer_text = ConflictResolutionMode::PreferText.label(lang);
+                        let prefer_visual = ConflictResolutionMode::PreferVisual.label(lang);
+                        let selected = self.settings.sync.conflict_resolution.label(lang);
+                        row![
+                            text(label),
+                            pick_list(
+                                vec![prefer_text, prefer_visual],
+                                Some(selected),
+                                move |choice| {
+                                    let mode = if choice == prefer_text {
+                                        ConflictResolutionMode::PreferText
+                                    } else {
+                                        ConflictResolutionMode::PreferVisual
+                                    };
+                                    Message::ConflictResolutionModeSelected(mode)
+                                }
+                            )
+                        ]
+                        .spacing(10)
+                    },
                     row![
                         text("Сохранять формат мета-комментариев"),
                         checkbox("", self.settings.sync.preserve_meta_formatting)

--- a/desktop/src/sync/settings.rs
+++ b/desktop/src/sync/settings.rs
@@ -1,8 +1,7 @@
-use std::fmt;
-
 use serde::{Deserialize, Serialize};
 
 use super::conflict_resolver::ResolutionPolicy;
+use crate::app::{settings_translations::{settings_text, SettingsText}, Language};
 
 fn default_conflict_mode() -> ConflictResolutionMode {
     ConflictResolutionMode::PreferText
@@ -27,20 +26,20 @@ impl ConflictResolutionMode {
         ConflictResolutionMode::PreferText,
         ConflictResolutionMode::PreferVisual,
     ];
+
+    pub fn label(self, lang: Language) -> &'static str {
+        match self {
+            ConflictResolutionMode::PreferText =>
+                settings_text(SettingsText::ConflictModePreferText, lang),
+            ConflictResolutionMode::PreferVisual =>
+                settings_text(SettingsText::ConflictModePreferVisual, lang),
+        }
+    }
 }
 
 impl Default for ConflictResolutionMode {
     fn default() -> Self {
         default_conflict_mode()
-    }
-}
-
-impl fmt::Display for ConflictResolutionMode {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            ConflictResolutionMode::PreferText => write!(f, "Текст"),
-            ConflictResolutionMode::PreferVisual => write!(f, "Визуально"),
-        }
     }
 }
 


### PR DESCRIPTION
## Summary
- add settings translations for conflict resolution modes
- localize conflict resolution setting

## Testing
- `cargo test -p desktop`


------
https://chatgpt.com/codex/tasks/task_e_68adbeb77c508323b16b7888c3c825c0