### PR TITLE
feat(ui): allow selecting code language

### DIFF
--- a/desktop/src/ui/main_layout/state.rs
+++ b/desktop/src/ui/main_layout/state.rs
@@ -25,6 +25,8 @@ pub struct MainUI {
     pub dragging: Option<Dragging>,
     /// Current interface language for visual components.
     pub language: Language,
+    /// Currently selected programming language for code editor.
+    pub code_lang: Lang,
     /// Whether the block palette is visible.
     pub show_palette: bool,
     /// Registered view mode renderers allowing easy extension.
@@ -44,6 +46,7 @@ pub enum Dragging {
 
 impl Default for MainUI {
     fn default() -> Self {
+        let code_lang = Lang::Rust;
         let mut ui = Self {
             view_mode: ViewMode::Code,
             code_editor: text_editor::Content::new(),
@@ -52,9 +55,10 @@ impl Default for MainUI {
             connections: Vec::new(),
             dragging: None,
             language: Language::default(),
+            code_lang,
             show_palette: true,
             view_modes: view::default_modes(),
-            sync_engine: SyncEngine::new(Lang::Rust, SyncSettings::default()),
+            sync_engine: SyncEngine::new(code_lang, SyncSettings::default()),
             conflicts: Vec::new(),
             active_conflict: None,
         };

--- a/desktop/src/ui/main_layout/update.rs
+++ b/desktop/src/ui/main_layout/update.rs
@@ -2,7 +2,7 @@ use super::state::{Dragging, MainUI};
 use crate::app::ViewMode;
 use crate::sync::{ResolutionOption, SyncMessage};
 use crate::visual::canvas::CanvasMessage;
-use multicode_core::{export, parser::Lang, search, BlockInfo};
+use multicode_core::{export, search, BlockInfo};
 use multicode_core::meta::{VisualMeta, DEFAULT_VERSION};
 use iced::widget::text_editor;
 use chrono::Utc;
@@ -68,7 +68,7 @@ impl MessageHandler for DefaultHandler {
             MainMessage::CodeEditorMsg(action) => {
                 state.code_editor.perform(action);
                 let content = state.code_editor.text().to_string();
-                handle_sync_message(state, SyncMessage::TextChanged(content, Lang::Rust));
+                handle_sync_message(state, SyncMessage::TextChanged(content, state.code_lang));
             }
             MainMessage::StartPaletteDrag(i) => {
                 if let Some(info) = state.palette.get(i).cloned() {
@@ -129,7 +129,7 @@ pub fn update(state: &mut MainUI, msg: MainMessage) {
 /// Initialize synchronization engine with current editor state.
 pub fn start_sync_engine(state: &mut MainUI) {
     let content = state.code_editor.text().to_string();
-    handle_sync_message(state, SyncMessage::TextChanged(content, Lang::Rust));
+    handle_sync_message(state, SyncMessage::TextChanged(content, state.code_lang));
 }
 
 /// Process a [`SyncMessage`] through the engine and refresh indicators.


### PR DESCRIPTION
## Summary
- track current code language in `MainUI`
- use `code_lang` for `SyncEngine` and sync messages

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68ae7f0e46a48323b1052e16363c320a