### PR TITLE
Add conflict navigation messages to desktop UI

### DIFF
--- a/desktop/src/ui/conflict_dialog.rs
+++ b/desktop/src/ui/conflict_dialog.rs
@@ -2,21 +2,41 @@ use crate::sync::{ResolutionOption, SyncConflict};
 use iced::widget::{button, column, row, text};
 use iced::Element;
 
+/// Possible user interactions within the conflict dialog.
+#[derive(Debug, Clone)]
+pub enum ConflictDialogMessage {
+    /// User selected a resolution option or cancelled the dialog.
+    Resolve(Option<ResolutionOption>),
+    /// Move to the next conflict.
+    Next,
+    /// Move to the previous conflict.
+    Prev,
+}
+
 /// Render a dialog for resolving a synchronization conflict.
 ///
 /// The dialog shows details about the conflicting metadata and allows
 /// choosing which version should win. A `Cancel` button lets the user
 /// dismiss the dialog without applying a resolution.
-pub fn view(conflict: &SyncConflict) -> Element<Option<ResolutionOption>> {
+pub fn view(conflict: &SyncConflict) -> Element<ConflictDialogMessage> {
     column![
         text(format!("Conflict for {}", conflict.id)),
         text(format!("Type: {:?}", conflict.conflict_type)),
         text(format!("Suggested: {:?}", conflict.resolution)),
         row![
-            button("Text").on_press(Some(ResolutionOption::Text)),
-            button("Visual").on_press(Some(ResolutionOption::Visual)),
-            button("Merge").on_press(Some(ResolutionOption::Merge)),
-            button("Cancel").on_press(None),
+            button("Text").on_press(ConflictDialogMessage::Resolve(Some(ResolutionOption::Text))),
+            button("Visual").on_press(ConflictDialogMessage::Resolve(Some(
+                ResolutionOption::Visual
+            ))),
+            button("Merge").on_press(ConflictDialogMessage::Resolve(Some(
+                ResolutionOption::Merge
+            ))),
+            button("Cancel").on_press(ConflictDialogMessage::Resolve(None)),
+        ]
+        .spacing(10),
+        row![
+            button("Prev").on_press(ConflictDialogMessage::Prev),
+            button("Next").on_press(ConflictDialogMessage::Next),
         ]
         .spacing(10)
     ]

--- a/desktop/src/ui/main_layout/state.rs
+++ b/desktop/src/ui/main_layout/state.rs
@@ -1,5 +1,5 @@
-use super::view::{self, ModeView};
 use super::update::{start_sync_engine, MainMessage};
+use super::view::{self, ModeView};
 use crate::app::ViewMode;
 use crate::sync::{SyncConflict, SyncDiagnostics, SyncEngine, SyncSettings};
 use crate::visual::connections::Connection;
@@ -37,6 +37,8 @@ pub struct MainUI {
     pub conflicts: Vec<SyncConflict>,
     /// Currently visible conflict dialog.
     pub active_conflict: Option<SyncConflict>,
+    /// Index of the currently displayed conflict.
+    pub conflict_index: usize,
     /// Diagnostics reported by the synchronization engine.
     pub diagnostics: SyncDiagnostics,
 }
@@ -63,6 +65,7 @@ impl Default for MainUI {
             sync_engine: SyncEngine::new(code_lang, SyncSettings::default()),
             conflicts: Vec::new(),
             active_conflict: None,
+            conflict_index: 0,
             diagnostics: SyncDiagnostics::default(),
         };
         start_sync_engine(&mut ui);

--- a/desktop/src/ui/main_layout/update.rs
+++ b/desktop/src/ui/main_layout/update.rs
@@ -34,6 +34,10 @@ pub enum MainMessage {
     Sync(SyncMessage),
     /// Show conflict resolution dialog for current conflicts.
     ShowConflict,
+    /// Show next conflict in the list.
+    NextConflict,
+    /// Show previous conflict in the list.
+    PrevConflict,
     /// Resolve conflict with selected option. `None` closes the dialog.
     ResolveConflict(String, Option<ResolutionOption>),
 }
@@ -110,6 +114,18 @@ impl MessageHandler for DefaultHandler {
             MainMessage::ShowConflict => {
                 show_conflict_dialog(state);
             }
+            MainMessage::NextConflict => {
+                if state.conflict_index + 1 < state.conflicts.len() {
+                    state.conflict_index += 1;
+                }
+                show_conflict_dialog(state);
+            }
+            MainMessage::PrevConflict => {
+                if state.conflict_index > 0 {
+                    state.conflict_index -= 1;
+                }
+                show_conflict_dialog(state);
+            }
             MainMessage::ResolveConflict(id, Some(option)) => {
                 state.sync_engine.apply_resolution(&id, option);
                 update_sync_indicators(state);
@@ -183,12 +199,15 @@ fn update_sync_indicators(state: &mut MainUI) {
     state.conflicts = state.sync_engine.last_conflicts().to_vec();
     if state.conflicts.is_empty() {
         state.active_conflict = None;
+        state.conflict_index = 0;
+    } else if state.conflict_index >= state.conflicts.len() {
+        state.conflict_index = 0;
     }
 }
 
 /// Display the next conflict in a dialog if any.
 fn show_conflict_dialog(state: &mut MainUI) {
-    state.active_conflict = state.conflicts.first().cloned();
+    state.active_conflict = state.conflicts.get(state.conflict_index).cloned();
 }
 
 fn block_to_meta(block: &BlockInfo) -> VisualMeta {


### PR DESCRIPTION
## Summary
- track active conflict index in main UI state
- add NextConflict/PrevConflict messages and update conflict dialog
- enable cycling through conflicts without removing them

## Testing
- `rustfmt desktop/src/ui/conflict_dialog.rs desktop/src/ui/main_layout/state.rs desktop/src/ui/main_layout/update.rs desktop/src/ui/main_layout/view.rs`
- `cargo test -p desktop`

------
https://chatgpt.com/codex/tasks/task_e_68aec2d5841483239d948067b512b9a9