### PR TITLE
Use mem::take for metas in SyncEngine

### DIFF
--- a/desktop/src/sync/engine.rs
+++ b/desktop/src/sync/engine.rs
@@ -123,7 +123,7 @@ impl SyncEngine {
                     self.lang = lang;
                     self.parser = ASTParser::new(lang);
                 }
-                let previous = self.state.metas.clone();
+                let previous = std::mem::take(&mut self.state.metas);
                 let resolver = ConflictResolver::default();
                 let mut map = HashMap::new();
                 for mut m in meta::read_all(&code) {


### PR DESCRIPTION
## Summary
- avoid cloning metadata in `SyncEngine::handle` by taking ownership of the map
- restore processed metadata back into engine state

## Testing
- `cargo test -q`


------
https://chatgpt.com/codex/tasks/task_e_68adc8287aa88323b4ae78e18b46d952