### PR TITLE
test: ensure sync engine updates settings

### DIFF
--- a/desktop/src/app/events/handler.rs
+++ b/desktop/src/app/events/handler.rs
@@ -2230,3 +2230,26 @@ fn detect_lang(path: &Path) -> Option<Lang> {
         _ => None,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sync::ConflictResolutionMode;
+    use iced::Application;
+
+    #[test]
+    fn updates_sync_engine_settings() {
+        let (mut app, _) = <MulticodeApp as Application>::new(None);
+
+        let _ = app.handle_message(Message::ConflictResolutionModeSelected(
+            ConflictResolutionMode::PreferVisual,
+        ));
+        let engine_state = format!("{:?}", app.sync_engine);
+        assert!(engine_state.contains("policy: PreferVisual"));
+
+        let _ =
+            app.handle_message(Message::TogglePreserveMetaFormatting(false));
+        let engine_state = format!("{:?}", app.sync_engine);
+        assert!(engine_state.contains("preserve_meta_formatting: false"));
+    }
+}


### PR DESCRIPTION
## Summary
- cover ConflictResolutionModeSelected and TogglePreserveMetaFormatting messages
- verify SyncEngine settings are updated accordingly

## Testing
- `cargo test -p desktop tests::updates_sync_engine_settings -- --nocapture`


------
https://chatgpt.com/codex/tasks/task_e_68adc375a5c4832385b64d31a4227ffa