### PR TITLE
feat: allow custom extension path

### DIFF
--- a/desktop/src/sync/engine.rs
+++ b/desktop/src/sync/engine.rs
@@ -95,7 +95,7 @@ pub struct SyncEngine {
 impl SyncEngine {
     /// Создаёт новый движок синхронизации.
     pub fn new(lang: Lang, settings: SyncSettings) -> Self {
-        init_extensions();
+        init_extensions(None);
         Self {
             state: SyncState::default(),
             parser: ASTParser::new(lang),


### PR DESCRIPTION
## Summary
- allow specifying extension directory for sync engine via function parameter or `SYNC_EXTENSIONS_DIR` env var
- load extensions from user-provided path instead of fixed `plugins/`

## Testing
- `cargo test -p desktop`


------
https://chatgpt.com/codex/tasks/task_e_68ae0adf325c832386c5880837964fa1