### PR TITLE
Integrate SyncEngine with main layout

### DIFF
--- a/desktop/src/ui/main_layout/state.rs
+++ b/desktop/src/ui/main_layout/state.rs
@@ -1,5 +1,5 @@
 use super::view::{self, ModeView};
-use super::update::MainMessage;
+use super::update::{start_sync_engine, MainMessage};
 use crate::app::ViewMode;
 use crate::sync::{SyncConflict, SyncEngine, SyncSettings};
 use crate::visual::connections::Connection;
@@ -44,7 +44,7 @@ pub enum Dragging {
 
 impl Default for MainUI {
     fn default() -> Self {
-        Self {
+        let mut ui = Self {
             view_mode: ViewMode::Code,
             code_editor: text_editor::Content::new(),
             palette: load_palette(),
@@ -57,7 +57,9 @@ impl Default for MainUI {
             sync_engine: SyncEngine::new(Lang::Rust, SyncSettings::default()),
             conflicts: Vec::new(),
             active_conflict: None,
-        }
+        };
+        start_sync_engine(&mut ui);
+        ui
     }
 }
 


### PR DESCRIPTION
## Summary
- start SyncEngine automatically and forward editor changes as SyncMessage
- add Sync variant to MainMessage with dispatch handler
- update conflict handling helpers for status and dialog

## Testing
- `cargo test -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae7290df4c832387423323d26241a2