### PR TITLE
Use DLL_EXTENSION for plugin loading

### DIFF
--- a/desktop/src/sync/mod.rs
+++ b/desktop/src/sync/mod.rs
@@ -112,16 +112,19 @@ fn load_extensions(path: Option<&Path>) {
                 match entry {
                     Ok(entry) => {
                         let path = entry.path();
-                        match path.extension().and_then(|e| e.to_str()) {
-                            Some("dll") | Some("so") | Some("dylib") => unsafe {
+                        if path
+                            .extension()
+                            .and_then(|e| e.to_str())
+                            == Some(std::env::consts::DLL_EXTENSION)
+                        {
+                            unsafe {
                                 if let Some((ext, lib)) = load_dll(&path) {
                                     register_boxed_extension(ext);
                                     if let Ok(mut libs) = LOADED_LIBS.lock() {
                                         libs.push(lib);
                                     }
                                 }
-                            },
-                            _ => {}
+                            }
                         }
                     }
                     Err(e) => warn!("Failed to read entry in plugins directory: {e}")

--- a/legacy-backend/src/lib.rs
+++ b/legacy-backend/src/lib.rs
@@ -124,36 +124,33 @@ pub fn load_plugins() -> Vec<Box<dyn Plugin>> {
     if let Ok(entries) = std::fs::read_dir("plugins") {
         for entry in entries.flatten() {
             let path = entry.path();
-            match path.extension().and_then(|e| e.to_str()) {
-                Some("dll") | Some("so") | Some("dylib") => {
-                    if let Some(p) = unsafe { load_dll(&path) } {
-                        if p.version() == expected {
-                            loaded.push(p);
-                        } else {
-                            eprintln!(
-                                "Skipping plugin {} due to version mismatch: {} != {}",
-                                p.name(),
-                                p.version(),
-                                expected
-                            );
-                        }
+            let ext = path.extension().and_then(|e| e.to_str());
+            if ext == Some(std::env::consts::DLL_EXTENSION) {
+                if let Some(p) = unsafe { load_dll(&path) } {
+                    if p.version() == expected {
+                        loaded.push(p);
+                    } else {
+                        eprintln!(
+                            "Skipping plugin {} due to version mismatch: {} != {}",
+                            p.name(),
+                            p.version(),
+                            expected
+                        );
                     }
                 }
-                Some("wasm") => {
-                    if let Some(p) = load_wasm(&path) {
-                        if p.version() == expected {
-                            loaded.push(p);
-                        } else {
-                            eprintln!(
-                                "Skipping plugin {} due to version mismatch: {} != {}",
-                                p.name(),
-                                p.version(),
-                                expected
-                            );
-                        }
+            } else if ext == Some("wasm") {
+                if let Some(p) = load_wasm(&path) {
+                    if p.version() == expected {
+                        loaded.push(p);
+                    } else {
+                        eprintln!(
+                            "Skipping plugin {} due to version mismatch: {} != {}",
+                            p.name(),
+                            p.version(),
+                            expected
+                        );
                     }
                 }
-                _ => {}
             }
         }
     }


### PR DESCRIPTION
## Summary
- match dynamic library filenames using `std::env::consts::DLL_EXTENSION`
- streamline plugin loading logic and remove redundant match arms

## Testing
- `cargo test -p desktop`
- `cargo test -p backend` *(fails: The system library `javascriptcoregtk-4.1` required by crate `javascriptcore-rs-sys` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae0f5ffef88323acf188048d6d60ba